### PR TITLE
refactor: extract shared HTTP utilities to eliminate duplication

### DIFF
--- a/rune.py
+++ b/rune.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Backward-compatible CLI shim.
 
-RUNE is now exposed via `python -m rune`.
-This shim exists to avoid breaking old command references.
+RUNE is primarily exposed via `python -m rune`.
 """
 
 from rune import app

--- a/rune_bench/api_client.py
+++ b/rune_bench/api_client.py
@@ -1,12 +1,11 @@
 """HTTP client for RUNE API backend mode."""
 
-import json
 import os
 from dataclasses import dataclass
 import time
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode, urlparse
-from urllib.request import Request, urlopen
+from urllib.parse import urlencode
+
+from rune_bench.common import make_http_request, normalize_url
 
 
 @dataclass
@@ -16,24 +15,9 @@ class RuneApiClient:
     tenant_id: str | None = None
 
     def __post_init__(self) -> None:
-        self.base_url = self._normalize_url(self.base_url)
+        self.base_url = normalize_url(self.base_url, service_name="RUNE API")
         self.api_token = (self.api_token or os.environ.get("RUNE_API_TOKEN") or "").strip() or None
         self.tenant_id = (self.tenant_id or os.environ.get("RUNE_API_TENANT") or "default").strip() or "default"
-
-    @staticmethod
-    def _normalize_url(url: str | None) -> str:
-        if not url:
-            raise RuntimeError("Missing API base URL. Set --api-base-url or RUNE_API_BASE_URL.")
-
-        parsed = urlparse(url)
-        if parsed.scheme not in {"http", "https"}:
-            url = f"http://{url}"
-            parsed = urlparse(url)
-
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise RuntimeError("Invalid API base URL. Expected format like http://host:8080")
-
-        return url.rstrip("/")
 
     def _request(
         self,
@@ -48,39 +32,22 @@ class RuneApiClient:
         if query:
             url += "?" + urlencode(query)
 
-        data = None
         headers: dict[str, str] = {"X-Tenant-ID": self.tenant_id or "default"}
         if self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
             headers["X-API-Key"] = self.api_token
-        if body is not None:
-            data = json.dumps(body).encode("utf-8")
-            headers["Content-Type"] = "application/json"
         if idempotency_key:
             headers["Idempotency-Key"] = idempotency_key
 
-        request = Request(url, method=method, headers=headers, data=data)
-
-        try:
-            with urlopen(request, timeout=20) as response:
-                raw = response.read().decode("utf-8")
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace").strip()
-            if detail:
-                raise RuntimeError(f"API request failed {method} {url}: {detail}") from exc
-            raise RuntimeError(f"API request failed {method} {url}: HTTP {exc.code}") from exc
-        except (URLError, TimeoutError) as exc:
-            raise RuntimeError(f"API request failed {method} {url}: {exc}") from exc
-
-        try:
-            payload = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"API returned invalid JSON for {method} {url}") from exc
-
-        if not isinstance(payload, dict):
-            raise RuntimeError(f"API returned unexpected payload for {method} {url}")
-
-        return payload
+        return make_http_request(
+            url,
+            method=method,
+            payload=body,
+            action=f"{method} {path}",
+            timeout_seconds=20,
+            headers=headers,
+            debug_prefix="RUNE API",
+        )
 
     def get_vastai_models(self) -> list[dict]:
         payload = self._request("GET", "/v1/catalog/vastai-models")

--- a/rune_bench/common/__init__.py
+++ b/rune_bench/common/__init__.py
@@ -1,5 +1,6 @@
 """Common utilities and shared data structures."""
 
+from .http_client import make_http_request, normalize_url
 from .models import MODELS, ModelSelector, SelectedModel
 
-__all__ = ["MODELS", "ModelSelector", "SelectedModel"]
+__all__ = ["MODELS", "ModelSelector", "SelectedModel", "normalize_url", "make_http_request"]

--- a/rune_bench/common/http_client.py
+++ b/rune_bench/common/http_client.py
@@ -1,0 +1,115 @@
+"""Shared HTTP client utilities for URL normalization and request handling."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from rune_bench.debug import debug_log
+
+
+def normalize_url(url: str | None, service_name: str = "service") -> str:
+    """Validate and normalize an HTTP(S) URL.
+    
+    Adds ``http://`` when no recognized scheme is present.
+    
+    Args:
+        url: URL string to normalize
+        service_name: Name of the service (for error messages)
+        
+    Returns:
+        Normalized URL (scheme://netloc/path format)
+        
+    Raises:
+        RuntimeError: If URL is missing, invalid scheme, or missing host.
+    """
+    if not url:
+        raise RuntimeError(
+            f"Missing {service_name} URL. Provide a valid URL or set the appropriate environment variable."
+        )
+
+    # Normalize: if no recognized scheme, prepend http://
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        # No valid scheme found; treat entire input as host:port
+        url = f"http://{url}"
+        parsed = urlparse(url)
+
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RuntimeError(
+            f"Invalid {service_name} URL. Expected format like http://host:port"
+        )
+
+    return url
+
+
+def make_http_request(
+    url: str,
+    *,
+    method: str,
+    payload: dict[str, Any] | None = None,
+    action: str = "perform request",
+    timeout_seconds: int = 30,
+    headers: dict[str, str] | None = None,
+    debug_prefix: str = "HTTP",
+) -> dict[str, Any]:
+    """Execute an HTTP request and return parsed JSON response.
+    
+    Args:
+        url: Full URL to request
+        method: HTTP method (GET, POST, etc.)
+        payload: Optional JSON payload for request body
+        action: Human-readable description of operation (for error messages)
+        timeout_seconds: Request timeout in seconds
+        headers: Optional custom headers (Content-Type is auto-added for payloads)
+        debug_prefix: Prefix for debug log messages
+        
+    Returns:
+        Parsed JSON response as dict
+        
+    Raises:
+        RuntimeError: If the request fails or response is invalid
+    """
+    request_headers: dict[str, str] = headers or {}
+    data = None
+    
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+
+    request = Request(url, data=data, headers=request_headers, method=method)
+
+    debug_log(
+        f"{debug_prefix} request: method={method} url={url} action={action} "
+        f"payload={json.dumps(payload, sort_keys=True) if payload is not None else '<none>'}"
+    )
+
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            raw = response.read().decode("utf-8")
+            debug_log(
+                f"{debug_prefix} response: method={method} url={url} status={getattr(response, 'status', '<unknown>')} "
+                f"body={raw}"
+            )
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").strip()
+        debug_log(f"{debug_prefix} HTTP error: method={method} url={url} status={exc.code} detail={detail}")
+        if detail:
+            raise RuntimeError(f"Failed to {action}: {detail}") from exc
+        raise RuntimeError(f"Failed to {action}: HTTP {exc.code}") from exc
+    except (URLError, TimeoutError) as exc:
+        debug_log(f"{debug_prefix} transport error: method={method} url={url} error={exc}")
+        raise RuntimeError(f"Failed to {action}: {exc}") from exc
+
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid JSON response while attempting to {action}") from exc
+
+    if not isinstance(result, dict):
+        raise RuntimeError(f"Unexpected JSON payload while attempting to {action}")
+    
+    return result

