### PR TITLE
ci: skip unchanged gates with path-change detection and cache Docker layers

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -10,8 +10,56 @@ permissions:
   contents: read
 
 jobs:
+  # ─── Path-change detection ──────────────────────────────────────────────────
+  # Skips expensive jobs when irrelevant files change (e.g. README-only edits).
+  # Jobs that run on docker=true: smoke-cli-api, security-sbom, publish-image.
+  # Jobs that run on python=true: everything else except secrets.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.diff.outputs.python }}
+      docker: ${{ steps.diff.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Compute changed paths
+        id: diff
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" 2>/dev/null || echo ".")
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              CHANGED="."
+            else
+              CHANGED=$(git diff --name-only "$BEFORE" "${{ github.sha }}" 2>/dev/null || echo ".")
+            fi
+          fi
+          printf '%s\n' "$CHANGED"
+          # python: source code, tests, dependencies, build config
+          if printf '%s\n' "$CHANGED" | grep -qE '^(rune/|rune_bench/|tests/|requirements\.txt|pyproject\.toml)'; then
+            echo "python=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "python=false" >> "$GITHUB_OUTPUT"
+          fi
+          # docker: Dockerfile or anything baked into the image
+          if printf '%s\n' "$CHANGED" | grep -qE '^(Dockerfile|rune/|rune_bench/|requirements\.txt)'; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─── Python gates ────────────────────────────────────────────────────────────
+
   coverage-python:
     name: RuneGate/Coverage/Python
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,7 +117,8 @@ jobs:
 
   feature-python:
     name: RuneGate/Feature/Python
-    needs: [coverage-python]
+    needs: [changes, coverage-python]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -93,6 +142,8 @@ jobs:
 
   linting-python:
     name: RuneGate/Linting/Python
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -116,9 +167,131 @@ jobs:
           .venv/bin/ruff check rune rune_bench
           .venv/bin/mypy rune rune_bench
 
+  regression-python:
+    name: RuneGate/Regression/Python
+    needs: [changes, feature-python]
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+      - uses: actions/cache@v5
+        id: cache-venv
+        with:
+          path: .venv
+          key: venv-regression-${{ runner.os }}-py3.14-${{ hashFiles('requirements.txt', '.github/workflows/quality-gates.yml') }}
+      - name: Install dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install --upgrade pip
+          pip install --prefer-binary -r requirements.txt pytest
+      - run: .venv/bin/python -m pytest -p no:cov -o addopts='' -m regression tests/ -v --tb=short
+
+  integration-ollama:
+    name: RuneGate/Ollama-Integration/TinyLlama
+    needs: [changes, feature-python]
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+      - uses: actions/cache@v5
+        id: cache-venv
+        with:
+          path: .venv
+          key: venv-integration-${{ runner.os }}-py3.14-${{ hashFiles('requirements.txt', '.github/workflows/quality-gates.yml') }}
+      - name: Install dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install --upgrade pip
+          pip install --prefer-binary -r requirements.txt pytest
+      - uses: actions/cache@v5
+        id: cache-ollama-models
+        with:
+          path: /tmp/ollama-models
+          key: ollama-tinyllama-${{ runner.os }}-v1
+      - name: Start Ollama container
+        run: |
+          mkdir -p /tmp/ollama-models
+          docker run -d --name ollama \
+            -v /tmp/ollama-models:/root/.ollama \
+            -p 11434:11434 \
+            ollama/ollama
+      - name: Wait for Ollama to be ready
+        run: |
+          echo "Waiting for Ollama to become ready..."
+          for i in {1..30}; do
+            if curl -fsS http://localhost:11434/api/tags > /dev/null 2>&1; then
+              echo "Ollama ready (attempt $i)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Ollama did not become ready after 60 seconds"
+          exit 1
+      - name: Pull tinyllama (from cache or registry)
+        run: docker exec ollama ollama pull tinyllama
+      - name: Run Ollama integration tests
+        env:
+          OLLAMA_TEST_URL: http://localhost:11434
+          OLLAMA_TEST_MODEL: tinyllama
+        run: .venv/bin/python -m pytest -m integration -p no:cov -o addopts='' -v --tb=short tests/test_ollama_integration.py
+      - name: Collect Ollama logs on failure
+        if: failure()
+        run: docker logs ollama 2>&1 || true
+      - name: Stop and remove Ollama container
+        if: always()
+        run: docker rm -f ollama 2>/dev/null || true
+
+  bare-install-smoke:
+    name: RuneGate/PackageInstall/BareAndExtras
+    needs: [changes, feature-python]
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Build wheel from source
+        run: |
+          pip install --upgrade pip build
+          python -m build --wheel
+      - name: "Bare install (no extras) — must import and run without vastai/holmes"
+        run: |
+          python -m venv .venv-bare
+          .venv-bare/bin/pip install --upgrade pip --quiet
+          .venv-bare/bin/pip install dist/*.whl --quiet
+          .venv-bare/bin/python -c "from rune import app; print('bare import: OK')"
+          .venv-bare/bin/python -m rune --help
+      - name: "Install with [vastai] extra — vastai import must succeed"
+        run: |
+          WHEEL=$(ls dist/*.whl)
+          python -m venv .venv-vastai
+          .venv-vastai/bin/pip install --upgrade pip --quiet
+          .venv-vastai/bin/pip install "${WHEEL}[vastai]" --quiet
+          .venv-vastai/bin/python -c "from vastai import VastAI; print('vastai extra import: OK')"
+          .venv-vastai/bin/python -m rune --help
+
+  # ─── Docker / container gates ────────────────────────────────────────────────
+  # Decoupled from the Python test chain so a Dockerfile-only change still
+  # exercises the smoke and SBOM jobs without re-running Python unit tests.
+
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers
-    needs: [feature-python]
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -149,6 +322,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: rune:rune-ci-local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Load amd64 image and smoke test
         uses: docker/build-push-action@v7
         with:
@@ -158,6 +333,7 @@ jobs:
           load: true
           push: false
           tags: rune:rune-ci-local
+          cache-from: type=gha
       - run: |
           set -euo pipefail
           docker run -d --name rune-smoke -e RUNE_API_AUTH_DISABLED=1 -p 18080:8080 rune:rune-ci-local
@@ -180,33 +356,12 @@ jobs:
             exit 1
           fi
 
-  regression-python:
-    name: RuneGate/Regression/Python
-    needs: [feature-python]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-          cache: 'pip'
-      - uses: actions/cache@v5
-        id: cache-venv
-        with:
-          path: .venv
-          key: venv-regression-${{ runner.os }}-py3.14-${{ hashFiles('requirements.txt', '.github/workflows/quality-gates.yml') }}
-      - name: Install dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest
-      - run: .venv/bin/python -m pytest -p no:cov -o addopts='' -m regression tests/ -v --tb=short
+  # ─── Security gates ──────────────────────────────────────────────────────────
 
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
-    needs: [feature-python, linting-python]
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write      # required for SLSA provenance attestation
@@ -214,11 +369,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
-      - name: Build images
-        run: |
-          docker build -t rune:rune-ci-local -f Dockerfile .
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: rune:rune-ci-local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Generate SBOMs — CycloneDX via Syft (IEC 62443 4-1 ML4 SM-9)
         run: |
           set -euo pipefail
@@ -305,6 +466,8 @@ jobs:
 
   security-sast:
     name: RuneGate/Security/SAST
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -367,6 +530,8 @@ jobs:
 
   security-licenses:
     name: RuneGate/Security/LicenseCompliance
+    needs: [changes]
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -456,10 +621,13 @@ jobs:
           path: licenses-python.json
           retention-days: 14
 
+  # ─── CD gate (push to main/develop only) ─────────────────────────────────────
+
   publish-image-and-notify-charts:
     name: RuneGate/CD/Publish-Image-and-Notify-Charts
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
     needs:
+      - changes
       - smoke-cli-api
       - security-sbom
       - security-sast
@@ -493,6 +661,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}
@@ -517,100 +687,13 @@ jobs:
           }
           JSON
 
-  integration-ollama:
-    name: RuneGate/Ollama-Integration/TinyLlama
-    needs: [feature-python]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-          cache: 'pip'
-      - uses: actions/cache@v5
-        id: cache-venv
-        with:
-          path: .venv
-          key: venv-integration-${{ runner.os }}-py3.14-${{ hashFiles('requirements.txt', '.github/workflows/quality-gates.yml') }}
-      - name: Install dependencies
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest
-      - uses: actions/cache@v5
-        id: cache-ollama-models
-        with:
-          path: /tmp/ollama-models
-          key: ollama-tinyllama-${{ runner.os }}-v1
-      - name: Start Ollama container
-        run: |
-          mkdir -p /tmp/ollama-models
-          docker run -d --name ollama \
-            -v /tmp/ollama-models:/root/.ollama \
-            -p 11434:11434 \
-            ollama/ollama
-      - name: Wait for Ollama to be ready
-        run: |
-          echo "Waiting for Ollama to become ready..."
-          for i in {1..30}; do
-            if curl -fsS http://localhost:11434/api/tags > /dev/null 2>&1; then
-              echo "Ollama ready (attempt $i)"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Ollama did not become ready after 60 seconds"
-          exit 1
-      - name: Pull tinyllama (from cache or registry)
-        run: docker exec ollama ollama pull tinyllama
-      - name: Run Ollama integration tests
-        env:
-          OLLAMA_TEST_URL: http://localhost:11434
-          OLLAMA_TEST_MODEL: tinyllama
-        run: .venv/bin/python -m pytest -m integration -p no:cov -o addopts='' -v --tb=short tests/test_ollama_integration.py
-      - name: Collect Ollama logs on failure
-        if: failure()
-        run: docker logs ollama 2>&1 || true
-      - name: Stop and remove Ollama container
-        if: always()
-        run: docker rm -f ollama 2>/dev/null || true
-
-  bare-install-smoke:
-    name: RuneGate/PackageInstall/BareAndExtras
-    needs: [feature-python]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-      - name: Build wheel from source
-        run: |
-          pip install --upgrade pip build
-          python -m build --wheel
-      - name: "Bare install (no extras) — must import and run without vastai/holmes"
-        run: |
-          python -m venv .venv-bare
-          .venv-bare/bin/pip install --upgrade pip --quiet
-          .venv-bare/bin/pip install dist/*.whl --quiet
-          .venv-bare/bin/python -c "from rune import app; print('bare import: OK')"
-          .venv-bare/bin/python -m rune --help
-      - name: "Install with [vastai] extra — vastai import must succeed"
-        run: |
-          WHEEL=$(ls dist/*.whl)
-          python -m venv .venv-vastai
-          .venv-vastai/bin/pip install --upgrade pip --quiet
-          .venv-vastai/bin/pip install "${WHEEL}[vastai]" --quiet
-          .venv-vastai/bin/python -c "from vastai import VastAI; print('vastai extra import: OK')"
-          .venv-vastai/bin/python -m rune --help
+  # ─── Merge gate ──────────────────────────────────────────────────────────────
 
   merge-gate:
     name: Merge Gate
     if: always()
     needs:
+      - changes
       - coverage-python
       - feature-python
       - linting-python


### PR DESCRIPTION
## Summary

- Add `changes` detection job that diffs PR/push against its base and outputs `python` and `docker` boolean flags; every gate is guarded by the relevant flag so a README-only commit doesn't spin up Docker builds or run the full test suite
- Add `cache-from/cache-to: type=gha` to all `build-push-action` calls — BuildKit layers are reused across jobs in the same run and across runs when Dockerfile/deps are unchanged; switch `security-sbom` from plain `docker build` to `build-push-action` with `load: true` (required for GHA cache backend) and remove QEMU (amd64-only for SBOM)
- Decouple `smoke-cli-api` from the Python test chain so a Dockerfile-only change exercises the container smoke path without waiting for unit tests

## Path filter mapping

| Flag | Triggers on |
|---|---|
| `python` | `rune/`, `rune_bench/`, `tests/`, `requirements.txt`, `pyproject.toml` |
| `docker` | `Dockerfile`, `rune/`, `rune_bench/`, `requirements.txt` |

Merge gate already allowed `skipped` results — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)