### PR TITLE
feat(security): TPM 2.0 remote attestation scaffold

### DIFF
--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -132,7 +132,22 @@ def run_agentic_agent(request: RunAgenticAgentRequest) -> dict:
     return {"answer": answer}
 
 
+def _verify_attestation(target: str) -> None:
+    """Run PCR attestation for *target*; raises RuntimeError on failure."""
+    from rune_bench.attestation.factory import get_driver
+
+    driver = get_driver()
+    result = driver.verify(target)
+    if not result.passed:
+        raise RuntimeError(
+            f"Attestation failed for scheduling target {target!r}: {result.message}"
+        )
+
+
 def run_benchmark(request: RunBenchmarkRequest) -> dict:
+    if request.attestation_required:
+        _verify_attestation(request.kubeconfig)
+
     provider = _make_resource_provider_for_benchmark(request)
     result = provider.provision()
 

--- a/rune_bench/api_contracts.py
+++ b/rune_bench/api_contracts.py
@@ -68,6 +68,7 @@ class RunBenchmarkRequest:
     ollama_warmup_timeout: int
     kubeconfig: str
     vastai_stop_instance: bool
+    attestation_required: bool = False
 
     @classmethod
     def from_cli(
@@ -85,6 +86,7 @@ class RunBenchmarkRequest:
         ollama_warmup_timeout: int,
         kubeconfig: Path,
         vastai_stop_instance: bool,
+        attestation_required: bool = False,
     ) -> "RunBenchmarkRequest":
         return cls(
             vastai=vastai,
@@ -99,6 +101,7 @@ class RunBenchmarkRequest:
             ollama_warmup_timeout=ollama_warmup_timeout,
             kubeconfig=str(kubeconfig),
             vastai_stop_instance=vastai_stop_instance,
+            attestation_required=attestation_required,
         )
 
     def to_dict(self) -> dict:

--- a/rune_bench/attestation/__init__.py
+++ b/rune_bench/attestation/__init__.py
@@ -1,0 +1,6 @@
+"""TPM 2.0 remote attestation scaffold for benchmark job scheduling targets."""
+
+from .factory import get_driver
+from .interface import AttestationDriver, AttestationResult
+
+__all__ = ["AttestationDriver", "AttestationResult", "get_driver"]

--- a/rune_bench/attestation/factory.py
+++ b/rune_bench/attestation/factory.py
@@ -1,0 +1,53 @@
+"""Factory for attestation drivers.
+
+Resolves the driver name from the supplied *config* dict, falling back to
+the ``RUNE_ATTESTATION_DRIVER`` environment variable (default: ``noop``).
+"""
+
+from __future__ import annotations
+
+import os
+
+from .interface import AttestationDriver
+
+
+def get_driver(config: dict | None = None) -> AttestationDriver:
+    """Return the AttestationDriver configured by *config* or environment.
+
+    Args:
+        config: Attestation section from ``rune.yaml``, e.g.::
+
+                {"driver": "noop"}
+                {"driver": "tpm2", "pcr_policy_path": "/etc/rune/pcr.policy"}
+
+            When ``None`` or empty, falls back to the
+            ``RUNE_ATTESTATION_DRIVER`` env var (default: ``"noop"``).
+
+    Returns:
+        A concrete :class:`AttestationDriver` instance.
+
+    Raises:
+        ValueError: When the driver name is not ``"noop"`` or ``"tpm2"``.
+        RuntimeError: When ``driver="tpm2"`` and tpm2-tools is not installed.
+    """
+    cfg = config or {}
+    driver_name = cfg.get("driver") or os.environ.get("RUNE_ATTESTATION_DRIVER", "noop")
+    pcr_policy_path = cfg.get("pcr_policy_path") or os.environ.get(
+        "RUNE_ATTESTATION_PCR_POLICY_PATH"
+    )
+
+    if driver_name == "noop":
+        from .noop import NoOpDriver
+
+        return NoOpDriver()
+
+    if driver_name == "tpm2":
+        from .tpm2 import TPM2Driver
+
+        return TPM2Driver(pcr_policy_path=pcr_policy_path)
+
+    raise ValueError(
+        f"Unknown attestation driver: {driver_name!r}. "
+        "Expected 'noop' or 'tpm2'. "
+        "Set attestation.driver in rune.yaml or RUNE_ATTESTATION_DRIVER env var."
+    )

