### PR TITLE
fix(ci): bare-install gate, publish guards, rune info, v0.0.0a1

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,20 @@
 #
 # Trigger: push of a tag matching v* (e.g. v0.2.0, v1.0.0-rc1)
 #
+# ─── TAGGING PROCESS ────────────────────────────────────────────────────────
+#  Tags MUST only be pushed AFTER the PR has been merged to main and all
+#  quality gates (RuneGate Grouped) have passed.
+#
+#  Correct flow:
+#    1. Open PR → quality gates pass → merge to main
+#    2. git pull origin main
+#    3. git tag v<version>   (version must match pyproject.toml exactly)
+#    4. git push origin v<version>
+#
+#  NEVER push a tag on an unmerged branch or before quality gates pass.
+#  The guard step below will reject tags not reachable from origin/main.
+# ────────────────────────────────────────────────────────────────────────────
+#
 # Authentication: OIDC Trusted Publisher (no long-lived credentials).
 #   id-token: write is scoped to the publish job only (principle of least privilege).
 #
@@ -16,12 +30,6 @@
 # │       Environment: pypi                                                     │
 # │  3. Save — no API token or secret is needed after this.                     │
 # └─────────────────────────────────────────────────────────────────────────────┘
-#
-# The tag should only be placed on a commit that has already passed all
-# quality gates via the PR merge process. This workflow performs a final
-# build-integrity check (twine check + fast unit tests) before uploading.
-# A guard step verifies that the tag version matches pyproject.toml and
-# that the tagged commit is reachable from origin/main.
 #
 # Security:
 #   - contents: read is the minimum needed to check out the repository.
@@ -40,6 +48,8 @@ permissions:
 jobs:
   publish:
     name: Build and publish to PyPI
+    # Extra safety: ensure this only ever runs on a real tag push, not on a branch.
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -65,6 +75,7 @@ jobs:
           git fetch origin main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "ERROR: Tagged commit is not reachable from origin/main." >&2
+            echo "Tags must only be pushed AFTER merging to main." >&2
             exit 1
           fi
           TAG_VERSION="${GITHUB_REF_NAME#v}"
@@ -80,20 +91,23 @@ jobs:
           fi
           echo "Version check passed: $PKG_VERSION"
 
-      - name: Install dependencies and build tools
-        run: |
-          pip install --upgrade pip build twine
-          pip install --prefer-binary -r requirements.txt pytest
-
-      - name: Run fast unit tests (smoke check before publish)
-        run: |
-          python -m pytest -m "not integration" -p no:cov -o addopts='' -q
+      - name: Install build tools
+        run: pip install --upgrade pip build twine
 
       - name: Build sdist and wheel
         run: python -m build
