### PR TITLE
feat: automatically tag rune-docs when rune is released

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -56,7 +56,8 @@ jobs:
       url: https://pypi.org/project/rune-bench/
 
     permissions:
-      id-token: write  # Required for OIDC token exchange with PyPI
+      id-token: write   # Required for OIDC token exchange with PyPI
+      contents: write   # Required to create GitHub Releases
 
     steps:
       - name: Checkout
@@ -111,3 +112,37 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag \
+            dist/*.whl dist/*.tar.gz
+
+      - name: Tag rune-docs with matching version
+        env:
+          CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CROSS_REPO_TOKEN:-}" ]; then
+            echo "RUNE_CHARTS_BOT_TOKEN not set — skipping rune-docs tag."
+            exit 0
+          fi
+          # Use GitHub API to create the same tag on rune-docs
+          # Get the SHA of the HEAD commit of rune-docs main
+          DOCS_SHA=$(curl -fsSL \
+            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/lpasquali/rune-docs/git/refs/heads/main \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['object']['sha'])")
+          # Create the tag ref on rune-docs
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/lpasquali/rune-docs/git/refs \
+            -d "{\"ref\": \"refs/tags/${TAG}\", \"sha\": \"${DOCS_SHA}\"}"
+          echo "Tagged rune-docs with ${TAG}"


### PR DESCRIPTION
## Summary

When a `v*` tag is pushed to rune (triggering `publish-pypi.yml`), a new step calls the GitHub API to apply the **same tag** to the HEAD commit of `rune-docs/main`. This cross-repo tag then triggers the new `pages.yml` deploy workflow in rune-docs, publishing versioned MkDocs docs for every release.

## Changes

- `.github/workflows/publish-pypi.yml`: adds **"Tag rune-docs with matching version"** step after the GitHub Release step.

## How it works

1. Uses `RUNE_CHARTS_BOT_TOKEN` (already configured in this repo — same PAT used by the charts notify job).
2. Fetches the current HEAD SHA of `rune-docs/main` via the GitHub API.
3. Creates `refs/tags/${TAG}` on `lpasquali/rune-docs` pointing to that SHA.
4. If `RUNE_CHARTS_BOT_TOKEN` is absent, the step exits 0 cleanly — the publish job is never blocked.

## Related

Companion PR in rune-docs: lpasquali/rune-docs — feat/mkdocs-github-pages