### PR TITLE
ci: add publish-pypi workflow — tag v* triggers PyPI release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,4 @@
-# Publish rune-bench to PyPI on version tags pushed to main.
+# Publish rune-bench to PyPI on version tags.
 #
 # Trigger: push of a tag matching v* (e.g. v0.2.0, v1.0.0-rc1)
 #
@@ -9,6 +9,8 @@
 # The tag should only be placed on a commit that has already passed all
 # quality gates via the PR merge process. This workflow performs a final
 # build-integrity check (twine check + fast unit tests) before uploading.
+# A guard step verifies that the tag version matches pyproject.toml and
+# that the tagged commit is reachable from origin/main.
 #
 # Security:
 #   - id-token: write is NOT used; classic API token auth avoids the need
@@ -35,13 +37,35 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
+
+      - name: Verify tag is on main and version matches pyproject.toml
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
+            exit 1
+          fi
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python - <<'EOF'
+          import tomllib, pathlib
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          EOF
+          )
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "ERROR: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)." >&2
+            exit 1
+          fi
+          echo "Version check passed: $PKG_VERSION"
 
       - name: Install dependencies and build tools
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,65 @@
+# Publish rune-bench to PyPI on version tags pushed to main.
+#
+# Trigger: push of a tag matching v* (e.g. v0.2.0, v1.0.0-rc1)
+#
+# Required secret:
+#   PYPI_API_TOKEN — a PyPI API token scoped to the rune-bench project
+#                    (create at https://pypi.org/manage/account/token/)
+#
+# The tag should only be placed on a commit that has already passed all
+# quality gates via the PR merge process. This workflow performs a final
+# build-integrity check (twine check + fast unit tests) before uploading.
+#
+# Security:
+#   - id-token: write is NOT used; classic API token auth avoids the need
+#     to configure PyPI Trusted Publisher (simpler for a personal project).
+#   - contents: read is the minimum needed to check out the repository.
+
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/rune-bench/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies and build tools
+        run: |
+          pip install --upgrade pip build twine
+          pip install --prefer-binary -r requirements.txt pytest
+
+      - name: Run fast unit tests (smoke check before publish)
+        run: |
+          python -m pytest -m "not integration" -p no:cov -o addopts='' -q
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify dist contents
+        run: twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*


### PR DESCRIPTION
Adds `.github/workflows/publish-pypi.yml` to publish **rune-bench** to PyPI automatically when a `v*` tag is pushed.

## How it works
1. Push a tag: `git tag v0.2.0 && git push origin v0.2.0`
2. Workflow triggers and runs a guard step that verifies:
   - The tagged commit is reachable from `origin/main`
   - The tag version (e.g. `0.2.0`) matches `[project].version` in `pyproject.toml`
3. Runs fast unit tests as a final sanity check
4. Builds sdist + wheel with `python -m build`
5. Verifies with `twine check`
6. Uploads to PyPI using `PYPI_API_TOKEN`

## Required setup
- Go to **Settings → Secrets → Actions** and add secret `PYPI_API_TOKEN`
- Create a PyPI API token at https://pypi.org/manage/account/token/ scoped to the `rune-bench` project
- Optionally create a **`pypi` environment** in Settings → Environments for deployment tracking