### PR TITLE
feat: enterprise stub drivers for 8 agents without public APIs

### DIFF
--- a/rune_bench/drivers/harvey/__init__.py
+++ b/rune_bench/drivers/harvey/__init__.py
@@ -1,0 +1,41 @@
+"""Harvey AI driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class HarveyDriverClient:
+    """Harvey AI legal AI assistant. Requires enterprise API access.
+
+    Configure via environment variables:
+        RUNE_HARVEY_API_KEY    — API key/token
+        RUNE_HARVEY_API_BASE   — Base URL for the Harvey API
+    """
+
+    ONBOARDING_URL = "https://www.harvey.ai/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("harvey")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the Harvey AI driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_HARVEY_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_HARVEY_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"Harvey AI requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_HARVEY_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/harvey/__init__.py
+++ b/rune_bench/drivers/harvey/__init__.py
@@ -29,9 +29,9 @@ class HarveyDriverClient:
         api_key = os.getenv("RUNE_HARVEY_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"Harvey AI requires an enterprise contract or API access. "
+                "Harvey AI requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_HARVEY_API_KEY."
+                "Once provisioned, set RUNE_HARVEY_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/harvey/__main__.py
+++ b/rune_bench/drivers/harvey/__main__.py
@@ -1,0 +1,76 @@
+"""Harvey AI driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_HARVEY_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Harvey AI requires RUNE_HARVEY_API_KEY to be set. "
+            "Visit https://www.harvey.ai/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "Harvey AI driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "harvey",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://www.harvey.ai/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/harvey/__main__.py
+++ b/rune_bench/drivers/harvey/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/krea/__init__.py
+++ b/rune_bench/drivers/krea/__init__.py
@@ -30,9 +30,9 @@ class KreaDriverClient:
         api_key = os.getenv("RUNE_KREA_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"Krea AI requires an enterprise contract or API access. "
+                "Krea AI requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_KREA_API_KEY."
+                "Once provisioned, set RUNE_KREA_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/krea/__init__.py
+++ b/rune_bench/drivers/krea/__init__.py
@@ -1,0 +1,42 @@
+"""Krea AI driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class KreaDriverClient:
+    """Krea AI generative visual AI platform. Requires enterprise API access.
+
+    API access is currently via waitlist.
+
+    Configure via environment variables:
+        RUNE_KREA_API_KEY   — API key/token
+    """
+
+    ONBOARDING_URL = "https://www.krea.ai/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("krea")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the Krea AI driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_KREA_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_KREA_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"Krea AI requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_KREA_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/krea/__main__.py
+++ b/rune_bench/drivers/krea/__main__.py
@@ -1,0 +1,76 @@
+"""Krea AI driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_KREA_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Krea AI requires RUNE_KREA_API_KEY to be set. "
+            "Visit https://www.krea.ai/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "Krea AI driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "krea",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://www.krea.ai/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/krea/__main__.py
+++ b/rune_bench/drivers/krea/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/midjourney/__init__.py
+++ b/rune_bench/drivers/midjourney/__init__.py
@@ -32,9 +32,9 @@ class MidjourneyDriverClient:
         api_key = os.getenv("RUNE_MIDJOURNEY_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"Midjourney requires an enterprise contract or API access. "
+                "Midjourney requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_MIDJOURNEY_API_KEY."
+                "Once provisioned, set RUNE_MIDJOURNEY_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/midjourney/__init__.py
+++ b/rune_bench/drivers/midjourney/__init__.py
@@ -1,0 +1,44 @@
+"""Midjourney driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class MidjourneyDriverClient:
+    """Midjourney image generation. Requires proxy service (no official API).
+
+    There is no official Midjourney API. Access typically requires a proxy
+    service such as useapi.net or similar.
+
+    Configure via environment variables:
+        RUNE_MIDJOURNEY_API_KEY    — API key/token for proxy service
+        RUNE_MIDJOURNEY_API_BASE   — Base URL for the proxy API
+    """
+
+    ONBOARDING_URL = "https://docs.midjourney.com/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("midjourney")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the Midjourney driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_MIDJOURNEY_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_MIDJOURNEY_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"Midjourney requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_MIDJOURNEY_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/midjourney/__main__.py
+++ b/rune_bench/drivers/midjourney/__main__.py
@@ -1,0 +1,76 @@
+"""Midjourney driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_MIDJOURNEY_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Midjourney requires RUNE_MIDJOURNEY_API_KEY to be set. "
+            "Visit https://docs.midjourney.com/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "Midjourney driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "midjourney",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://docs.midjourney.com/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/midjourney/__main__.py
+++ b/rune_bench/drivers/midjourney/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/radiant/__init__.py
+++ b/rune_bench/drivers/radiant/__init__.py
@@ -1,0 +1,41 @@
+"""Radiant Security driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class RadiantDriverClient:
+    """Radiant Security AI SOC analyst. Requires enterprise API access.
+
+    Configure via environment variables:
+        RUNE_RADIANT_API_KEY    — API key/token
+        RUNE_RADIANT_API_BASE   — Base URL for the Radiant API
+    """
+
+    ONBOARDING_URL = "https://radiantsecurity.ai/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("radiant")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the Radiant Security driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_RADIANT_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_RADIANT_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"Radiant Security requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_RADIANT_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/radiant/__init__.py
+++ b/rune_bench/drivers/radiant/__init__.py
@@ -29,9 +29,9 @@ class RadiantDriverClient:
         api_key = os.getenv("RUNE_RADIANT_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"Radiant Security requires an enterprise contract or API access. "
+                "Radiant Security requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_RADIANT_API_KEY."
+                "Once provisioned, set RUNE_RADIANT_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/radiant/__main__.py
+++ b/rune_bench/drivers/radiant/__main__.py
@@ -1,0 +1,76 @@
+"""Radiant Security driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_RADIANT_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Radiant Security requires RUNE_RADIANT_API_KEY to be set. "
+            "Visit https://radiantsecurity.ai/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "Radiant Security driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "radiant",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://radiantsecurity.ai/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/radiant/__main__.py
+++ b/rune_bench/drivers/radiant/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/sierra/__init__.py
+++ b/rune_bench/drivers/sierra/__init__.py
@@ -1,0 +1,40 @@
+"""Sierra driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class SierraDriverClient:
+    """Sierra conversational AI platform. Requires enterprise API access.
+
+    Configure via environment variables:
+        RUNE_SIERRA_API_KEY   — API key/token
+    """
+
+    ONBOARDING_URL = "https://sierra.ai/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("sierra")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the Sierra driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_SIERRA_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_SIERRA_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"Sierra requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_SIERRA_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/sierra/__init__.py
+++ b/rune_bench/drivers/sierra/__init__.py
@@ -28,9 +28,9 @@ class SierraDriverClient:
         api_key = os.getenv("RUNE_SIERRA_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"Sierra requires an enterprise contract or API access. "
+                "Sierra requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_SIERRA_API_KEY."
+                "Once provisioned, set RUNE_SIERRA_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/sierra/__main__.py
+++ b/rune_bench/drivers/sierra/__main__.py
@@ -1,0 +1,76 @@
+"""Sierra driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_SIERRA_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Sierra requires RUNE_SIERRA_API_KEY to be set. "
+            "Visit https://sierra.ai/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "Sierra driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "sierra",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://sierra.ai/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/sierra/__main__.py
+++ b/rune_bench/drivers/sierra/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/skillfortify/__init__.py
+++ b/rune_bench/drivers/skillfortify/__init__.py
@@ -28,9 +28,9 @@ class SkillfortifyDriverClient:
         api_key = os.getenv("RUNE_SKILLFORTIFY_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"SkillFortify requires an enterprise contract or API access. "
+                "SkillFortify requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_SKILLFORTIFY_API_KEY."
+                "Once provisioned, set RUNE_SKILLFORTIFY_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/skillfortify/__init__.py
+++ b/rune_bench/drivers/skillfortify/__init__.py
@@ -1,0 +1,40 @@
+"""SkillFortify driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class SkillfortifyDriverClient:
+    """SkillFortify AI skills assessment platform. Requires enterprise API access.
+
+    Configure via environment variables:
+        RUNE_SKILLFORTIFY_API_KEY   — API key/token
+    """
+
+    ONBOARDING_URL = "https://skillfortify.com/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("skillfortify")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the SkillFortify driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_SKILLFORTIFY_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_SKILLFORTIFY_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"SkillFortify requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_SKILLFORTIFY_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/skillfortify/__main__.py
+++ b/rune_bench/drivers/skillfortify/__main__.py
@@ -1,0 +1,76 @@
+"""SkillFortify driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_SKILLFORTIFY_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "SkillFortify requires RUNE_SKILLFORTIFY_API_KEY to be set. "
+            "Visit https://skillfortify.com/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "SkillFortify driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "skillfortify",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://skillfortify.com/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/skillfortify/__main__.py
+++ b/rune_bench/drivers/skillfortify/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/spellbook/__init__.py
+++ b/rune_bench/drivers/spellbook/__init__.py
@@ -30,9 +30,9 @@ class SpellbookDriverClient:
         api_key = os.getenv("RUNE_SPELLBOOK_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"Spellbook requires an enterprise contract or API access. "
+                "Spellbook requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_SPELLBOOK_API_KEY."
+                "Once provisioned, set RUNE_SPELLBOOK_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/spellbook/__init__.py
+++ b/rune_bench/drivers/spellbook/__init__.py
@@ -1,0 +1,42 @@
+"""Spellbook driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class SpellbookDriverClient:
+    """Spellbook legal AI contract drafting. Requires enterprise API access.
+
+    No public API or enterprise developer docs are currently available.
+
+    Configure via environment variables:
+        RUNE_SPELLBOOK_API_KEY   — API key/token
+    """
+
+    ONBOARDING_URL = "https://www.spellbook.legal/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("spellbook")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the Spellbook driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_SPELLBOOK_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_SPELLBOOK_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"Spellbook requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_SPELLBOOK_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/spellbook/__main__.py
+++ b/rune_bench/drivers/spellbook/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/spellbook/__main__.py
+++ b/rune_bench/drivers/spellbook/__main__.py
@@ -1,0 +1,76 @@
+"""Spellbook driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_SPELLBOOK_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Spellbook requires RUNE_SPELLBOOK_API_KEY to be set. "
+            "Visit https://www.spellbook.legal/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "Spellbook driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "spellbook",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://www.spellbook.legal/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/xbow/__init__.py
+++ b/rune_bench/drivers/xbow/__init__.py
@@ -28,9 +28,9 @@ class XbowDriverClient:
         api_key = os.getenv("RUNE_XBOW_API_KEY")
         if not api_key:
             raise RuntimeError(
-                f"XBOW requires an enterprise contract or API access. "
+                "XBOW requires an enterprise contract or API access. "
                 f"Visit {self.ONBOARDING_URL} to get started. "
-                f"Once provisioned, set RUNE_XBOW_API_KEY."
+                "Once provisioned, set RUNE_XBOW_API_KEY."
             )
         result = self._transport.call("ask", {
             "question": question,

--- a/rune_bench/drivers/xbow/__init__.py
+++ b/rune_bench/drivers/xbow/__init__.py
@@ -1,0 +1,40 @@
+"""XBOW driver client — enterprise stub pending API access."""
+
+from __future__ import annotations
+
+import os
+
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class XbowDriverClient:
+    """XBOW autonomous pentesting agent. Requires enterprise API access.
+
+    Configure via environment variables:
+        RUNE_XBOW_API_KEY   — API key/token
+    """
+
+    ONBOARDING_URL = "https://xbow.com/"
+
+    def __init__(self, *, transport: DriverTransport | None = None) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("xbow")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Send a question to the XBOW driver.
+
+        Raises:
+            RuntimeError: if ``RUNE_XBOW_API_KEY`` is not set.
+        """
+        api_key = os.getenv("RUNE_XBOW_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                f"XBOW requires an enterprise contract or API access. "
+                f"Visit {self.ONBOARDING_URL} to get started. "
+                f"Once provisioned, set RUNE_XBOW_API_KEY."
+            )
+        result = self._transport.call("ask", {
+            "question": question,
+            "model": model,
+            "ollama_url": ollama_url,
+        })
+        return result.get("answer", "")

--- a/rune_bench/drivers/xbow/__main__.py
+++ b/rune_bench/drivers/xbow/__main__.py
@@ -2,7 +2,8 @@
 
 Wire protocol (v1):
     stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
-    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+    stdout success: {"status": "ok", "result": {...}, "id": "UUID"}
+    stdout error:   {"status": "error", "error": "MESSAGE", "id": "UUID"}
 
 Supported actions:
     ask — params: question (str), model (str, optional), ollama_url (str, optional)

--- a/rune_bench/drivers/xbow/__main__.py
+++ b/rune_bench/drivers/xbow/__main__.py
@@ -1,0 +1,76 @@
+"""XBOW driver entry point — enterprise stub.
+
+Wire protocol (v1):
+    stdin:  {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout: {"status": "ok"|"error", "result": {...}, "id": "UUID"}
+
+Supported actions:
+    ask — params: question (str), model (str, optional), ollama_url (str, optional)
+    info — no params
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    api_key = os.getenv("RUNE_XBOW_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "XBOW requires RUNE_XBOW_API_KEY to be set. "
+            "Visit https://xbow.com/ for enterprise API access."
+        )
+    # TODO: Implement actual API call when access is available
+    raise NotImplementedError(
+        "XBOW driver is an enterprise stub. "
+        "API integration will be implemented when access is obtained."
+    )
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "xbow",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "status": "enterprise_stub",
+        "onboarding_url": "https://xbow.com/",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_enterprise_stubs.py
+++ b/tests/test_enterprise_stubs.py
@@ -164,15 +164,82 @@ def test_handle_info_returns_enterprise_stub(
     _STUBS,
     ids=[s[4] for s in _STUBS],
 )
-def test_handle_ask_raises_without_api_key(
+def test_handle_ask_raises_not_implemented_with_key(
     module_path: str,
     class_name: str,
     env_var: str,
     onboarding_url: str,
     driver_name: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``_handle_ask()`` must raise RuntimeError when the API key is missing."""
+    """``_handle_ask()`` must raise NotImplementedError when the API key is present."""
+    monkeypatch.setenv(env_var, "dummy-key")
     main_mod = importlib.import_module(f"{module_path}.__main__")
 
-    with pytest.raises(RuntimeError, match=env_var):
+    with pytest.raises(NotImplementedError, match="enterprise stub"):
         main_mod._handle_ask({"question": "test", "model": "test"})
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, env_var, onboarding_url, driver_name",
+    _STUBS,
+    ids=[s[4] for s in _STUBS],
+)
+def test_main_loop_success(
+    module_path: str,
+    class_name: str,
+    env_var: str,
+    onboarding_url: str,
+    driver_name: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main()`` must process JSON requests from stdin and write to stdout."""
+    import json
+    import io
+
+    main_mod = importlib.import_module(f"{module_path}.__main__")
+    
+    # Test 'info' action
+    input_data = json.dumps({"action": "info", "id": "123"}) + "\n"
+    monkeypatch.setattr("sys.stdin", io.StringIO(input_data))
+    
+    main_mod.main()
+    
+    out, _ = capsys.readouterr()
+    resp = json.loads(out.strip())
+    assert resp["status"] == "ok"
+    assert resp["id"] == "123"
+    assert resp["result"]["name"] == driver_name
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, env_var, onboarding_url, driver_name",
+    _STUBS,
+    ids=[s[4] for s in _STUBS],
+)
+def test_main_loop_unknown_action(
+    module_path: str,
+    class_name: str,
+    env_var: str,
+    onboarding_url: str,
+    driver_name: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main()`` must handle unknown actions by returning an error JSON."""
+    import json
+    import io
+
+    main_mod = importlib.import_module(f"{module_path}.__main__")
+    
+    input_data = json.dumps({"action": "invalid", "id": "456"}) + "\n"
+    monkeypatch.setattr("sys.stdin", io.StringIO(input_data))
+    
+    main_mod.main()
+    
+    out, _ = capsys.readouterr()
+    resp = json.loads(out.strip())
+    assert resp["status"] == "error"
+    assert resp["id"] == "456"
+    assert "Unknown action" in resp["error"]

--- a/tests/test_enterprise_stubs.py
+++ b/tests/test_enterprise_stubs.py
@@ -1,0 +1,178 @@
+"""Tests for enterprise stub drivers.
+
+Each stub must:
+1. Raise RuntimeError with the onboarding URL when the API key env var is unset.
+2. Return correct metadata from ``_handle_info()`` with ``"status": "enterprise_stub"``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Driver specs: (module_path, client_class, env_var, onboarding_url, driver_name)
+# ---------------------------------------------------------------------------
+_STUBS = [
+    (
+        "rune_bench.drivers.radiant",
+        "RadiantDriverClient",
+        "RUNE_RADIANT_API_KEY",
+        "https://radiantsecurity.ai/",
+        "radiant",
+    ),
+    (
+        "rune_bench.drivers.xbow",
+        "XbowDriverClient",
+        "RUNE_XBOW_API_KEY",
+        "https://xbow.com/",
+        "xbow",
+    ),
+    (
+        "rune_bench.drivers.harvey",
+        "HarveyDriverClient",
+        "RUNE_HARVEY_API_KEY",
+        "https://www.harvey.ai/",
+        "harvey",
+    ),
+    (
+        "rune_bench.drivers.spellbook",
+        "SpellbookDriverClient",
+        "RUNE_SPELLBOOK_API_KEY",
+        "https://www.spellbook.legal/",
+        "spellbook",
+    ),
+    (
+        "rune_bench.drivers.sierra",
+        "SierraDriverClient",
+        "RUNE_SIERRA_API_KEY",
+        "https://sierra.ai/",
+        "sierra",
+    ),
+    (
+        "rune_bench.drivers.skillfortify",
+        "SkillfortifyDriverClient",
+        "RUNE_SKILLFORTIFY_API_KEY",
+        "https://skillfortify.com/",
+        "skillfortify",
+    ),
+    (
+        "rune_bench.drivers.krea",
+        "KreaDriverClient",
+        "RUNE_KREA_API_KEY",
+        "https://www.krea.ai/",
+        "krea",
+    ),
+    (
+        "rune_bench.drivers.midjourney",
+        "MidjourneyDriverClient",
+        "RUNE_MIDJOURNEY_API_KEY",
+        "https://docs.midjourney.com/",
+        "midjourney",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure none of the enterprise API key env vars are set."""
+    for _, _, env_var, _, _ in _STUBS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Client-level tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, env_var, onboarding_url, driver_name",
+    _STUBS,
+    ids=[s[4] for s in _STUBS],
+)
+def test_ask_raises_without_api_key(
+    module_path: str,
+    class_name: str,
+    env_var: str,
+    onboarding_url: str,
+    driver_name: str,
+) -> None:
+    """``ask()`` must raise RuntimeError when the API key env var is missing."""
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name)
+    client = cls(transport=MagicMock())
+
+    with pytest.raises(RuntimeError, match=env_var):
+        client.ask("test question", "test-model")
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, env_var, onboarding_url, driver_name",
+    _STUBS,
+    ids=[s[4] for s in _STUBS],
+)
+def test_ask_error_contains_onboarding_url(
+    module_path: str,
+    class_name: str,
+    env_var: str,
+    onboarding_url: str,
+    driver_name: str,
+) -> None:
+    """The RuntimeError message must contain the onboarding URL."""
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name)
+    client = cls(transport=MagicMock())
+
+    with pytest.raises(RuntimeError, match=onboarding_url.replace(".", r"\.")):
+        client.ask("test question", "test-model")
+
+
+# ---------------------------------------------------------------------------
+# __main__ handler-level tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, env_var, onboarding_url, driver_name",
+    _STUBS,
+    ids=[s[4] for s in _STUBS],
+)
+def test_handle_info_returns_enterprise_stub(
+    module_path: str,
+    class_name: str,
+    env_var: str,
+    onboarding_url: str,
+    driver_name: str,
+) -> None:
+    """``_handle_info()`` must return ``status: enterprise_stub`` and correct metadata."""
+    main_mod = importlib.import_module(f"{module_path}.__main__")
+    info = main_mod._handle_info({})
+
+    assert info["name"] == driver_name
+    assert info["version"] == "1"
+    assert info["status"] == "enterprise_stub"
+    assert info["onboarding_url"] == onboarding_url
+    assert "ask" in info["actions"]
+    assert "info" in info["actions"]
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, env_var, onboarding_url, driver_name",
+    _STUBS,
+    ids=[s[4] for s in _STUBS],
+)
+def test_handle_ask_raises_without_api_key(
+    module_path: str,
+    class_name: str,
+    env_var: str,
+    onboarding_url: str,
+    driver_name: str,
+) -> None:
+    """``_handle_ask()`` must raise RuntimeError when the API key is missing."""
+    main_mod = importlib.import_module(f"{module_path}.__main__")
+
+    with pytest.raises(RuntimeError, match=env_var):
+        main_mod._handle_ask({"question": "test", "model": "test"})


### PR DESCRIPTION
## Summary

- Add enterprise stub drivers for **Radiant Security** (#70), **XBOW** (#73), **Harvey AI** (#74), **Spellbook** (#75), **Sierra** (#79), **SkillFortify** (#80), **Midjourney** (#81), and **Krea AI** (#83)
- Each driver follows the Holmes driver pattern with a client class (`__init__.py`) and wire-protocol entry point (`__main__.py`)
- When the required API key env var is unset, `ask()` raises a `RuntimeError` with a clear message pointing to the vendor onboarding URL
- Includes 32 parametrized tests covering all 8 stubs (API key guard, onboarding URL in error, `_handle_info` metadata)

## Test plan

- [x] `python -m pytest tests/test_enterprise_stubs.py -v` — 32/32 passed
- [ ] Verify each driver can be loaded via `python -m rune_bench.drivers.<name>` without import errors
- [ ] Confirm error messages are actionable for users without API keys

Refs #70, #73, #74, #75, #79, #80, #81, #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)