### PR TITLE
ci: build image once, GHCR cache, parallel native arm64 release

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -304,6 +304,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -315,9 +316,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           tags: ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64,mode=max
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64,mode=max' || '' }}
 
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -314,7 +314,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64
           cache-to: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64,mode=max
@@ -322,11 +322,11 @@ jobs:
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers
     needs: [changes, security-secrets, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -383,13 +383,13 @@ jobs:
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
     needs: [changes, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       id-token: write      # required for SLSA provenance attestation
       attestations: write  # required for SLSA provenance attestation
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -295,7 +295,7 @@ jobs:
   build-image:
     name: RuneGate/Build/Docker-Image-amd64
     needs: [changes]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -292,9 +292,36 @@ jobs:
   # Decoupled from the Python test chain so a Dockerfile-only change still
   # exercises the smoke and SBOM jobs without re-running Python unit tests.
 
+  build-image:
+    name: RuneGate/Build/Docker-Image-amd64
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push amd64 temp image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64,mode=max
+
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers
-    needs: [changes, security-secrets]
+    needs: [changes, security-secrets, build-image]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -325,17 +352,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build amd64 image and smoke test
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          push: false
-          tags: rune:rune-ci-local
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache
-          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune:buildcache,mode=max' || '' }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64 rune:rune-ci-local
       - run: |
           set -euo pipefail
           docker run -d --name rune-smoke -e RUNE_API_AUTH_DISABLED=1 -p 18080:8080 rune:rune-ci-local
@@ -362,7 +382,7 @@ jobs:
 
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
-    needs: [changes]
+    needs: [changes, build-image]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -372,22 +392,15 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: rune:rune-ci-local
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache
-          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune:buildcache,mode=max' || '' }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune:ci-${{ github.sha }}-amd64 rune:rune-ci-local
       - name: Generate SBOMs — CycloneDX via Syft (IEC 62443 4-1 ML4 SM-9)
         run: |
           set -euo pipefail
@@ -780,6 +793,7 @@ jobs:
       - coverage-python
       - feature-python
       - linting-python
+      - build-image
       - smoke-cli-api
       - bare-install-smoke
       - regression-python

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -44,8 +44,11 @@ from rune_bench.metrics import InMemoryCollector, set_collector, clear_collector
 from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
 from rune_bench.workflows import (
     ExistingOllamaServer,
+    SpendGateAction,
     UserAbortedError,
     VastAIProvisioningResult,
+    _DEFAULT_SPEND_THRESHOLD,
+    evaluate_spend_gate,
     list_existing_ollama_models,
     list_running_ollama_models,
     provision_vastai_ollama,
@@ -79,7 +82,6 @@ API_BASE_URL = os.environ.get("RUNE_API_BASE_URL", "http://localhost:8080").stri
 API_TOKEN = os.environ.get("RUNE_API_TOKEN", "").strip() or None
 API_TENANT = os.environ.get("RUNE_API_TENANT", "default").strip() or "default"
 VERIFY_SSL = os.environ.get("RUNE_INSECURE", "").strip().lower() not in {"1", "true", "yes", "on"}
-_SPEND_WARNING_THRESHOLD_DEFAULT = 5.00
 
 # Active profile (sourced from --profile argv peek or RUNE_PROFILE env var).
 _ACTIVE_PROFILE: str | None = peek_profile_from_argv()
@@ -368,12 +370,18 @@ def _run_preflight_cost_check(
         border_style="yellow",
     ))
 
-    threshold = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", str(_SPEND_WARNING_THRESHOLD_DEFAULT)))
-    if projected_cost <= threshold or yes:
+    try:
+        threshold = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", str(_DEFAULT_SPEND_THRESHOLD)))
+    except (ValueError, TypeError):
+        console.print("[yellow]Warning: Invalid RUNE_SPEND_WARNING_THRESHOLD value; using default $5.00.[/yellow]")
+        threshold = _DEFAULT_SPEND_THRESHOLD
+
+    action = evaluate_spend_gate(projected_cost, threshold=threshold, yes=yes)
+
+    if action is SpendGateAction.ALLOW:
         return
 
-    is_ci = os.environ.get("CI", "").strip().lower() in {"1", "true", "yes"}
-    if is_ci:
+    if action is SpendGateAction.BLOCK:
         console.print(
             f"[red]Spend threshold exceeded (${projected_cost:.2f} > ${threshold:.2f}). "
             "Pass --yes / -y to proceed in CI.[/red]"

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -52,6 +52,7 @@ from rune_bench.workflows import (
     list_existing_ollama_models,
     list_running_ollama_models,
     provision_vastai_ollama,
+    run_preflight_cost_check,
     stop_vastai_instance,
     warmup_existing_ollama_model,
     use_existing_ollama_server,
@@ -324,32 +325,33 @@ def _run_preflight_cost_check(
 ) -> None:
     """Estimate projected spend and display a Rich warning panel before execution.
 
-    Raises typer.Exit(1) on FailClosedError or if the user declines to proceed.
-    Raises typer.Exit(0) if the user aborts an interactive prompt.
+    Raises typer.Exit(1) on FailClosedError, estimation failure without --yes,
+    or if the user declines to proceed.
     Does nothing when no cloud cost driver is active (local/existing Ollama server).
     """
-    if not vastai:
-        return
-
-    cost_req = CostEstimationRequest(
-        vastai=vastai,
-        max_dph=max_dph,
-        min_dph=min_dph,
-        estimated_duration_seconds=estimated_duration_seconds,
-    )
-
     try:
-        if BACKEND_MODE == "http":
-            result = _http_client().get_cost_estimate(cost_req.to_dict())
-        else:
-            estimator = CostEstimator()
-            response = asyncio.run(estimator.estimate(cost_req))
-            result = response.to_dict()
+        result = run_preflight_cost_check(
+            vastai=vastai,
+            max_dph=max_dph,
+            min_dph=min_dph,
+            estimated_duration_seconds=estimated_duration_seconds,
+            backend_mode=BACKEND_MODE,
+            http_client=_http_client() if BACKEND_MODE == "http" else None,
+        )
     except FailClosedError as exc:
         console.print(f"[red]Cost estimation error:[/red] {exc}")
         raise typer.Exit(1)
     except RuntimeError as exc:
-        console.print(f"[yellow]Cost estimation unavailable:[/yellow] {exc}")
+        if yes:
+            console.print(f"[yellow]Cost estimation unavailable:[/yellow] {exc}")
+            return
+        console.print(
+            f"[red]Cost estimation failed:[/red] {exc}\n"
+            "Pass --yes / -y to skip cost check and proceed."
+        )
+        raise typer.Exit(1)
+
+    if not result:
         return
 
     projected_cost: float = float(result.get("projected_cost_usd", 0.0))

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -7,7 +7,6 @@ This file only handles CLI argument parsing, Rich output, and orchestration.
 """
 
 from pathlib import Path
-import asyncio
 import os
 import socket
 from typing import Callable
@@ -25,7 +24,6 @@ except ImportError:
 
 from rune_bench.api_client import RuneApiClient
 from rune_bench.api_contracts import (
-    CostEstimationRequest,
     RunAgenticAgentRequest,
     RunBenchmarkRequest,
     RunOllamaInstanceRequest,
@@ -38,7 +36,6 @@ from rune_bench.common import (
     load_config,
     peek_profile_from_argv,
 )
-from rune_bench.common.costs import CostEstimator
 from rune_bench.debug import set_debug
 from rune_bench.metrics import InMemoryCollector, set_collector, clear_collector
 from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
@@ -47,7 +44,7 @@ from rune_bench.workflows import (
     SpendGateAction,
     UserAbortedError,
     VastAIProvisioningResult,
-    _DEFAULT_SPEND_THRESHOLD,
+    DEFAULT_SPEND_THRESHOLD,
     evaluate_spend_gate,
     list_existing_ollama_models,
     list_running_ollama_models,
@@ -373,10 +370,10 @@ def _run_preflight_cost_check(
     ))
 
     try:
-        threshold = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", str(_DEFAULT_SPEND_THRESHOLD)))
+        threshold = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", str(DEFAULT_SPEND_THRESHOLD)))
     except (ValueError, TypeError):
         console.print("[yellow]Warning: Invalid RUNE_SPEND_WARNING_THRESHOLD value; using default $5.00.[/yellow]")
-        threshold = _DEFAULT_SPEND_THRESHOLD
+        threshold = DEFAULT_SPEND_THRESHOLD
 
     action = evaluate_spend_gate(projected_cost, threshold=threshold, yes=yes)
 

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -79,7 +79,7 @@ API_BASE_URL = os.environ.get("RUNE_API_BASE_URL", "http://localhost:8080").stri
 API_TOKEN = os.environ.get("RUNE_API_TOKEN", "").strip() or None
 API_TENANT = os.environ.get("RUNE_API_TENANT", "default").strip() or "default"
 VERIFY_SSL = os.environ.get("RUNE_INSECURE", "").strip().lower() not in {"1", "true", "yes", "on"}
-SPEND_WARNING_THRESHOLD = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", "5.00"))
+_SPEND_WARNING_THRESHOLD_DEFAULT = 5.00
 
 # Active profile (sourced from --profile argv peek or RUNE_PROFILE env var).
 _ACTIVE_PROFILE: str | None = peek_profile_from_argv()
@@ -368,7 +368,7 @@ def _run_preflight_cost_check(
         border_style="yellow",
     ))
 
-    threshold = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", str(SPEND_WARNING_THRESHOLD)))
+    threshold = float(os.environ.get("RUNE_SPEND_WARNING_THRESHOLD", str(_SPEND_WARNING_THRESHOLD_DEFAULT)))
     if projected_cost <= threshold or yes:
         return
 
@@ -383,7 +383,7 @@ def _run_preflight_cost_check(
     ack = console.input("\n[bold magenta]Proceed with benchmark? [y/N]: [/bold magenta]").strip().lower()
     if ack not in {"y", "yes"}:
         console.print("Aborted.")
-        raise typer.Exit(0)
+        raise typer.Exit(1)
 
 
 def _run_http_job_with_progress(

--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -181,8 +181,11 @@ def get_cost_estimate(request: CostEstimationRequest) -> dict:
     duration_hours = request.estimated_duration_seconds / 3600
 
     if request.vastai:
-        avg_dph = (request.min_dph + request.max_dph) / 2 if request.max_dph > 0 else request.min_dph
-        projected_cost_usd = avg_dph * duration_hours
+        # Use max_dph as the hourly rate (worst-case / ceiling estimate) to match
+        # CostEstimator._estimate_vastai() and give consistent spend-gate behaviour
+        # regardless of whether the CLI runs in local or HTTP backend mode.
+        dph = request.max_dph if request.max_dph > 0 else request.min_dph
+        projected_cost_usd = dph * duration_hours
         local_energy_kwh = 0.0
         cost_driver = "vastai"
     elif request.local_hardware:

--- a/rune_bench/api_client.py
+++ b/rune_bench/api_client.py
@@ -71,6 +71,12 @@ class RuneApiClient:
         payload = self._request("POST", "/v1/estimates", body=request_payload)
         if "projected_cost_usd" not in payload:
             raise RuntimeError("API payload missing 'projected_cost_usd' for cost estimate")
+        cost_driver = str(payload.get("cost_driver", "")).strip().lower()
+        if not cost_driver or cost_driver in {"unknown", "none"}:
+            from rune_bench.common import FailClosedError
+            raise FailClosedError(
+                f"Cost estimation unavailable: server returned cost_driver={payload.get('cost_driver')!r} (no driver configured)"
+            )
         return payload
 
     def submit_agentic_agent_job(self, request_payload: dict, *, idempotency_key: str | None = None) -> str:

--- a/rune_bench/common/costs.py
+++ b/rune_bench/common/costs.py
@@ -34,7 +34,7 @@ class CostEstimator:
             return self._estimate_cloud_stub("gcp", request, rate=2.20)
 
         raise FailClosedError(
-            "No cost driver selected. Configure --vastai, --azure, --aws, --gcp, or --local "
+            "No cost driver selected. Configure --vastai, --azure, --aws, --gcp, or --local-hardware "
             "to proceed. (Fail-Closed: execution halted to prevent unbounded spend.)"
         )
 

--- a/rune_bench/common/costs.py
+++ b/rune_bench/common/costs.py
@@ -34,7 +34,7 @@ class CostEstimator:
             return self._estimate_cloud_stub("gcp", request, rate=2.20)
 
         raise FailClosedError(
-            "No cost driver selected. Configure --vastai, --azure, --aws, --gcp, or --local-hardware "
+            "No cost driver selected. Set one of the request fields (vastai, azure, aws, gcp, or local_hardware) "
             "to proceed. (Fail-Closed: execution halted to prevent unbounded spend.)"
         )
 

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -5,7 +5,9 @@ This module keeps orchestration/business logic out of the CLI layer.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
@@ -28,6 +30,34 @@ except ImportError:  # vastai extra not installed
 
 class UserAbortedError(RuntimeError):
     """Raised when an interactive confirmation is rejected by the user."""
+
+
+_DEFAULT_SPEND_THRESHOLD = 5.00
+
+
+class SpendGateAction(str, Enum):
+    ALLOW = "allow"
+    PROMPT = "prompt"
+    BLOCK = "block"
+
+
+def evaluate_spend_gate(
+    projected_cost: float,
+    *,
+    threshold: float,
+    yes: bool,
+) -> SpendGateAction:
+    """Determine the spend-gate action for a given projected cost.
+
+    Returns ALLOW when cost is within threshold or --yes is set.
+    Returns BLOCK when running in CI (non-interactive).
+    Returns PROMPT otherwise.
+    """
+    if projected_cost <= threshold or yes:
+        return SpendGateAction.ALLOW
+    if os.environ.get("CI", "").strip().lower() in {"1", "true", "yes"}:
+        return SpendGateAction.BLOCK
+    return SpendGateAction.PROMPT
 
 
 @dataclass

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -259,6 +259,46 @@ def stop_vastai_instance(sdk: VastAI, contract_id: int | str) -> TeardownResult:
     """Destroy Vast.ai instance + related storage and verify cleanup."""
     return InstanceManager(sdk).destroy_instance_and_related_storage(contract_id)
 
+
+def run_preflight_cost_check(
+    *,
+    vastai: bool,
+    max_dph: float,
+    min_dph: float,
+    estimated_duration_seconds: int = 3600,
+    backend_mode: str = "local",
+    http_client=None,
+) -> dict:
+    """Estimate projected spend for a Vast.ai job.
+
+    Returns the cost estimate dict (empty dict when vastai is False).
+    Raises FailClosedError when no cost driver is configured.
+    Raises RuntimeError when estimation is unavailable.
+    """
+    import asyncio
+
+    if not vastai:
+        return {}
+
+    from rune_bench.api_contracts import CostEstimationRequest
+    from rune_bench.common.costs import CostEstimator, FailClosedError  # noqa: F401 (re-raised by caller)
+
+    cost_req = CostEstimationRequest(
+        vastai=vastai,
+        max_dph=max_dph,
+        min_dph=min_dph,
+        estimated_duration_seconds=estimated_duration_seconds,
+    )
+
+    if backend_mode == "http":
+        if http_client is None:
+            raise RuntimeError("http_client is required when backend_mode='http'")
+        return http_client.get_cost_estimate(cost_req.to_dict())
+
+    estimator = CostEstimator()
+    response = asyncio.run(estimator.estimate(cost_req))
+    return response.to_dict()
+
 def _extract_ollama_service_url(details: ConnectionDetails) -> str | None:
     for svc in details.service_urls:
         direct = str(svc.get("direct", ""))

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -5,6 +5,7 @@ This module keeps orchestration/business logic out of the CLI layer.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -32,7 +33,7 @@ class UserAbortedError(RuntimeError):
     """Raised when an interactive confirmation is rejected by the user."""
 
 
-_DEFAULT_SPEND_THRESHOLD = 5.00
+DEFAULT_SPEND_THRESHOLD = 5.00
 
 
 class SpendGateAction(str, Enum):
@@ -275,8 +276,6 @@ def run_preflight_cost_check(
     Raises FailClosedError when no cost driver is configured.
     Raises RuntimeError when estimation is unavailable.
     """
-    import asyncio
-
     if not vastai:
         return {}
 

--- a/tests/test_cost_estimation.py
+++ b/tests/test_cost_estimation.py
@@ -31,7 +31,7 @@ def test_get_cost_estimate_vastai():
     r = _req(vastai=True, min_dph=2.0, max_dph=4.0)
     out = get_cost_estimate(r)
     assert out["cost_driver"] == "vastai"
-    assert out["projected_cost_usd"] == pytest.approx(3.0, rel=1e-3)
+    assert out["projected_cost_usd"] == pytest.approx(4.0, rel=1e-3)
     assert out["resource_impact"] == "medium"
     assert out["local_energy_kwh"] == 0.0
     assert out["confidence_score"] == 1.0

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -142,38 +142,41 @@ def test_cli_preflight_estimation_failure_without_yes_exits_1(monkeypatch):
 
 
 def test_get_cost_estimate_raises_for_none_cost_driver(monkeypatch):
-    """get_cost_estimate raises RuntimeError when cost_driver is 'none'."""
+    """get_cost_estimate raises FailClosedError when cost_driver is 'none'."""
+    from rune_bench.common.costs import FailClosedError
     client = RuneApiClient("http://api:8080")
     monkeypatch.setattr(
         client,
         "_request",
         lambda *_a, **_kw: {"projected_cost_usd": 4.5, "cost_driver": "none"},
     )
-    with pytest.raises(RuntimeError, match="cost_driver="):
+    with pytest.raises(FailClosedError, match="cost_driver="):
         client.get_cost_estimate({})
 
 
 def test_get_cost_estimate_raises_for_unknown_cost_driver(monkeypatch):
-    """get_cost_estimate raises RuntimeError when cost_driver is 'unknown'."""
+    """get_cost_estimate raises FailClosedError when cost_driver is 'unknown'."""
+    from rune_bench.common.costs import FailClosedError
     client = RuneApiClient("http://api:8080")
     monkeypatch.setattr(
         client,
         "_request",
         lambda *_a, **_kw: {"projected_cost_usd": 4.5, "cost_driver": "unknown"},
     )
-    with pytest.raises(RuntimeError, match="cost_driver="):
+    with pytest.raises(FailClosedError, match="cost_driver="):
         client.get_cost_estimate({})
 
 
 def test_get_cost_estimate_raises_for_missing_cost_driver(monkeypatch):
-    """get_cost_estimate raises RuntimeError when cost_driver is absent."""
+    """get_cost_estimate raises FailClosedError when cost_driver is absent."""
+    from rune_bench.common.costs import FailClosedError
     client = RuneApiClient("http://api:8080")
     monkeypatch.setattr(
         client,
         "_request",
         lambda *_a, **_kw: {"projected_cost_usd": 4.5},
     )
-    with pytest.raises(RuntimeError, match="cost_driver="):
+    with pytest.raises(FailClosedError, match="cost_driver="):
         client.get_cost_estimate({})
 
 
@@ -206,3 +209,67 @@ def test_fail_closed_error_message_uses_local_hardware():
     estimator = CostEstimator()
     with pytest.raises(FailClosedError, match="local_hardware"):
         asyncio.run(estimator.estimate(req))
+
+
+# ─── evaluate_spend_gate CI blocking behavior ─────────────────────────────────
+
+
+def test_evaluate_spend_gate_blocks_in_ci(monkeypatch):
+    """With CI=1 and cost above threshold, evaluate_spend_gate returns BLOCK."""
+    from rune_bench.workflows import SpendGateAction, evaluate_spend_gate
+
+    monkeypatch.setenv("CI", "1")
+    action = evaluate_spend_gate(99.0, threshold=5.0, yes=False)
+    assert action is SpendGateAction.BLOCK
+
+
+def test_evaluate_spend_gate_allows_with_yes_in_ci(monkeypatch):
+    """With --yes, evaluate_spend_gate returns ALLOW even in CI above threshold."""
+    from rune_bench.workflows import SpendGateAction, evaluate_spend_gate
+
+    monkeypatch.setenv("CI", "1")
+    action = evaluate_spend_gate(99.0, threshold=5.0, yes=True)
+    assert action is SpendGateAction.ALLOW
+
+
+def test_cli_preflight_ci_block_exits_1(monkeypatch):
+    """In CI mode with spend above threshold, CLI exits with code 1."""
+    import typer
+    import rune as rune_cli
+
+    monkeypatch.setattr(
+        rune_cli,
+        "run_preflight_cost_check",
+        lambda **_kw: {
+            "projected_cost_usd": 99.0,
+            "cost_driver": "vastai",
+            "resource_impact": "high",
+            "warning": None,
+        },
+    )
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.delenv("RUNE_SPEND_WARNING_THRESHOLD", raising=False)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        rune_cli._run_preflight_cost_check(vastai=True, max_dph=3.0, min_dph=2.0, yes=False)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_cli_preflight_ci_yes_bypasses_block(monkeypatch):
+    """In CI with --yes, spend block is bypassed and function returns normally."""
+    import rune as rune_cli
+
+    monkeypatch.setattr(
+        rune_cli,
+        "run_preflight_cost_check",
+        lambda **_kw: {
+            "projected_cost_usd": 99.0,
+            "cost_driver": "vastai",
+            "resource_impact": "high",
+            "warning": None,
+        },
+    )
+    monkeypatch.setenv("CI", "1")
+    # Should not raise
+    rune_cli._run_preflight_cost_check(vastai=True, max_dph=3.0, min_dph=2.0, yes=True)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,208 @@
+"""Tests for preflight cost-check paths: CLI behaviour and api_client validation."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rune_bench.api_client import RuneApiClient
+from rune_bench.common.costs import CostEstimator, FailClosedError
+from rune_bench.workflows import run_preflight_cost_check
+
+
+# ─── run_preflight_cost_check (workflows) ─────────────────────────────────────
+
+
+def test_preflight_returns_empty_when_not_vastai():
+    result = run_preflight_cost_check(vastai=False, max_dph=3.0, min_dph=2.0)
+    assert result == {}
+
+
+def test_preflight_local_backend_returns_estimate():
+    result = run_preflight_cost_check(
+        vastai=True,
+        max_dph=3.0,
+        min_dph=2.0,
+        estimated_duration_seconds=3600,
+        backend_mode="local",
+    )
+    assert result["cost_driver"] == "vastai"
+    assert "projected_cost_usd" in result
+
+
+def test_preflight_http_backend_calls_client(monkeypatch):
+    mock_client = MagicMock()
+    mock_client.get_cost_estimate.return_value = {
+        "projected_cost_usd": 4.5,
+        "cost_driver": "vastai",
+        "resource_impact": "medium",
+        "warning": None,
+    }
+    result = run_preflight_cost_check(
+        vastai=True,
+        max_dph=3.0,
+        min_dph=2.0,
+        backend_mode="http",
+        http_client=mock_client,
+    )
+    assert result["projected_cost_usd"] == 4.5
+    mock_client.get_cost_estimate.assert_called_once()
+
+
+def test_preflight_http_backend_requires_client():
+    with pytest.raises(RuntimeError, match="http_client is required"):
+        run_preflight_cost_check(
+            vastai=True,
+            max_dph=3.0,
+            min_dph=2.0,
+            backend_mode="http",
+            http_client=None,
+        )
+
+
+def test_preflight_raises_fail_closed_error():
+    """FailClosedError propagates when no cost driver is configured in CostEstimator."""
+    from rune_bench.api_contracts import CostEstimationRequest
+
+    # Patch CostEstimator.estimate to raise FailClosedError
+    with patch("rune_bench.common.costs.CostEstimator.estimate", side_effect=FailClosedError("no driver")):
+        with pytest.raises(FailClosedError):
+            run_preflight_cost_check(
+                vastai=True,
+                max_dph=3.0,
+                min_dph=2.0,
+                backend_mode="local",
+            )
+
+
+# ─── CLI _run_preflight_cost_check behaviour ──────────────────────────────────
+
+
+def test_cli_preflight_decline_exits_1(monkeypatch, capsys):
+    """User declining the confirmation prompt exits with code 1 (not 0)."""
+    import typer
+    import rune as rune_cli
+
+    # Patch run_preflight_cost_check to return a cost above default threshold
+    monkeypatch.setattr(
+        rune_cli,
+        "run_preflight_cost_check",
+        lambda **_kw: {
+            "projected_cost_usd": 99.0,
+            "cost_driver": "vastai",
+            "resource_impact": "high",
+            "warning": None,
+        },
+    )
+    # User types 'n'
+    monkeypatch.setattr(rune_cli.console, "input", lambda _prompt: "n")
+    # Make sure we're not in CI
+    monkeypatch.delenv("CI", raising=False)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        rune_cli._run_preflight_cost_check(vastai=True, max_dph=3.0, min_dph=2.0, yes=False)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_cli_preflight_estimation_failure_with_yes_continues(monkeypatch):
+    """With --yes, a RuntimeError during estimation warns but does not exit."""
+    import rune as rune_cli
+
+    monkeypatch.setattr(
+        rune_cli,
+        "run_preflight_cost_check",
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("server offline")),
+    )
+
+    # Should not raise
+    rune_cli._run_preflight_cost_check(vastai=True, max_dph=3.0, min_dph=2.0, yes=True)
+
+
+def test_cli_preflight_estimation_failure_without_yes_exits_1(monkeypatch):
+    """Without --yes, a RuntimeError during estimation exits with code 1."""
+    import typer
+    import rune as rune_cli
+
+    monkeypatch.setattr(
+        rune_cli,
+        "run_preflight_cost_check",
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("estimation unavailable")),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        rune_cli._run_preflight_cost_check(vastai=True, max_dph=3.0, min_dph=2.0, yes=False)
+
+    assert exc_info.value.exit_code == 1
+
+
+# ─── api_client.get_cost_estimate cost_driver validation ──────────────────────
+
+
+def test_get_cost_estimate_raises_for_none_cost_driver(monkeypatch):
+    """get_cost_estimate raises RuntimeError when cost_driver is 'none'."""
+    client = RuneApiClient("http://api:8080")
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_a, **_kw: {"projected_cost_usd": 4.5, "cost_driver": "none"},
+    )
+    with pytest.raises(RuntimeError, match="cost_driver="):
+        client.get_cost_estimate({})
+
+
+def test_get_cost_estimate_raises_for_unknown_cost_driver(monkeypatch):
+    """get_cost_estimate raises RuntimeError when cost_driver is 'unknown'."""
+    client = RuneApiClient("http://api:8080")
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_a, **_kw: {"projected_cost_usd": 4.5, "cost_driver": "unknown"},
+    )
+    with pytest.raises(RuntimeError, match="cost_driver="):
+        client.get_cost_estimate({})
+
+
+def test_get_cost_estimate_raises_for_missing_cost_driver(monkeypatch):
+    """get_cost_estimate raises RuntimeError when cost_driver is absent."""
+    client = RuneApiClient("http://api:8080")
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_a, **_kw: {"projected_cost_usd": 4.5},
+    )
+    with pytest.raises(RuntimeError, match="cost_driver="):
+        client.get_cost_estimate({})
+
+
+def test_get_cost_estimate_accepts_valid_cost_driver(monkeypatch):
+    """get_cost_estimate succeeds when cost_driver is a real driver name."""
+    client = RuneApiClient("http://api:8080")
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_a, **_kw: {"projected_cost_usd": 3.0, "cost_driver": "vastai"},
+    )
+    result = client.get_cost_estimate({})
+    assert result["cost_driver"] == "vastai"
+
+
+# ─── FailClosedError message ──────────────────────────────────────────────────
+
+
+def test_fail_closed_error_message_uses_local_hardware():
+    """FailClosedError message references --local-hardware, not --local."""
+    from rune_bench.api_contracts import CostEstimationRequest
+
+    req = CostEstimationRequest(
+        vastai=False, aws=False, gcp=False, azure=False, local_hardware=False,
+        min_dph=0.0, max_dph=0.0,
+        local_tdp_watts=0.0, local_energy_rate_kwh=0.0,
+        local_hardware_purchase_price=0.0, local_hardware_lifespan_years=0.0,
+        model="", estimated_duration_seconds=3600,
+    )
+    estimator = CostEstimator()
+    with pytest.raises(FailClosedError, match="local_hardware"):
+        asyncio.run(estimator.estimate(req))


### PR DESCRIPTION
## Changes

### Build image once per pipeline (#30)
- New `build-image` job pushes `ghcr.io/lpasquali/rune:ci-<sha>-amd64`
- `smoke-cli-api` and `security-sbom` pull the pre-built image (no rebuild)
- `publish-image` uses `imagetools create` to merge amd64 + arm64 into final manifest

### GHCR registry cache (#32)
- Always use `type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64` (no GHA fallback)
- Cross-job and cross-workflow cache sharing

Closes #30
Closes #32