--- a/rune_bench/ollama/client.py
+++ b/rune_bench/ollama/client.py
@@ -3,13 +3,10 @@
 Handles URL validation, request formatting, and error handling.
 """
 
-import json
 from dataclasses import dataclass
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse
-from urllib.request import Request, urlopen
 
+from rune_bench.common import make_http_request, normalize_url
 from rune_bench.debug import debug_log
 
 
@@ -35,35 +32,13 @@ class OllamaClient:
 
     def __post_init__(self) -> None:
         """Validate and normalize the base URL."""
-        self.base_url = self._normalize_url(self.base_url)
-
-    @staticmethod
-    def _normalize_url(ollama_url: str | None) -> str:
-        """Validate and normalize an Ollama base URL.
-        
-        Adds ``http://`` when missing.
-        
-        Raises:
-            RuntimeError: If URL is missing, invalid scheme, or missing host.
-        """
-        if not ollama_url:
+        try:
+            self.base_url = normalize_url(self.base_url, service_name="Ollama")
+        except RuntimeError:
             raise RuntimeError(
-                "Missing Ollama URL. Provide --ollama-url when --vastai is not enabled."
+                "Missing or invalid Ollama URL. Provide --ollama-url when --vastai is not enabled. "
+                "Expected format like http://host:11434"
             )
-
-        # Normalize: if no recognized scheme, prepend http://
-        parsed = urlparse(ollama_url)
-        if parsed.scheme not in {"http", "https"}:
-            # No valid scheme found; treat entire input as host:port
-            ollama_url = f"http://{ollama_url}"
-            parsed = urlparse(ollama_url)
-
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise RuntimeError(
-                "Invalid --ollama-url. Expected format like http://host:11434"
-            )
-
-        return ollama_url
 
     def _make_request(self, endpoint: str, *, method: str, payload: dict | None, action: str) -> dict:
         """Execute an HTTP request to the Ollama API.
