### PR TITLE
chore: set version to 0.0.0a0 for first alpha release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.backends.legacy:build"
 
 [project]
 name = "rune-bench"
-version = "0.1.0"
+version = "0.0.0a0"
 description = "RUNE — Reliability Use-case Numeric Evaluator"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Sets `version = "0.0.0a0"` in pyproject.toml ahead of the first alpha PyPI publish.

**Why `0.0.0a0` and not `0.0.0-alpha-0`?**
PyPI enforces [PEP 440](https://peps.python.org/pep-0440/). The word `alpha` and hyphens are not valid PEP 440 pre-release identifiers — the canonical alpha form is the `a` suffix. The publish workflow's version guard does a string comparison between the git tag (minus `v`) and this field, so tag `v0.0.0a0` will match.