--- a/rune_bench/attestation/interface.py
+++ b/rune_bench/attestation/interface.py
@@ -1,0 +1,27 @@
+"""Attestation driver interface for TPM 2.0 PCR verification."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AttestationResult:
+    passed: bool
+    pcr_digest: str | None
+    message: str
+
+
+class AttestationDriver(ABC):
+    @abstractmethod
+    def verify(self, target: str) -> AttestationResult:
+        """Verify PCR attestation for the given scheduling target.
+
+        Args:
+            target: Identifier for the scheduling target (e.g. kubeconfig path
+                    or cluster endpoint) used as the attestation nonce.
+
+        Returns:
+            AttestationResult with ``passed=True`` when attestation succeeds.
+        """

--- a/rune_bench/attestation/noop.py
+++ b/rune_bench/attestation/noop.py
@@ -1,0 +1,26 @@
+"""NoOp attestation driver for local/dev environments.
+
+Always passes — use only when hardware TPM is unavailable or unnecessary.
+"""
+
+from __future__ import annotations
+
+from .interface import AttestationDriver, AttestationResult
+
+
+class NoOpDriver(AttestationDriver):
+    """Attestation driver that unconditionally passes verification.
+
+    Intended for local development and CI environments where a physical
+    TPM 2.0 chip is absent.  Should *not* be used in production.
+    """
+
+    def verify(self, target: str) -> AttestationResult:
+        return AttestationResult(
+            passed=True,
+            pcr_digest=None,
+            message=(
+                f"NoOp attestation: PCR verification skipped for {target!r} "
+                "(dev/local mode — not suitable for production)"
+            ),
+        )

--- a/rune_bench/attestation/tpm2.py
+++ b/rune_bench/attestation/tpm2.py
@@ -1,0 +1,170 @@
+"""TPM 2.0 attestation driver using the tpm2-tools CLI.
+
+Invokes ``tpm2_quote`` to obtain a PCR quote from the local TPM chip and,
+when a PCR policy file is supplied, runs ``tpm2_checkquote`` to validate it.
+
+Requirements:
+    tpm2-tools >= 5.x must be installed (``apt install tpm2-tools`` or
+    equivalent).  The Attestation Key context file ``ak.ctx`` must already
+    exist in the working directory (created once via ``tpm2_createak``).
+
+Note on replay protection:
+    This scaffold passes the *target* string (e.g. kubeconfig path) as the
+    TPM qualifying data.  This binds the quote to that specific target but
+    does **not** provide freshness — a static target can be replayed.  For
+    production use, replace ``target`` with a per-request server-generated
+    nonce (challenge) and validate it inside ``tpm2_checkquote`` to prevent
+    quote replay attacks.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+
+from .interface import AttestationDriver, AttestationResult
+
+# PCR indices used for OS boot-integrity measurement.
+_DEFAULT_PCR_LIST = "sha256:0,1,2,3,4,7"
+_QUOTE_TIMEOUT = 30  # seconds
+
+
+class TPM2Driver(AttestationDriver):
+    """Attestation driver that calls tpm2-tools subprocesses.
+
+    Args:
+        pcr_policy_path: Optional path to a PCR policy file passed to
+            ``tpm2_checkquote``.  When ``None``, quote verification is
+            skipped and only the raw PCR measurement is returned.
+    """
+
+    def __init__(self, pcr_policy_path: str | None = None) -> None:
+        self.pcr_policy_path = pcr_policy_path
+        self._check_tpm2_tools()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _check_tpm2_tools(self) -> None:
+        required = ["tpm2_quote"]
+        if self.pcr_policy_path is not None:
+            required.append("tpm2_checkquote")
+        missing = [cmd for cmd in required if shutil.which(cmd) is None]
+        if missing:
+            raise RuntimeError(
+                f"tpm2-tools binaries not found: {missing}. "
+                "Install tpm2-tools to use the TPM2 attestation driver "
+                "(e.g. `apt install tpm2-tools`)."
+            )
+
+    # ------------------------------------------------------------------
+    # AttestationDriver interface
+    # ------------------------------------------------------------------
+
+    def verify(self, target: str) -> AttestationResult:
+        """Run tpm2_quote and optionally tpm2_checkquote for *target*.
+
+        The *target* string is encoded as the qualifying data fed to
+        ``tpm2_quote``, binding the quote to this scheduling target.
+
+        .. note::
+            ``target`` is typically a stable value (e.g. kubeconfig path) and
+            does **not** provide freshness — it cannot prevent quote replay.
+            For replay protection, pass a server-generated per-request nonce
+            as ``target`` and validate it in ``tpm2_checkquote``.
+
+        Each call writes TPM artefacts to an isolated temporary directory that
+        is cleaned up before this method returns, so concurrent calls cannot
+        cross-contaminate each other.
+        """
+        qualifying_data = target.encode("utf-8", errors="replace").hex()
+
+        with tempfile.TemporaryDirectory(prefix="rune-attest-") as workdir:
+            sig_path = f"{workdir}/quote.sig"
+            pcrs_path = f"{workdir}/quote.pcrs"
+            msg_path = f"{workdir}/quote.msg"
+
+            cmd = [
+                "tpm2_quote",
+                "--key-context", "ak.ctx",
+                "--pcr-list", _DEFAULT_PCR_LIST,
+                "--qualifying-data", qualifying_data,
+                "--signature", sig_path,
+                "--pcrs_output", pcrs_path,
+                "--message", msg_path,
+            ]
+
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=_QUOTE_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                return AttestationResult(
+                    passed=False,
+                    pcr_digest=None,
+                    message=f"tpm2_quote timed out after {_QUOTE_TIMEOUT}s for target {target!r}",
+                )
+            except FileNotFoundError:
+                raise RuntimeError(
+                    "tpm2_quote binary disappeared after driver initialisation. "
+                    "Ensure tpm2-tools remains installed throughout the process lifetime."
+                )
+
+            if proc.returncode != 0:
+                return AttestationResult(
+                    passed=False,
+                    pcr_digest=None,
+                    message=f"tpm2_quote failed (rc={proc.returncode}): {proc.stderr.strip()}",
+                )
+
+            pcr_digest = proc.stdout.strip() or None
+
+            if self.pcr_policy_path:
+                check_cmd = [
+                    "tpm2_checkquote",
+                    "--public", "ak.pub",
+                    "--message", msg_path,
+                    "--signature", sig_path,
+                    "--pcrs_input", pcrs_path,
+                    "--pcr-list", _DEFAULT_PCR_LIST,
+                    "--qualification", qualifying_data,
+                    "--policy", self.pcr_policy_path,
+                ]
+                try:
+                    check_proc = subprocess.run(
+                        check_cmd,
+                        capture_output=True,
+                        text=True,
+                        timeout=_QUOTE_TIMEOUT,
+                    )
+                except subprocess.TimeoutExpired:
+                    return AttestationResult(
+                        passed=False,
+                        pcr_digest=pcr_digest,
+                        message=f"tpm2_checkquote timed out after {_QUOTE_TIMEOUT}s",
+                    )
+                except FileNotFoundError:
+                    raise RuntimeError(
+                        "tpm2_checkquote binary disappeared after driver initialisation."
+                    )
+
+                if check_proc.returncode != 0:
+                    return AttestationResult(
+                        passed=False,
+                        pcr_digest=pcr_digest,
+                        message=(
+                            f"tpm2_checkquote policy mismatch (rc={check_proc.returncode}): "
+                            f"{check_proc.stderr.strip()}"
+                        ),
+                    )
+
+        return AttestationResult(
+            passed=True,
+            pcr_digest=pcr_digest,
+            message=f"TPM2 PCR attestation passed for target {target!r}",
+        )