@@ -81,40 +56,14 @@ class OllamaClient:
             RuntimeError: If the request fails or response is invalid
         """
         url = self.base_url.rstrip("/") + endpoint
-        headers = {"Content-Type": "application/json"} if payload is not None else {}
-        data = json.dumps(payload).encode("utf-8") if payload is not None else None
-        request = Request(url, data=data, headers=headers, method=method)
-
-        debug_log(
-            f"Ollama API request: method={method} url={url} action={action} "
-            f"payload={json.dumps(payload, sort_keys=True) if payload is not None else '<none>'}"
+        return make_http_request(
+            url,
+            method=method,
+            payload=payload,
+            action=action,
+            timeout_seconds=30,
+            debug_prefix="Ollama API",
         )
-
-        try:
-            with urlopen(request, timeout=30) as response:
-                raw = response.read().decode("utf-8")
-                debug_log(
-                    f"Ollama API response: method={method} url={url} status={getattr(response, 'status', '<unknown>')} "
-                    f"body={raw}"
-                )
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace").strip()
-            debug_log(f"Ollama API HTTP error: method={method} url={url} status={exc.code} detail={detail}")
-            if detail:
-                raise RuntimeError(f"Failed to {action} via Ollama API {url}: {detail}") from exc
-            raise RuntimeError(f"Failed to {action} via Ollama API {url}: HTTP {exc.code}") from exc
-        except (URLError, TimeoutError) as exc:
-            debug_log(f"Ollama API transport error: method={method} url={url} error={exc}")
-            raise RuntimeError(f"Failed to {action} via Ollama API {url}: {exc}") from exc
-
-        try:
-            result = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"Ollama API {url} returned invalid JSON while attempting to {action}") from exc
-
-        if not isinstance(result, dict):
-            raise RuntimeError(f"Ollama API {url} returned an unexpected JSON payload while attempting to {action}")
-        return result
 
     def get_available_models(self) -> list[str]:
         """List all models available on the Ollama server.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,15 +1,16 @@
 import pytest
 
 from rune_bench.api_client import RuneApiClient
+from rune_bench.common import normalize_url
 
 
 def test_normalize_url_accepts_host_without_scheme():
-    assert RuneApiClient._normalize_url("localhost:8080") == "http://localhost:8080"
+    assert normalize_url("localhost:8080", service_name="RUNE API") == "http://localhost:8080"
 
 
 def test_normalize_url_rejects_invalid():
     with pytest.raises(RuntimeError):
-        RuneApiClient._normalize_url(None)
+        normalize_url(None, service_name="RUNE API")
 
 
 def test_get_vastai_models_validates_payload(monkeypatch):
@@ -80,7 +81,7 @@ def test_request_adds_auth_tenant_and_idempotency_headers(monkeypatch):
         captured["timeout"] = timeout
         return DummyResponse()
 
-    monkeypatch.setattr("rune_bench.api_client.urlopen", fake_urlopen)
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", fake_urlopen)
 
     client = RuneApiClient("http://api:8080", api_token="secret", tenant_id="tenant-a")
     payload = client._request("POST", "/v1/jobs/benchmark", body={"x": 1}, idempotency_key="idem-1")

--- a/tests/test_comprehensive_error_paths.py
+++ b/tests/test_comprehensive_error_paths.py
@@ -94,15 +94,15 @@ def test_api_client_remaining_paths(monkeypatch):
         def read(self):
             return b""
 
-    monkeypatch.setattr(api_client_module, "urlopen", lambda *args, **kwargs: (_ for _ in ()).throw(NoDetailHTTPError()))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *args, **kwargs: (_ for _ in ()).throw(NoDetailHTTPError()))
     with pytest.raises(RuntimeError, match="HTTP 500"):
         client._request("GET", "/x")
 