+
+      - name: Verify bare install works (no extras)
+        run: |
+          python -m venv .venv-bare
+          .venv-bare/bin/pip install --upgrade pip --quiet
+          .venv-bare/bin/pip install dist/*.whl --quiet
+          .venv-bare/bin/python -c "from rune import app; print('bare import: OK')"
+          .venv-bare/bin/python -m rune --help
 
       - name: Verify dist contents
         run: twine check dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -577,6 +577,36 @@ jobs:
         if: always()
         run: docker rm -f ollama 2>/dev/null || true
 
+  bare-install-smoke:
+    name: RuneGate/PackageInstall/BareAndExtras
+    needs: [feature-python]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Build wheel from source
+        run: |
+          pip install --upgrade pip build
+          python -m build --wheel
+      - name: "Bare install (no extras) — must import and run without vastai/holmes"
+        run: |
+          python -m venv .venv-bare
+          .venv-bare/bin/pip install --upgrade pip --quiet
+          .venv-bare/bin/pip install dist/*.whl --quiet
+          .venv-bare/bin/python -c "from rune import app; print('bare import: OK')"
+          .venv-bare/bin/python -m rune --help
+      - name: "Install with [vastai] extra — vastai import must succeed"
+        run: |
+          WHEEL=$(ls dist/*.whl)
+          python -m venv .venv-vastai
+          .venv-vastai/bin/pip install --upgrade pip --quiet
+          .venv-vastai/bin/pip install "${WHEEL}[vastai]" --quiet
+          .venv-vastai/bin/python -c "from vastai import VastAI; print('vastai extra import: OK')"
+          .venv-vastai/bin/python -m rune --help
+
   merge-gate:
     name: Merge Gate
     if: always()
@@ -585,6 +615,7 @@ jobs:
       - feature-python
       - linting-python
       - smoke-cli-api
+      - bare-install-smoke
       - regression-python
       - integration-ollama
       - security-sbom

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rune-bench"
-version = "0.0.0a0"
+version = "0.0.0a1"
 description = "RUNE — Reliability Use-case Numeric Evaluator"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -27,6 +27,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Extras are intentionally optional to avoid conflicts in shared Python environments.
+# Install only what you need:
+#
+#   pip install "rune-bench[vastai]"   — Vast.ai GPU provisioning
+#   pip install "rune-bench[holmes]"   — HolmesGPT SRE agent
+#   pip install "rune-bench[all]"      — everything
+#
+# Run `rune info` to see which extras are currently installed.
 holmes = [
     "holmesgpt>=0.23.0",
     # supabase<2.8 required to resolve holmesgpt's postgrest==0.16.8 pin conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ include = ["rune*", "rune_bench*"]
 python_version = "3.11"
 
 [[tool.mypy.overrides]]
-module = ["vastai"]
+module = ["vastai", "holmes", "holmes.*"]
 ignore_missing_imports = true
 
 [tool.bandit]

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -895,3 +895,47 @@ def run_benchmark(
 
 if __name__ == "__main__":
     app()
+
+
+@app.command("info")
+def show_info() -> None:
+    """Show installed extras and environment information."""
+    import importlib.metadata
+
+    try:
+        version = importlib.metadata.version("rune-bench")
+    except importlib.metadata.PackageNotFoundError:
+        version = "(dev — not installed as package)"
+
+    table = Table(title="RUNE Environment", show_header=True, header_style="bold blue")
+    table.add_column("Extra / Component", style="cyan")
+    table.add_column("Status", style="bold")
+    table.add_column("Install command", style="dim")
+
+    # Check vastai
+    try:
+        import vastai  # noqa: F401
+        vastai_status = "[green]✓ installed[/green]"
+        vastai_cmd = ""
+    except ImportError:
+        vastai_status = "[yellow]✗ not installed[/yellow]"
+        vastai_cmd = 'pip install "rune-bench[vastai]"'
+
+    # Check holmesgpt
+    try:
+        import holmes  # noqa: F401
+        holmes_status = "[green]✓ installed[/green]"
+        holmes_cmd = ""
+    except ImportError:
+        holmes_status = "[yellow]✗ not installed[/yellow]"
+        holmes_cmd = 'pip install "rune-bench[holmes]"'
+
+    table.add_row("[bold]vastai[/bold]  (Vast.ai GPU provisioning)", vastai_status, vastai_cmd)
+    table.add_row("[bold]holmes[/bold]  (HolmesGPT SRE agent)", holmes_status, holmes_cmd)
+
+    console.print(Panel.fit(f"[bold blue]rune-bench[/bold blue] v{version}"))
+    console.print(table)
+    if vastai_cmd or holmes_cmd:
+        console.print(
+            "\n[dim]Install all extras:[/dim] [cyan]pip install \"rune-bench[all]\"[/cyan]"
+        )

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -299,3 +299,20 @@ def test_vastai_provider_provision_and_teardown(monkeypatch):
     provider._stop_on_teardown = True
     provider.teardown(result)
     assert stop_calls == [42]
+
+
+def test_show_info_command(monkeypatch):
+    """rune info should display extra status without crashing."""
+    import sys
+    from unittest.mock import MagicMock
+
+    # Case 1: both extras missing → shows install commands
+    monkeypatch.setitem(sys.modules, "vastai", None)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "holmes", None)  # type: ignore[arg-type]
+    rune.show_info()
+
+    # Case 2: both extras present → shows "installed"
+    monkeypatch.setitem(sys.modules, "vastai", MagicMock())
+    monkeypatch.setitem(sys.modules, "holmes", MagicMock())
+    rune.show_info()
+


### PR DESCRIPTION
## Summary

Three issues fixed + version bump.

### 1. No gate caught bare import failures before PyPI publish

Added **RuneGate/PackageInstall/BareAndExtras** job to quality gates:
- Builds wheel from source using `python -m build`
- Installs WITHOUT extras → runs `rune --help` (would have caught the `ModuleNotFoundError: vastai` on 0.0.0a0)
- Installs WITH `[vastai]` extra → verifies vastai import works
- Required by Merge Gate — blocks merge if fails

### 2. publish-pypi.yml cleanup

- Added `if: github.ref_type == 'tag'` explicit job-level guard (belt-and-suspenders alongside the workflow-level tag trigger)
- Replaced unit test step with a bare-install smoke (unit tests are already proven green by quality gates before tagging)
- Expanded header comment with clear tagging process documentation

### 3. Dependency clarity

**`rune info`** new command:
```
$ rune info
╭────────────────╮
│ rune-bench v0.0.0a1 │
╰────────────────╯
RUNE Environment
Extra / Component         Status             Install command
vastai (Vast.ai GPU)     ✗ not installed    pip install "rune-bench[vastai]"
holmes (HolmesGPT SRE)   ✗ not installed    pip install "rune-bench[holmes]"

Install all extras: pip install "rune-bench[all]"
```

- pyproject.toml: added install guidance comment above extras section

### Version

`0.0.0a0` → `0.0.0a1`

After merge, tag with `v0.0.0a1` to publish.