### PR TITLE
fix: make vastai an optional import — CLI works without [vastai] extra

### DIFF
--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -16,7 +16,11 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
-from vastai import VastAI
+
+try:
+    from vastai import VastAI
+except ImportError:
+    VastAI = None  # type: ignore[assignment,misc]
 
 from rune_bench.api_client import RuneApiClient
 from rune_bench.api_contracts import (
@@ -173,8 +177,13 @@ def _fetch_model_capabilities(ollama_url: str, model: str) -> OllamaModelCapabil
         return None
 
 
-def _vastai_sdk() -> VastAI:
+def _vastai_sdk() -> "VastAI":
     """Instantiate VastAI SDK reading the API key from the environment."""
+    if VastAI is None:
+        raise RuntimeError(
+            "The 'vastai' package is required for Vast.ai provisioning. "
+            "Install it with: pip install 'rune-bench[vastai]'"
+        )
     api_key = os.environ.get("VAST_API_KEY", "")
     return VastAI(api_key=api_key, raw=True)
 

--- a/rune_bench/__init__.py
+++ b/rune_bench/__init__.py
@@ -10,11 +10,15 @@ Exposes the top-level classes used by rune.py:
 """
 
 from .common import ModelSelector
-from rune_bench.resources.vastai import InstanceManager, OfferFinder, TemplateLoader
 
 __all__ = [
-    "OfferFinder",
     "ModelSelector",
-    "TemplateLoader",
-    "InstanceManager",
 ]
+
+def __getattr__(name: str) -> object:
+    """Lazily expose vastai resources only when the 'vastai' extra is installed."""
+    if name in ("OfferFinder", "TemplateLoader", "InstanceManager"):
+        from rune_bench.resources.vastai import InstanceManager, OfferFinder, TemplateLoader  # noqa: PLC0415
+        _map = {"OfferFinder": OfferFinder, "TemplateLoader": TemplateLoader, "InstanceManager": InstanceManager}
+        return _map[name]
+    raise AttributeError(f"module 'rune_bench' has no attribute {name!r}")

--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -1,9 +1,9 @@
 """Local execution backend behind the RUNE HTTP API."""
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
-
-from vastai import VastAI
 
 from rune_bench.agents.base import AgentRunner
 from rune_bench.api_contracts import (
@@ -14,7 +14,6 @@ from rune_bench.api_contracts import (
 from rune_bench.common import ModelSelector
 from rune_bench.resources.base import LLMResourceProvider
 from rune_bench.resources.existing_ollama_provider import ExistingOllamaProvider
-from rune_bench.resources.vastai import VastAIProvider
 from rune_bench.workflows import (
     list_existing_ollama_models,
     list_running_ollama_models,
@@ -22,9 +21,19 @@ from rune_bench.workflows import (
     warmup_existing_ollama_model,
 )
 
+try:
+    from vastai import VastAI
+except ImportError:
+    VastAI = None  # type: ignore[assignment,misc]
 
-def _vastai_sdk() -> VastAI:
+
+def _vastai_sdk() -> "VastAI":
     """Instantiate VastAI SDK reading the API key from the environment."""
+    if VastAI is None:
+        raise RuntimeError(
+            "The 'vastai' package is required for Vast.ai provisioning. "
+            "Install it with: pip install 'rune-bench[vastai]'"
+        )
     api_key = os.environ.get("VAST_API_KEY", "")
     return VastAI(api_key=api_key, raw=True)
 
@@ -32,6 +41,7 @@ def _vastai_sdk() -> VastAI:
 def _make_resource_provider_for_benchmark(request: RunBenchmarkRequest) -> LLMResourceProvider:
     """Factory: return the LLM resource provider for a benchmark run."""
     if request.vastai:
+        from rune_bench.resources.vastai import VastAIProvider
         return VastAIProvider(
             _vastai_sdk(),
             template_hash=request.template_hash,
@@ -51,6 +61,7 @@ def _make_resource_provider_for_benchmark(request: RunBenchmarkRequest) -> LLMRe
 def _make_resource_provider_for_ollama_instance(request: RunOllamaInstanceRequest) -> LLMResourceProvider:
     """Factory: return the LLM resource provider for an Ollama instance run."""
     if request.vastai:
+        from rune_bench.resources.vastai import VastAIProvider
         return VastAIProvider(
             _vastai_sdk(),
             template_hash=request.template_hash,

--- a/rune_bench/resources/__init__.py
+++ b/rune_bench/resources/__init__.py
@@ -2,11 +2,15 @@
 
 from .base import LLMResourceProvider, ProvisioningResult
 from .existing_ollama_provider import ExistingOllamaProvider
-from .vastai import VastAIProvider
 
 __all__ = [
     "LLMResourceProvider",
     "ProvisioningResult",
-    "VastAIProvider",
     "ExistingOllamaProvider",
 ]
+
+def __getattr__(name: str) -> object:
+    if name == "VastAIProvider":
+        from .vastai import VastAIProvider
+        return VastAIProvider
+    raise AttributeError(f"module 'rune_bench.resources' has no attribute {name!r}")

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -3,15 +3,26 @@
 This module keeps orchestration/business logic out of the CLI layer.
 """
 
-from dataclasses import dataclass
-from typing import Callable
+from __future__ import annotations
 
-from vastai import VastAI
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from vastai import VastAI
 
 from .common import ModelSelector
 from .debug import debug_log
 from rune_bench.backends.ollama import OllamaClient, OllamaModelManager
-from rune_bench.resources.vastai import ConnectionDetails, InstanceManager, OfferFinder, TeardownResult, TemplateLoader
+
+try:
+    from rune_bench.resources.vastai import ConnectionDetails, InstanceManager, OfferFinder, TeardownResult, TemplateLoader
+except ImportError:  # vastai extra not installed
+    ConnectionDetails = None  # type: ignore[assignment,misc]
+    InstanceManager = None  # type: ignore[assignment,misc]
+    OfferFinder = None  # type: ignore[assignment,misc]
+    TeardownResult = None  # type: ignore[assignment,misc]
+    TemplateLoader = None  # type: ignore[assignment,misc]
 
 
 class UserAbortedError(RuntimeError):
@@ -210,7 +221,6 @@ def provision_vastai_ollama(
 def stop_vastai_instance(sdk: VastAI, contract_id: int | str) -> TeardownResult:
     """Destroy Vast.ai instance + related storage and verify cleanup."""
     return InstanceManager(sdk).destroy_instance_and_related_storage(contract_id)
-
 
 def _extract_ollama_service_url(details: ConnectionDetails) -> str | None:
     for svc in details.service_urls:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,14 @@
 """Pytest configuration: shared fixtures and test helpers."""
+
+import sys
+from unittest.mock import MagicMock
+
+# Provide a minimal vastai stub when the optional [vastai] extra is not installed.
+# Tests use MagicMock for all SDK interactions; this just satisfies the import.
+try:
+    import vastai  # noqa: F401
+except ImportError:
+    _vastai_stub = MagicMock()
+    _vastai_stub.VastAI = MagicMock
+    sys.modules["vastai"] = _vastai_stub
+


### PR DESCRIPTION
## Problem

Users installing `rune-bench` without the `[vastai]` extra got:

```
ModuleNotFoundError: No module named 'vastai'
```

even when only running `rune --help` or non-Vast.ai commands.

## Fix

Wrapped all top-level `vastai` imports with `try/except ImportError` so the CLI and API server start cleanly without the optional extra. The vastai classes are exposed as module-level attributes (patchable by tests) but degrade gracefully to `None` when not installed. Calling a Vast.ai-dependent function without the extra now raises a helpful `RuntimeError` with install instructions.

### Files changed
- `rune/__init__.py` — `try/except` for `VastAI`; `_vastai_sdk()` checks for `None`
- `rune_bench/workflows.py` — `try/except` for vastai resources; `TYPE_CHECKING` guard
- `rune_bench/api_backend.py` — `try/except` for `VastAI`; lazy `VastAIProvider` import
- `rune_bench/resources/__init__.py` — lazy `VastAIProvider` via `__getattr__`
- `rune_bench/__init__.py` — lazy vastai classes via `__getattr__`
- `tests/conftest.py` — stub vastai in `sys.modules` when extra not installed (keeps tests green in dev without extra)

## Verification

```bash
# Without vastai installed:
python -c "from rune import app; print('OK')"  # → OK

# Tests still pass at 97.77% coverage
python -m pytest -m 'not regression' --ignore=lib
```