### PR TITLE
fix(build): use setuptools.build_meta backend for PyPI packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "rune-bench"


### PR DESCRIPTION
Fixes the PyPI publish failure caused by `BackendUnavailable: Cannot import 'setuptools.backends.legacy'`.

The `setuptools.backends.legacy` path is not available in standard environments. The correct and universally compatible build backend is `setuptools.build_meta` — the standard since setuptools>=40 and what all packaging tools expect.