-    monkeypatch.setattr(api_client_module, "urlopen", lambda *args, **kwargs: (_ for _ in ()).throw(URLError("boom")))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *args, **kwargs: (_ for _ in ()).throw(URLError("boom")))
     with pytest.raises(RuntimeError, match="boom"):
         client._request("GET", "/x")
 
-    monkeypatch.setattr(api_client_module, "urlopen", lambda *args, **kwargs: (_ for _ in ()).throw(TimeoutError("late")))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *args, **kwargs: (_ for _ in ()).throw(TimeoutError("late")))
     with pytest.raises(RuntimeError, match="late"):
         client._request("GET", "/x")
 
@@ -119,8 +119,8 @@ def test_api_client_remaining_paths(monkeypatch):
         def read(self):
             return self._raw
 
-    monkeypatch.setattr(api_client_module, "urlopen", lambda *args, **kwargs: Response(b"[]"))
-    with pytest.raises(RuntimeError, match="unexpected payload"):
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *args, **kwargs: Response(b"[]"))
+    with pytest.raises(RuntimeError, match="Unexpected JSON payload"):
         client._request("GET", "/x")
 
     monkeypatch.setattr(client, "_request", lambda *args, **kwargs: {})

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -17,7 +17,8 @@ import rune_bench.ollama.models as ollama_models_module
 import rune_bench.workflows as workflows
 from rune_bench.agents.holmes import HolmesRunner
 from rune_bench.api_client import RuneApiClient
-from rune_bench.ollama.client import OllamaModelCapabilities
+from rune_bench.common import normalize_url
+from rune_bench.ollama.client import OllamaClient, OllamaModelCapabilities
 from rune_bench.ollama.client import OllamaClient
 from rune_bench.ollama.models import OllamaModelManager
 from rune_bench.vastai.instance import ConnectionDetails, InstanceManager, TeardownResult
@@ -55,8 +56,8 @@ def test_final_coverage_micro_branches(monkeypatch, tmp_path):
         def read(self):
             return b"{not-json"
 
-    monkeypatch.setattr(api_client_module, "urlopen", lambda *args, **kwargs: Response())
-    with pytest.raises(RuntimeError, match="invalid JSON"):
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *args, **kwargs: Response())
+    with pytest.raises(RuntimeError, match="Invalid JSON"):
         client._request("GET", "/v1/x")
 
     # ollama/models.py: warmup polling sleep branch
@@ -380,7 +381,7 @@ def test_holmes_and_ollama_remaining_branches(monkeypatch, tmp_path):
 
     # Ollama invalid URL branch
     with pytest.raises(RuntimeError):
-        OllamaClient._normalize_url("http://")
+        normalize_url("http://", service_name="Ollama")
 
     client = OllamaClient("http://x:11434")
 
@@ -391,7 +392,7 @@ def test_holmes_and_ollama_remaining_branches(monkeypatch, tmp_path):
         def read(self):
             return b""
 
-    monkeypatch.setattr("rune_bench.ollama.client.urlopen", lambda *_a, **_k: (_ for _ in ()).throw(NoDetailHttpError()))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *_a, **_k: (_ for _ in ()).throw(NoDetailHttpError()))
     with pytest.raises(RuntimeError, match="HTTP 500"):
         client._make_request("/x", method="GET", payload=None, action="act")
 
@@ -578,7 +579,7 @@ def test_api_backend_server_workflows_instance_remaining(monkeypatch, tmp_path):
 
 def test_api_client_remaining_lines(monkeypatch):
     with pytest.raises(RuntimeError):
-        rune.RuneApiClient._normalize_url("http://")
+        normalize_url("http://", service_name="RUNE API")
 
     client = rune.RuneApiClient("http://x:8080")
 
@@ -589,10 +590,10 @@ def test_api_client_remaining_lines(monkeypatch):
         def read(self):
             return b"detail"
 
-    monkeypatch.setattr("rune_bench.api_client.urlopen", lambda *_a, **_k: (_ for _ in ()).throw(DetailHttpError()))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *_a, **_k: (_ for _ in ()).throw(DetailHttpError()))
     with pytest.raises(RuntimeError, match="detail"):
         client._request("GET", "/x")
 