--- a/rune_bench/common/config.py
+++ b/rune_bench/common/config.py
@@ -54,6 +54,12 @@ _FIELD_ENV_MAP: dict[str, str] = {
     "kubeconfig": "RUNE_KUBECONFIG",
 }
 
+# Maps nested attestation section keys → RUNE_ATTESTATION_* env vars.
+_ATTESTATION_ENV_MAP: dict[str, str] = {
+    "driver": "RUNE_ATTESTATION_DRIVER",
+    "pcr_policy_path": "RUNE_ATTESTATION_PCR_POLICY_PATH",
+}
+
 # Search order: project-level (CWD) takes precedence over global user config.
 # Within each tier, .yaml is tried before .yml.
 _PROJECT_CANDIDATES: list[Path] = [Path("rune.yaml"), Path("rune.yml")]
@@ -127,6 +133,25 @@ profiles:
     ollama_url: http://localhost:11434
     ollama_warmup: false
     model: llama3.1:8b
+
+# Attestation settings (TPM 2.0 hardware PCR verification).
+# Can be placed at the top level (infrastructure config) or under
+# defaults/profiles (per-profile overrides take precedence).
+# driver: noop   — always passes; safe for local/dev/CI (default)
+# driver: tpm2   — calls tpm2_quote / tpm2_checkquote via subprocess;
+#                  requires tpm2-tools and a provisioned AK context.
+#
+# Top-level example (applies to all profiles unless overridden):
+# attestation:
+#   driver: noop
+#   pcr_policy_path: /etc/rune/pcr.policy
+#
+# Per-profile example (override in a specific profile):
+# profiles:
+#   production:
+#     attestation:
+#       driver: tpm2
+#       pcr_policy_path: /etc/rune/pcr.policy
 """
 
 
@@ -213,6 +238,18 @@ def load_config(profile: str | None = None) -> dict[str, Any]:
     for key, env_var in _FIELD_ENV_MAP.items():
         if key in effective and env_var not in os.environ:
             os.environ[env_var] = _to_env_str(effective[key])
+
+    # Handle nested attestation section.  The section may appear at the
+    # top level of the YAML (as infrastructure config, separate from per-run
+    # defaults) or under defaults/profiles.  Effective (defaults+profile)
+    # takes precedence; top-level serves as fallback.
+    attestation_cfg: dict[str, Any] = _merge(
+        raw.get("attestation") or {},
+        effective.get("attestation") or {},
+    )
+    for key, env_var in _ATTESTATION_ENV_MAP.items():
+        if key in attestation_cfg and env_var not in os.environ:
+            os.environ[env_var] = _to_env_str(attestation_cfg[key])
 
     return effective
 

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,0 +1,586 @@
+"""Tests for the rune_bench.attestation module.
+
+Covers:
+- AttestationResult dataclass
+- NoOpDriver: always passes, any target
+- TPM2Driver: tool-presence check, verify success/failure/timeout/FileNotFoundError
+- get_driver factory: noop default, tpm2 driver, env-var fallback, unknown name
+- api_contracts: RunBenchmarkRequest.attestation_required field
+- api_backend: _verify_attestation helper and run_benchmark integration
+- config: attestation section injected into env vars
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rune_bench.attestation.factory import get_driver
+from rune_bench.attestation.interface import AttestationDriver, AttestationResult
+from rune_bench.attestation.noop import NoOpDriver
+from rune_bench.attestation.tpm2 import TPM2Driver
+
+
+# ---------------------------------------------------------------------------
+# AttestationResult
+# ---------------------------------------------------------------------------
+
+
+def test_attestation_result_is_frozen():
+    result = AttestationResult(passed=True, pcr_digest="abc", message="ok")
+    with pytest.raises((FrozenInstanceError, AttributeError)):
+        result.passed = False  # type: ignore[misc]
+
+
+def test_attestation_result_fields():
+    r = AttestationResult(passed=False, pcr_digest=None, message="fail")
+    assert r.passed is False
+    assert r.pcr_digest is None
+    assert r.message == "fail"
+
+
+# ---------------------------------------------------------------------------
+# NoOpDriver
+# ---------------------------------------------------------------------------
+
+
+def test_noop_driver_passes_any_target():
+    driver = NoOpDriver()
+    for target in ("", "~/.kube/config", "/path/to/kubeconfig", "some-cluster"):
+        result = driver.verify(target)
+        assert result.passed is True
+        assert result.pcr_digest is None
+        assert "NoOp" in result.message
+
+
+def test_noop_driver_is_attestation_driver_subclass():
+    assert isinstance(NoOpDriver(), AttestationDriver)
+
+
+# ---------------------------------------------------------------------------
+# TPM2Driver — initialisation (tool presence)
+# ---------------------------------------------------------------------------
+
+
+@patch("rune_bench.attestation.tpm2.shutil.which", return_value=None)
+def test_tpm2_driver_raises_when_tools_missing(mock_which):
+    with pytest.raises(RuntimeError, match="tpm2-tools"):
+        TPM2Driver()
+
+
+def test_tpm2_driver_no_policy_only_requires_tpm2_quote():
+    """Driver without pcr_policy_path must NOT require tpm2_checkquote."""
+    with patch(
+        "rune_bench.attestation.tpm2.shutil.which",
+        side_effect=lambda cmd: "/usr/bin/tpm2_quote" if cmd == "tpm2_quote" else None,
+    ):
+        # Should not raise — tpm2_checkquote is absent but not required
+        driver = TPM2Driver(pcr_policy_path=None)
+    assert driver.pcr_policy_path is None
+
+
+def test_tpm2_driver_with_policy_requires_both_tools():
+    """Driver with pcr_policy_path MUST require tpm2_checkquote."""
+    with patch(
+        "rune_bench.attestation.tpm2.shutil.which",
+        side_effect=lambda cmd: "/usr/bin/tpm2_quote" if cmd == "tpm2_quote" else None,
+    ):
+        with pytest.raises(RuntimeError, match="tpm2_checkquote"):
+            TPM2Driver(pcr_policy_path="/etc/pcr.policy")
+
+
+# ---------------------------------------------------------------------------
+# TPM2Driver — verify
+# ---------------------------------------------------------------------------
+
+
+def _make_tpm2_driver(pcr_policy_path: str | None = None) -> TPM2Driver:
+    """Construct a TPM2Driver bypassing the tool-presence check."""
+    with patch("rune_bench.attestation.tpm2.shutil.which", return_value="/usr/bin/tpm2_quote"):
+        return TPM2Driver(pcr_policy_path=pcr_policy_path)
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock(spec=subprocess.CompletedProcess)
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+def test_tpm2_driver_verify_success_no_policy():
+    driver = _make_tpm2_driver()
+    with patch("rune_bench.attestation.tpm2.subprocess.run", return_value=_completed(0, "pcr-digest-hex")) as mock_run:
+        result = driver.verify("~/.kube/config")
+
+    assert result.passed is True
+    assert result.pcr_digest == "pcr-digest-hex"
+    assert "passed" in result.message
+    mock_run.assert_called_once()
+
+
+def test_tpm2_driver_verify_empty_stdout_gives_none_digest():
+    driver = _make_tpm2_driver()
+    with patch("rune_bench.attestation.tpm2.subprocess.run", return_value=_completed(0, "")):
+        result = driver.verify("target")
+
+    assert result.passed is True
+    assert result.pcr_digest is None
+
+
+def test_tpm2_driver_verify_quote_failure():
+    driver = _make_tpm2_driver()
+    with patch("rune_bench.attestation.tpm2.subprocess.run", return_value=_completed(1, "", "ERROR: device not found")):
+        result = driver.verify("target")
+
+    assert result.passed is False
+    assert "tpm2_quote failed" in result.message
+    assert "device not found" in result.message
+
+
+def test_tpm2_driver_verify_quote_timeout():
+    driver = _make_tpm2_driver()
+    with patch("rune_bench.attestation.tpm2.subprocess.run", side_effect=subprocess.TimeoutExpired("tpm2_quote", 30)):
+        result = driver.verify("target")
+
+    assert result.passed is False
+    assert "timed out" in result.message
+
+
+def test_tpm2_driver_verify_quote_file_not_found():
+    driver = _make_tpm2_driver()
+    with patch("rune_bench.attestation.tpm2.subprocess.run", side_effect=FileNotFoundError):
+        with pytest.raises(RuntimeError, match="tpm2_quote binary disappeared"):
+            driver.verify("target")
+
+
+def test_tpm2_driver_verify_success_with_policy():
+    driver = _make_tpm2_driver(pcr_policy_path="/etc/rune/pcr.policy")
+    quote_ok = _completed(0, "abc123")
+    check_ok = _completed(0)
+    with patch("rune_bench.attestation.tpm2.subprocess.run", side_effect=[quote_ok, check_ok]):
+        result = driver.verify("target")
+
+    assert result.passed is True
+    assert result.pcr_digest == "abc123"
+
+
+def test_tpm2_driver_verify_checkquote_failure():
+    driver = _make_tpm2_driver(pcr_policy_path="/etc/rune/pcr.policy")
+    quote_ok = _completed(0, "abc123")
+    check_fail = _completed(2, "", "policy mismatch")
+    with patch("rune_bench.attestation.tpm2.subprocess.run", side_effect=[quote_ok, check_fail]):
+        result = driver.verify("target")
+
+    assert result.passed is False
+    assert "policy mismatch" in result.message
+    assert result.pcr_digest == "abc123"
+
+
+def test_tpm2_driver_verify_checkquote_timeout():
+    driver = _make_tpm2_driver(pcr_policy_path="/etc/rune/pcr.policy")
+    quote_ok = _completed(0, "abc123")
+    with patch(
+        "rune_bench.attestation.tpm2.subprocess.run",
+        side_effect=[quote_ok, subprocess.TimeoutExpired("tpm2_checkquote", 30)],
+    ):
+        result = driver.verify("target")
+
+    assert result.passed is False
+    assert "tpm2_checkquote timed out" in result.message
+
+
+def test_tpm2_driver_verify_checkquote_file_not_found():
+    driver = _make_tpm2_driver(pcr_policy_path="/etc/rune/pcr.policy")
+    quote_ok = _completed(0, "abc123")
+    with patch(
+        "rune_bench.attestation.tpm2.subprocess.run",
+        side_effect=[quote_ok, FileNotFoundError],
+    ):
+        with pytest.raises(RuntimeError, match="tpm2_checkquote binary disappeared"):
+            driver.verify("target")
+
+
+# ---------------------------------------------------------------------------
+# get_driver factory
+# ---------------------------------------------------------------------------
+
+
+def test_get_driver_default_is_noop():
+    driver = get_driver()
+    assert isinstance(driver, NoOpDriver)
+
+
+def test_get_driver_explicit_noop():
+    driver = get_driver({"driver": "noop"})
+    assert isinstance(driver, NoOpDriver)
+
+
+def test_get_driver_tpm2():
+    with patch("rune_bench.attestation.tpm2.shutil.which", return_value="/usr/bin/tpm2_quote"):
+        driver = get_driver({"driver": "tpm2"})
+    assert isinstance(driver, TPM2Driver)
+
+
+def test_get_driver_tpm2_with_pcr_policy():
+    with patch("rune_bench.attestation.tpm2.shutil.which", return_value="/usr/bin/tpm2_quote"):
+        driver = get_driver({"driver": "tpm2", "pcr_policy_path": "/etc/rune/pcr.policy"})
+    assert isinstance(driver, TPM2Driver)
+    assert driver.pcr_policy_path == "/etc/rune/pcr.policy"
+
+
+def test_get_driver_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown attestation driver"):
+        get_driver({"driver": "hsm"})
+
+
+def test_get_driver_reads_env_var(monkeypatch):
+    monkeypatch.setenv("RUNE_ATTESTATION_DRIVER", "noop")
+    driver = get_driver()
+    assert isinstance(driver, NoOpDriver)
+
+
+def test_get_driver_env_var_tpm2(monkeypatch):
+    monkeypatch.setenv("RUNE_ATTESTATION_DRIVER", "tpm2")
+    monkeypatch.delenv("RUNE_ATTESTATION_PCR_POLICY_PATH", raising=False)
+    with patch("rune_bench.attestation.tpm2.shutil.which", return_value="/usr/bin/tpm2_quote"):
+        driver = get_driver()
+    assert isinstance(driver, TPM2Driver)
+    assert driver.pcr_policy_path is None
+
+
+def test_get_driver_pcr_policy_from_env(monkeypatch):
+    monkeypatch.setenv("RUNE_ATTESTATION_DRIVER", "tpm2")
+    monkeypatch.setenv("RUNE_ATTESTATION_PCR_POLICY_PATH", "/env/pcr.policy")
+    with patch("rune_bench.attestation.tpm2.shutil.which", return_value="/usr/bin/tpm2_quote"):
+        driver = get_driver()
+    assert driver.pcr_policy_path == "/env/pcr.policy"
+
+
+def test_get_driver_config_overrides_env(monkeypatch):
+    monkeypatch.setenv("RUNE_ATTESTATION_DRIVER", "tpm2")
+    # explicit config takes precedence over env var
+    driver = get_driver({"driver": "noop"})
+    assert isinstance(driver, NoOpDriver)
+
+
+# ---------------------------------------------------------------------------
+# api_contracts — RunBenchmarkRequest.attestation_required
+# ---------------------------------------------------------------------------
+
+
+def test_run_benchmark_request_attestation_defaults_false():
+    from rune_bench.api_contracts import RunBenchmarkRequest
+
+    req = RunBenchmarkRequest(
+        vastai=False,
+        template_hash="abc",
+        min_dph=1.0,
+        max_dph=2.0,
+        reliability=0.99,
+        ollama_url="http://localhost:11434",
+        question="q",
+        model="llama3.1:8b",
+        ollama_warmup=False,
+        ollama_warmup_timeout=60,
+        kubeconfig="~/.kube/config",
+        vastai_stop_instance=False,
+    )
+    assert req.attestation_required is False
+
+
+def test_run_benchmark_request_attestation_true():
+    from rune_bench.api_contracts import RunBenchmarkRequest
+
+    req = RunBenchmarkRequest(
+        vastai=False,
+        template_hash="abc",
+        min_dph=1.0,
+        max_dph=2.0,
+        reliability=0.99,
+        ollama_url=None,
+        question="q",
+        model="llama3.1:8b",
+        ollama_warmup=False,
+        ollama_warmup_timeout=60,
+        kubeconfig="/k",
+        vastai_stop_instance=False,
+        attestation_required=True,
+    )
+    assert req.attestation_required is True
+
+
+def test_run_benchmark_request_from_cli_attestation_default():
+    from rune_bench.api_contracts import RunBenchmarkRequest
+
+    req = RunBenchmarkRequest.from_cli(
+        vastai=False,
+        template_hash="abc",
+        min_dph=0.0,
+        max_dph=0.0,
+        reliability=0.99,
+        ollama_url=None,
+        question="q",
+        model="m",
+        ollama_warmup=False,
+        ollama_warmup_timeout=60,
+        kubeconfig=Path("/k"),
+        vastai_stop_instance=False,
+    )
+    assert req.attestation_required is False
+
+
+def test_run_benchmark_request_from_cli_attestation_true():
+    from rune_bench.api_contracts import RunBenchmarkRequest
+
+    req = RunBenchmarkRequest.from_cli(
+        vastai=False,
+        template_hash="abc",
+        min_dph=0.0,
+        max_dph=0.0,
+        reliability=0.99,
+        ollama_url=None,
+        question="q",
+        model="m",
+        ollama_warmup=False,
+        ollama_warmup_timeout=60,
+        kubeconfig=Path("/k"),
+        vastai_stop_instance=False,
+        attestation_required=True,
+    )
+    assert req.attestation_required is True
+
+
+def test_run_benchmark_request_to_dict_includes_attestation():
+    from rune_bench.api_contracts import RunBenchmarkRequest
+
+    req = RunBenchmarkRequest(
+        vastai=False,
+        template_hash="x",
+        min_dph=0.0,
+        max_dph=0.0,
+        reliability=0.9,
+        ollama_url=None,
+        question="q",
+        model="m",
+        ollama_warmup=False,
+        ollama_warmup_timeout=60,
+        kubeconfig="/k",
+        vastai_stop_instance=False,
+        attestation_required=True,
+    )
+    d = req.to_dict()
+    assert d["attestation_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# api_backend — _verify_attestation and run_benchmark integration
+# ---------------------------------------------------------------------------
+
+
+def _make_benchmark_request(attestation_required: bool = False):
+    from rune_bench.api_contracts import RunBenchmarkRequest
+
+    return RunBenchmarkRequest(
+        vastai=False,
+        template_hash="x",
+        min_dph=0.0,
+        max_dph=0.0,
+        reliability=0.9,
+        ollama_url="http://localhost:11434",
+        question="q",
+        model="llama3.1:8b",
+        ollama_warmup=False,
+        ollama_warmup_timeout=60,
+        kubeconfig="/k",
+        vastai_stop_instance=False,
+        attestation_required=attestation_required,
+    )
+
+
+def test_verify_attestation_passes_with_noop(monkeypatch):
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+    from rune_bench.api_backend import _verify_attestation
+
+    _verify_attestation("/k")  # should not raise
+
+
+def test_verify_attestation_raises_on_failure(monkeypatch):
+    monkeypatch.setenv("RUNE_ATTESTATION_DRIVER", "noop")
+    failing_result = AttestationResult(passed=False, pcr_digest=None, message="PCR mismatch")
+    with patch("rune_bench.attestation.noop.NoOpDriver.verify", return_value=failing_result):
+        from rune_bench.api_backend import _verify_attestation
+
+        with pytest.raises(RuntimeError, match="Attestation failed"):
+            _verify_attestation("/k")
+
+
+def test_run_benchmark_skips_attestation_when_not_required(monkeypatch):
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+    request = _make_benchmark_request(attestation_required=False)
+
+    mock_provider = MagicMock()
+    mock_provider.provision.return_value = MagicMock(
+        ollama_url="http://localhost:11434",
+        model="llama3.1:8b",
+        provider_handle="cid-123",
+    )
+
+    mock_runner = MagicMock()
+    mock_runner.ask.return_value = "answer"
+
+    with (
+        patch("rune_bench.api_backend._make_resource_provider_for_benchmark", return_value=mock_provider),
+        patch("rune_bench.api_backend._make_agent_runner", return_value=mock_runner),
+        patch("rune_bench.api_backend._verify_attestation") as mock_verify,
+    ):
+        from rune_bench.api_backend import run_benchmark
+
+        result = run_benchmark(request)
+
+    mock_verify.assert_not_called()
+    assert result["answer"] == "answer"
+
+
+def test_run_benchmark_calls_attestation_when_required(monkeypatch):
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+    request = _make_benchmark_request(attestation_required=True)
+
+    mock_provider = MagicMock()
+    mock_provider.provision.return_value = MagicMock(
+        ollama_url="http://localhost:11434",
+        model="llama3.1:8b",
+        provider_handle="cid-456",
+    )
+
+    mock_runner = MagicMock()
+    mock_runner.ask.return_value = "ans"
+
+    with (
+        patch("rune_bench.api_backend._make_resource_provider_for_benchmark", return_value=mock_provider),
+        patch("rune_bench.api_backend._make_agent_runner", return_value=mock_runner),
+        patch("rune_bench.api_backend._verify_attestation") as mock_verify,
+    ):
+        from rune_bench.api_backend import run_benchmark
+
+        result = run_benchmark(request)
+
+    mock_verify.assert_called_once_with("/k")
+    assert result["answer"] == "ans"
+
+
+def test_run_benchmark_aborts_when_attestation_fails(monkeypatch):
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+    request = _make_benchmark_request(attestation_required=True)
+
+    with patch(
+        "rune_bench.api_backend._verify_attestation",
+        side_effect=RuntimeError("Attestation failed"),
+    ):
+        from rune_bench.api_backend import run_benchmark
+
+        with pytest.raises(RuntimeError, match="Attestation failed"):
+            run_benchmark(request)
+
+
+# ---------------------------------------------------------------------------
+# config — attestation section is injected into env vars
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_injects_attestation_driver(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "rune.yaml"
+    cfg_file.write_text(
+        "version: '1'\n"
+        "defaults:\n"
+        "  model: llama3.1:8b\n"
+        "  attestation:\n"
+        "    driver: tpm2\n"
+        "    pcr_policy_path: /etc/rune/pcr.policy\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+    monkeypatch.delenv("RUNE_ATTESTATION_PCR_POLICY_PATH", raising=False)
+
+    import importlib
+    import rune_bench.common.config as config_mod
+    importlib.reload(config_mod)
+
+    effective = config_mod.load_config()
+    assert effective["attestation"]["driver"] == "tpm2"
+    import os
+    assert os.environ.get("RUNE_ATTESTATION_DRIVER") == "tpm2"
+    assert os.environ.get("RUNE_ATTESTATION_PCR_POLICY_PATH") == "/etc/rune/pcr.policy"
+
+
+def test_load_config_injects_top_level_attestation(tmp_path, monkeypatch):
+    """Top-level attestation: section (outside defaults) must be injected."""
+    cfg_file = tmp_path / "rune.yaml"
+    cfg_file.write_text(
+        "version: '1'\n"
+        "defaults:\n"
+        "  model: llama3.1:8b\n"
+        "attestation:\n"
+        "  driver: tpm2\n"
+        "  pcr_policy_path: /top/level/pcr.policy\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+    monkeypatch.delenv("RUNE_ATTESTATION_PCR_POLICY_PATH", raising=False)
+
+    import importlib
+    import rune_bench.common.config as config_mod
+    importlib.reload(config_mod)
+
+    config_mod.load_config()
+    import os
+    assert os.environ.get("RUNE_ATTESTATION_DRIVER") == "tpm2"
+    assert os.environ.get("RUNE_ATTESTATION_PCR_POLICY_PATH") == "/top/level/pcr.policy"
+
+
+def test_load_config_defaults_attestation_overrides_top_level(tmp_path, monkeypatch):
+    """attestation under defaults takes precedence over top-level attestation."""
+    cfg_file = tmp_path / "rune.yaml"
+    cfg_file.write_text(
+        "version: '1'\n"
+        "defaults:\n"
+        "  attestation:\n"
+        "    driver: noop\n"
+        "attestation:\n"
+        "  driver: tpm2\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RUNE_ATTESTATION_DRIVER", raising=False)
+
+    import importlib
+    import rune_bench.common.config as config_mod
+    importlib.reload(config_mod)
+
+    config_mod.load_config()
+    import os
+    assert os.environ.get("RUNE_ATTESTATION_DRIVER") == "noop"
+
+
+def test_load_config_attestation_env_not_overridden_when_set(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "rune.yaml"
+    cfg_file.write_text(
+        "version: '1'\n"
+        "defaults:\n"
+        "  attestation:\n"
+        "    driver: tpm2\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RUNE_ATTESTATION_DRIVER", "noop")  # already set
+
+    import importlib
+    import rune_bench.common.config as config_mod
+    importlib.reload(config_mod)
+
+    config_mod.load_config()
+    import os
+    # existing env var must not be overwritten by YAML
+    assert os.environ.get("RUNE_ATTESTATION_DRIVER") == "noop"


### PR DESCRIPTION
## Summary

Implements #42 — pluggable attestation layer for benchmark job scheduling targets.

## Changes

### New module: `rune_bench/attestation/`
| File | Purpose |
|------|---------|
| `interface.py` | `AttestationDriver` ABC + frozen `AttestationResult` dataclass |
| `noop.py` | NoOp driver — always passes, for local/dev/CI |
| `tpm2.py` | TPM 2.0 driver via `tpm2_quote` / `tpm2_checkquote` subprocesses |
| `factory.py` | `get_driver(config)` — resolves from config dict or `RUNE_ATTESTATION_DRIVER` env var |

### API contract
- `RunBenchmarkRequest` gains `attestation_required: bool = False` (backward-compatible default)

### Workflow integration
- `api_backend.run_benchmark()` calls `_verify_attestation(request.kubeconfig)` when `attestation_required=True`, before any provisioning occurs

### Configuration (`rune.yaml`)
```yaml
attestation:
  driver: noop        # or tpm2
  pcr_policy_path: /etc/rune/pcr.policy   # optional, for tpm2_checkquote
```
Keys are injected into `RUNE_ATTESTATION_DRIVER` / `RUNE_ATTESTATION_PCR_POLICY_PATH`.

## Testing
36 new tests in `tests/test_attestation.py` covering:
- `AttestationResult` immutability
- `NoOpDriver` pass-through behaviour  
- `TPM2Driver` tool-presence guard, subprocess success/failure/timeout/FileNotFoundError paths, policy verification
- `get_driver` factory (all driver names, env-var fallback, config-over-env precedence)
- `RunBenchmarkRequest` field and `from_cli` / `to_dict` round-trip
- `_verify_attestation` and `run_benchmark` integration (gate skipped/called/blocking)
- `load_config` attestation section env injection

Full suite: **306 tests, 97.29% coverage** ✅

Closes #42