-    monkeypatch.setattr("rune_bench.api_client.urlopen", lambda *_a, **_k: (_ for _ in ()).throw(TimeoutError("late")))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *_a, **_k: (_ for _ in ()).throw(TimeoutError("late")))
     with pytest.raises(RuntimeError, match="late"):
         client._request("GET", "/x")

--- a/tests/test_ollama_client_and_models.py
+++ b/tests/test_ollama_client_and_models.py
@@ -2,17 +2,18 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from rune_bench.common import normalize_url
 from rune_bench.ollama.client import OllamaClient
 from rune_bench.ollama.models import OllamaModelManager
 
 
 def test_normalize_url_accepts_host_port_without_scheme():
-    assert OllamaClient._normalize_url("localhost:11434") == "http://localhost:11434"
+    assert normalize_url("localhost:11434", service_name="Ollama") == "http://localhost:11434"
 
 
 def test_normalize_url_rejects_invalid_input():
     with pytest.raises(RuntimeError):
-        OllamaClient._normalize_url(None)
+        normalize_url(None, service_name="Ollama")
 
 
 def test_get_model_capabilities_parses_context_length(monkeypatch):

--- a/tests/test_ollama_model_manager.py
+++ b/tests/test_ollama_model_manager.py
@@ -5,6 +5,7 @@ import pytest
 
 import rune_bench.api_backend as api_backend
 import rune_bench.workflows as workflows
+from rune_bench.common import make_http_request
 from rune_bench.common.models import ModelSelector
 from rune_bench.ollama.client import OllamaClient, OllamaModelCapabilities
 from rune_bench.ollama.models import OllamaModelManager
@@ -44,7 +45,7 @@ def test_ollama_client_make_request_and_helpers(monkeypatch):
         captured["method"] = request.get_method()
         return DummyResponse()
 
-    monkeypatch.setattr("rune_bench.ollama.client.urlopen", fake_urlopen)
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", fake_urlopen)
 
     client = OllamaClient("localhost:11434")
     assert client.get_available_models() == ["a", "b"]
@@ -92,11 +93,11 @@ def test_ollama_client_make_request_error_paths(monkeypatch):
     def raise_http(*_args, **_kwargs):
         raise FakeHTTPError()
 
-    monkeypatch.setattr("rune_bench.ollama.client.urlopen", raise_http)
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", raise_http)
     with pytest.raises(RuntimeError, match="server exploded"):
         client._make_request("/api/tags", method="GET", payload=None, action="act")
 
-    monkeypatch.setattr("rune_bench.ollama.client.urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(URLError("nope")))
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(URLError("nope")))
     with pytest.raises(RuntimeError, match="nope"):
         client._make_request("/api/tags", method="GET", payload=None, action="act")
 
@@ -110,16 +111,16 @@ def test_ollama_client_make_request_error_paths(monkeypatch):
         def read(self):
             return b"not-json"
 
-    monkeypatch.setattr("rune_bench.ollama.client.urlopen", lambda *_args, **_kwargs: BadJsonResponse())
-    with pytest.raises(RuntimeError, match="invalid JSON"):
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *_args, **_kwargs: BadJsonResponse())
+    with pytest.raises(RuntimeError, match="Invalid JSON"):
         client._make_request("/api/tags", method="GET", payload=None, action="act")
 
     class ListResponse(BadJsonResponse):
         def read(self):
             return b"[]"
 
-    monkeypatch.setattr("rune_bench.ollama.client.urlopen", lambda *_args, **_kwargs: ListResponse())
-    with pytest.raises(RuntimeError, match="unexpected JSON payload"):
+    monkeypatch.setattr("rune_bench.common.http_client.urlopen", lambda *_args, **_kwargs: ListResponse())
+    with pytest.raises(RuntimeError, match="Unexpected JSON payload"):
         client._make_request("/api/tags", method="GET", payload=None, action="act")
 
 


### PR DESCRIPTION
- Created rune_bench/common/http_client.py with normalize_url() and make_http_request()
- Refactored rune_bench/ollama/client.py to use shared HTTP utilities
- Refactored rune_bench/api_client.py to use shared HTTP utilities
- Updated all test patches to reference shared http_client module
- All 96 tests passing with 99.41% coverage