### PR TITLE
feat(drivers): implement K8sGPT SRE agent driver

### DIFF
--- a/devops_agent.py
+++ b/devops_agent.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 import time
 from openai import OpenAI

--- a/rune_bench/agents/sre/k8sgpt.py
+++ b/rune_bench/agents/sre/k8sgpt.py
@@ -1,40 +1,14 @@
-"""K8sGPT agentic runner stub.
+"""K8sGPT agentic runner — delegates to the K8sGPT driver.
 
 Scope:      SRE  |  Rank 1  |  Rating 5.0
 Capability: Scans clusters for issues and provides automated RCA.
 Docs:       https://github.com/k8sgpt-ai/k8sgpt
 Ecosystem:  CNCF Sandbox
-
-Implementation notes:
-- Install:  pip install k8sgpt  OR use the k8sgpt CLI binary
-- Auth:     kubeconfig for cluster access; optional AI backend API key
-- SDK:      https://github.com/k8sgpt-ai/k8sgpt#python-sdk (if available)
-            Alternatively invoke CLI: k8sgpt analyze --explain --backend ollama
-- Key CLI flags:
-    k8sgpt analyze --explain           # scan all namespaces, explain with LLM
-    k8sgpt analyze --filter <kind>     # scope to specific resource kind
-    k8sgpt analyze --backend ollama --model <model> --base-url <ollama_url>
-- Returns structured JSON results; extract .results[].error + .results[].details
 """
 
-from pathlib import Path
+from rune_bench.drivers.k8sgpt import K8sGPTDriverClient
 
+# Backwards-compatible alias so existing imports of K8sGPTRunner keep working.
+K8sGPTRunner = K8sGPTDriverClient
 
-class K8sGPTRunner:
-    """SRE agent: scans a Kubernetes cluster and returns AI-powered RCA.
-
-    Uses k8sgpt CLI with the Ollama backend so the same model/ollama_url
-    parameters from the RUNE benchmark flow are forwarded transparently.
-    """
-
-    def __init__(self, kubeconfig: Path) -> None:
-        if not kubeconfig.exists():
-            raise FileNotFoundError(f"kubeconfig not found: {kubeconfig}")
-        self._kubeconfig = kubeconfig
-
-    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
-        """Run a k8sgpt analysis and return the explanation as a string."""
-        raise NotImplementedError(
-            "K8sGPTRunner is not yet implemented. "
-            "See https://github.com/k8sgpt-ai/k8sgpt for SDK/CLI details."
-        )
+__all__ = ["K8sGPTRunner", "K8sGPTDriverClient"]

--- a/rune_bench/drivers/k8sgpt/__init__.py
+++ b/rune_bench/drivers/k8sgpt/__init__.py
@@ -1,0 +1,75 @@
+"""K8sGPT driver client — delegates k8sgpt analysis queries to the k8sgpt driver process.
+
+The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`
+(stdio subprocess by default, HTTP server in production).  The driver itself
+(``rune_bench.drivers.k8sgpt.__main__``) calls ``k8sgpt analyze`` and therefore
+only requires the k8sgpt binary to be installed in the *subprocess* environment
+— not in the rune core process.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class K8sGPTDriverClient:
+    """Scan a Kubernetes cluster for issues by delegating to the k8sgpt driver process.
+
+    The public interface mirrors :class:`~rune_bench.drivers.holmes.HolmesDriverClient`
+    so that SRE agent call-sites can use either backend interchangeably.
+    """
+
+    def __init__(
+        self,
+        kubeconfig: Path,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        if not kubeconfig.exists():
+            raise FileNotFoundError(f"kubeconfig not found: {kubeconfig}")
+        self._kubeconfig = kubeconfig
+        self._transport: DriverTransport = transport or make_driver_transport("k8sgpt")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Dispatch an analysis request to the k8sgpt driver and return the answer.
+
+        Args:
+            question: Natural-language question or resource-kind hint
+                      (e.g. ``"Pod"``, ``"Service"``, ``"Why is my pod failing?"``).
+            model: Ollama model identifier (e.g. ``"llama3.1:8b"``).
+            ollama_url: Base URL of the Ollama server (optional).
+
+        Returns:
+            K8sGPT's textual analysis or ``"No issues detected"`` when the
+            cluster is healthy.
+        """
+        resolved_model = model.strip()
+        params: dict = {
+            "question": question,
+            "model": resolved_model,
+            "kubeconfig_path": str(self._kubeconfig),
+        }
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"K8sGPTDriverClient.ask: question={question!r} model={resolved_model!r} "
+            f"ollama_url={ollama_url or '<none>'}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("K8sGPT driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("K8sGPT driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("K8sGPT driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/k8sgpt/__main__.py
+++ b/rune_bench/drivers/k8sgpt/__main__.py
@@ -35,7 +35,12 @@ def _format_findings(results: list[dict]) -> str:
     for i, item in enumerate(results, 1):
         kind = item.get("kind", "Unknown")
         name = item.get("name", "unknown")
-        errors = item.get("error", [])
+        errors_raw = item.get("error", [])
+        # Normalize: k8sgpt may emit error as a str, a list[dict], or a list[str]
+        if isinstance(errors_raw, (str, dict)):
+            errors = [errors_raw]
+        else:
+            errors = list(errors_raw)
         details = item.get("details", "")
         parent = item.get("parent_object", "")
 

--- a/rune_bench/drivers/k8sgpt/__main__.py
+++ b/rune_bench/drivers/k8sgpt/__main__.py
@@ -29,6 +29,14 @@ import subprocess
 import sys
 
 
+_K8S_KINDS: frozenset[str] = frozenset({
+    "pod", "service", "deployment", "replicaset", "statefulset",
+    "daemonset", "job", "cronjob", "ingress", "node",
+    "persistentvolumeclaim", "pvc", "configmap", "secret",
+    "networkpolicy", "hpa", "horizontalpodautoscaler",
+})
+
+
 def _format_findings(results: list[dict]) -> str:
     """Turn a list of k8sgpt result objects into a human-readable string."""
     lines: list[str] = []
@@ -84,14 +92,8 @@ def _handle_ask(params: dict) -> dict:
         cmd.extend(["--base-url", ollama_url])
 
     # Use the question as a resource-kind filter if it looks like a K8s kind
-    _k8s_kinds = {
-        "pod", "service", "deployment", "replicaset", "statefulset",
-        "daemonset", "job", "cronjob", "ingress", "node",
-        "persistentvolumeclaim", "pvc", "configmap", "secret",
-        "networkpolicy", "hpa", "horizontalpodautoscaler",
-    }
     hint = question.strip().lower()
-    if hint in _k8s_kinds:
+    if hint in _K8S_KINDS:
         cmd.extend(["--filter", question.strip()])
 
     env = os.environ.copy()

--- a/rune_bench/drivers/k8sgpt/__main__.py
+++ b/rune_bench/drivers/k8sgpt/__main__.py
@@ -1,0 +1,159 @@
+"""K8sGPT driver entry point — receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.k8sgpt
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str), kubeconfig_path (str),
+            ollama_url (str, optional)
+    result: {"answer": str, "findings": list}
+
+info
+    params: (none)
+    result: {"name": "k8sgpt", "version": "1", "actions": [...]}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _format_findings(results: list[dict]) -> str:
+    """Turn a list of k8sgpt result objects into a human-readable string."""
+    lines: list[str] = []
+    for i, item in enumerate(results, 1):
+        kind = item.get("kind", "Unknown")
+        name = item.get("name", "unknown")
+        errors = item.get("error", [])
+        details = item.get("details", "")
+        parent = item.get("parent_object", "")
+
+        lines.append(f"--- Finding {i}: {kind}/{name} ---")
+        if parent:
+            lines.append(f"  Parent: {parent}")
+        if errors:
+            for err in errors:
+                err_text = err.get("text", str(err)) if isinstance(err, dict) else str(err)
+                lines.append(f"  Error: {err_text}")
+        if details:
+            lines.append(f"  Details: {details}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def _handle_ask(params: dict) -> dict:
+    question: str = params["question"]
+    model: str = params["model"]
+    kubeconfig_path: str = params["kubeconfig_path"]
+    ollama_url: str | None = params.get("ollama_url")
+
+    if shutil.which("k8sgpt") is None:
+        raise RuntimeError(
+            "k8sgpt binary not found in PATH. "
+            "Install it from https://github.com/k8sgpt-ai/k8sgpt"
+        )
+
+    cmd: list[str] = [
+        "k8sgpt",
+        "analyze",
+        "--explain",
+        "--output",
+        "json",
+        "--backend",
+        "ollama",
+        "--model",
+        model,
+    ]
+    if ollama_url:
+        cmd.extend(["--base-url", ollama_url])
+
+    # Use the question as a resource-kind filter if it looks like a K8s kind
+    _k8s_kinds = {
+        "pod", "service", "deployment", "replicaset", "statefulset",
+        "daemonset", "job", "cronjob", "ingress", "node",
+        "persistentvolumeclaim", "pvc", "configmap", "secret",
+        "networkpolicy", "hpa", "horizontalpodautoscaler",
+    }
+    hint = question.strip().lower()
+    if hint in _k8s_kinds:
+        cmd.extend(["--filter", question.strip()])
+
+    env = os.environ.copy()
+    env["KUBECONFIG"] = kubeconfig_path
+
+    proc = subprocess.run(  # noqa: S603
+        cmd, env=env, capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        raise RuntimeError(f"k8sgpt CLI failed: {detail}")
+
+    # Parse output
+    stdout = proc.stdout.strip()
+    if not stdout:
+        return {"answer": "No issues detected", "findings": []}
+
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse k8sgpt JSON output: {exc}") from exc
+
+    results = data.get("results") or []
+    if not results:
+        return {"answer": "No issues detected", "findings": []}
+
+    answer = _format_findings(results)
+    return {"answer": answer, "findings": results}
+
+
+def _handle_info(_params: dict) -> dict:
+    return {"name": "k8sgpt", "version": "1", "actions": ["ask", "info"]}
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_catalog_loader.py
+++ b/tests/test_catalog_loader.py
@@ -8,14 +8,11 @@ from pathlib import Path
 import pytest
 
 from rune_bench.catalog import (
-    Catalog,
     ChainSpec,
-    ScopeSpec,
     load_catalog,
     load_from_csv,
     merge_chains,
 )
-from rune_bench.catalog.loader import _DEFAULTS_DIR
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_comprehensive_error_paths.py
+++ b/tests/test_comprehensive_error_paths.py
@@ -1,5 +1,3 @@
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock
 from urllib.request import Request, urlopen
 
@@ -11,7 +9,6 @@ import rune_bench.api_server as api_server
 import rune_bench.workflows as workflows
 from rune_bench.agents.sre.holmes import HolmesRunner
 from rune_bench.api_client import RuneApiClient
-from rune_bench.backends.ollama import OllamaClient
 from rune_bench.resources.vastai import InstanceManager
 from rune_bench.resources.vastai import OfferFinder
 from rune_bench.resources.vastai import TemplateLoader

--- a/tests/test_cost_estimation.py
+++ b/tests/test_cost_estimation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 
 import pytest
 import typer
@@ -262,7 +261,6 @@ def test_bedrock_backend_requires_region():
 def test_vastai_provider_provision_and_teardown(monkeypatch):
     from unittest.mock import MagicMock
     from rune_bench.resources.vastai.provider import VastAIProvider
-    from rune_bench.resources.base import ProvisioningResult
 
     fake_provision_result = MagicMock()
     fake_provision_result.ollama_url = "http://host:11434"

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -11,7 +11,6 @@ from urllib.request import Request, urlopen
 import rune
 import rune.api as rune_api_module
 import rune_bench.api_backend as api_backend
-import rune_bench.api_client as api_client_module
 import rune_bench.api_server as api_server
 import rune_bench.backends.ollama as ollama_models_module
 import rune_bench.workflows as workflows

--- a/tests/test_enterprise_stubs.py
+++ b/tests/test_enterprise_stubs.py
@@ -8,7 +8,6 @@ Each stub must:
 from __future__ import annotations
 
 import importlib
-import os
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_k8sgpt_driver.py
+++ b/tests/test_k8sgpt_driver.py
@@ -1,0 +1,318 @@
+"""Tests for rune_bench.drivers.k8sgpt — the driver entry point and client.
+
+The driver process calls ``k8sgpt analyze`` as a subprocess.
+subprocess.run and shutil.which are monkeypatched throughout so no k8sgpt
+installation is required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import rune_bench.drivers.k8sgpt.__main__ as k8sgpt_main
+from rune_bench.agents.sre.k8sgpt import K8sGPTRunner
+from rune_bench.drivers.k8sgpt import K8sGPTDriverClient
+
+
+# ---------------------------------------------------------------------------
+# Sample k8sgpt output
+# ---------------------------------------------------------------------------
+
+_SAMPLE_RESULTS = {
+    "results": [
+        {
+            "kind": "Pod",
+            "name": "default/nginx-broken",
+            "error": [{"text": "Back-off pulling image"}],
+            "details": "The image 'nginx:nonexistent' cannot be found.",
+            "parent_object": "Deployment/nginx",
+        },
+        {
+            "kind": "Service",
+            "name": "default/my-svc",
+            "error": [{"text": "No endpoints"}],
+            "details": "Service has no matching pods.",
+            "parent_object": "",
+        },
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_calls_k8sgpt_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(cmd: list, env: dict, capture_output: bool, text: bool, check: bool) -> subprocess.CompletedProcess:
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(_SAMPLE_RESULTS), stderr="")
+
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: "/usr/bin/k8sgpt")
+    monkeypatch.setattr(k8sgpt_main.subprocess, "run", fake_run)
+
+    result = k8sgpt_main._handle_ask({
+        "question": "What is wrong?",
+        "model": "llama3.1:8b",
+        "kubeconfig_path": "/tmp/kubeconfig",
+        "ollama_url": "http://ollama:11434",
+    })
+
+    assert "answer" in result
+    assert "findings" in result
+    assert len(result["findings"]) == 2
+    assert "nginx-broken" in result["answer"]
+    assert "k8sgpt" in captured["cmd"]
+    assert captured["env"]["KUBECONFIG"] == "/tmp/kubeconfig"
+    assert "--base-url" in captured["cmd"]
+    assert "http://ollama:11434" in captured["cmd"]
+
+
+def test_handle_ask_without_ollama_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(cmd: list, **kw) -> subprocess.CompletedProcess:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(_SAMPLE_RESULTS), stderr="")
+
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: "/usr/bin/k8sgpt")
+    monkeypatch.setattr(k8sgpt_main.subprocess, "run", fake_run)
+
+    result = k8sgpt_main._handle_ask({
+        "question": "q",
+        "model": "m",
+        "kubeconfig_path": "/tmp/kc",
+    })
+    assert result["answer"]
+    assert "--base-url" not in captured["cmd"]
+
+
+def test_handle_ask_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="k8sgpt binary not found"):
+        k8sgpt_main._handle_ask({
+            "question": "q",
+            "model": "m",
+            "kubeconfig_path": "/tmp/kc",
+        })
+
+
+def test_handle_ask_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: "/usr/bin/k8sgpt")
+    monkeypatch.setattr(
+        k8sgpt_main.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0, stdout=json.dumps({"results": None}), stderr=""),
+    )
+
+    result = k8sgpt_main._handle_ask({
+        "question": "q",
+        "model": "m",
+        "kubeconfig_path": "/tmp/kc",
+    })
+    assert result["answer"] == "No issues detected"
+    assert result["findings"] == []
+
+
+def test_handle_ask_empty_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: "/usr/bin/k8sgpt")
+    monkeypatch.setattr(
+        k8sgpt_main.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+    )
+
+    result = k8sgpt_main._handle_ask({
+        "question": "q",
+        "model": "m",
+        "kubeconfig_path": "/tmp/kc",
+    })
+    assert result["answer"] == "No issues detected"
+
+
+def test_handle_ask_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: "/usr/bin/k8sgpt")
+    monkeypatch.setattr(
+        k8sgpt_main.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 1, stdout="", stderr="k8sgpt error"),
+    )
+
+    with pytest.raises(RuntimeError, match="k8sgpt error"):
+        k8sgpt_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})
+
+
+def test_handle_ask_resource_kind_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(cmd: list, **kw) -> subprocess.CompletedProcess:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps({"results": []}), stderr="")
+
+    monkeypatch.setattr(k8sgpt_main.shutil, "which", lambda _: "/usr/bin/k8sgpt")
+    monkeypatch.setattr(k8sgpt_main.subprocess, "run", fake_run)
+
+    k8sgpt_main._handle_ask({
+        "question": "Pod",
+        "model": "m",
+        "kubeconfig_path": "/tmp/kc",
+    })
+    assert "--filter" in captured["cmd"]
+    assert "Pod" in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# _format_findings
+# ---------------------------------------------------------------------------
+
+
+def test_format_findings_produces_readable_output() -> None:
+    results = _SAMPLE_RESULTS["results"]
+    formatted = k8sgpt_main._format_findings(results)
+
+    assert "Finding 1" in formatted
+    assert "Pod/default/nginx-broken" in formatted
+    assert "Back-off pulling image" in formatted
+    assert "Parent: Deployment/nginx" in formatted
+    assert "Finding 2" in formatted
+    assert "Service/default/my-svc" in formatted
+
+
+def test_format_findings_empty_list() -> None:
+    assert k8sgpt_main._format_findings([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = k8sgpt_main._handle_info({})
+    assert result["name"] == "k8sgpt"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(k8sgpt_main, "_handle_ask", lambda p: {"answer": "great answer", "findings": []})
+    monkeypatch.setattr(
+        k8sgpt_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    k8sgpt_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "great answer"
+    assert response["id"] == "test-id"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        k8sgpt_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    k8sgpt_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# K8sGPTDriverClient
+# ---------------------------------------------------------------------------
+
+
+def test_client_init_requires_existing_kubeconfig(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-kubeconfig"
+    with pytest.raises(FileNotFoundError):
+        K8sGPTDriverClient(missing)
+
+
+def test_client_ask_calls_transport(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "the answer", "findings": []}
+
+    client = K8sGPTDriverClient(kubeconfig, transport=mock_transport)
+    answer = client.ask("What is wrong?", "llama3.1:8b", ollama_url="http://ollama:11434")
+
+    assert answer == "the answer"
+    mock_transport.call.assert_called_once()
+    action, params = mock_transport.call.call_args[0]
+    assert action == "ask"
+    assert params["question"] == "What is wrong?"
+    assert params["model"] == "llama3.1:8b"
+    assert params["kubeconfig_path"] == str(kubeconfig)
+    assert params["ollama_url"] == "http://ollama:11434"
+
+
+def test_client_ask_strips_model_whitespace(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "ok"}
+
+    client = K8sGPTDriverClient(kubeconfig, transport=mock_transport)
+    client.ask("q", "  llama3.1:8b  ")
+
+    _, params = mock_transport.call.call_args[0]
+    assert params["model"] == "llama3.1:8b"
+
+
+def test_client_ask_raises_on_missing_answer(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"findings": []}
+
+    client = K8sGPTDriverClient(kubeconfig, transport=mock_transport)
+    with pytest.raises(RuntimeError, match="did not include an answer"):
+        client.ask("q", "m")
+
+
+def test_client_ask_raises_on_none_answer(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": None}
+
+    client = K8sGPTDriverClient(kubeconfig, transport=mock_transport)
+    with pytest.raises(RuntimeError, match="empty answer"):
+        client.ask("q", "m")
+
+
+def test_runner_alias() -> None:
+    assert K8sGPTRunner is K8sGPTDriverClient

--- a/tests/test_k8sgpt_driver.py
+++ b/tests/test_k8sgpt_driver.py
@@ -316,3 +316,22 @@ def test_client_ask_raises_on_none_answer(tmp_path: Path) -> None:
 
 def test_runner_alias() -> None:
     assert K8sGPTRunner is K8sGPTDriverClient
+
+
+def test_format_findings_with_string_error() -> None:
+    """_format_findings must not iterate character-by-character when error is a string."""
+    results = {
+        "results": [
+            {
+                "kind": "Pod",
+                "name": "default/broken",
+                "error": "Back-off pulling image",
+                "details": "",
+                "parent_object": "",
+            }
+        ]
+    }
+    output = k8sgpt_main._format_findings(results["results"])
+    assert "Back-off pulling image" in output
+    # If iterated char-by-char the result would have "B", "a", "c", ... on separate lines
+    assert "Error: B\n" not in output

--- a/tests/test_ollama_model_manager.py
+++ b/tests/test_ollama_model_manager.py
@@ -5,9 +5,8 @@ import pytest
 
 import rune_bench.api_backend as api_backend
 import rune_bench.workflows as workflows
-from rune_bench.common import make_http_request
 from rune_bench.common.models import ModelSelector
-from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities
+from rune_bench.backends.ollama import OllamaClient
 from rune_bench.backends.ollama import OllamaModelManager
 
 

--- a/tests/test_perplexity_driver.py
+++ b/tests/test_perplexity_driver.py
@@ -1,8 +1,7 @@
 """Tests for rune_bench.drivers.perplexity — driver entry point and client.
 
-The driver subprocess calls the Perplexity REST API via urllib.request.
-urllib.request.urlopen is monkeypatched throughout so no real API calls
-are made.
+The driver subprocess calls the Perplexity REST API via make_http_request.
+make_http_request is monkeypatched throughout so no real API calls are made.
 """
 
 from __future__ import annotations
@@ -13,36 +12,6 @@ import json
 import pytest
 
 import rune_bench.drivers.perplexity.__main__ as perplexity_main
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_api_response(answer: str = "the answer", citations: list | None = None) -> bytes:
-    """Build a fake Perplexity API JSON response body."""
-    body: dict = {
-        "choices": [{"message": {"content": answer}}],
-    }
-    if citations is not None:
-        body["citations"] = citations
-    return json.dumps(body).encode()
-
-
-class _FakeHTTPResponse:
-    """Minimal context-manager wrapping bytes so urlopen can be mocked."""
-
-    def __init__(self, data: bytes) -> None:
-        self._data = data
-
-    def read(self) -> bytes:
-        return self._data
-
-    def __enter__(self):  # noqa: ANN204
-        return self
-
-    def __exit__(self, *_: object) -> None:
-        pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -64,7 +64,6 @@ def test_preflight_http_backend_requires_client():
 
 def test_preflight_raises_fail_closed_error():
     """FailClosedError propagates when no cost driver is configured in CostEstimator."""
-    from rune_bench.api_contracts import CostEstimationRequest
 
     # Patch CostEstimator.estimate to raise FailClosedError
     with patch("rune_bench.common.costs.CostEstimator.estimate", side_effect=FailClosedError("no driver")):

--- a/tests/test_rune_cli_integration.py
+++ b/tests/test_rune_cli_integration.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_vastai_instance_manager.py
+++ b/tests/test_vastai_instance_manager.py
@@ -1,6 +1,5 @@
 import json
 import threading
-from pathlib import Path
 from unittest.mock import MagicMock
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen


### PR DESCRIPTION
## Summary
- Implements the K8sGPT driver following the Holmes driver pattern (closes #60)
- `K8sGPTDriverClient` delegates analysis to a subprocess driver via the standard transport layer
- Driver subprocess invokes `k8sgpt analyze --explain --output json --backend ollama` CLI, parses JSON output, and formats findings into readable text
- Updates the `K8sGPTRunner` stub to alias `K8sGPTDriverClient` for backwards compatibility
- Handles edge cases: missing binary, empty/null results, resource-kind filtering via question hint

## Test plan
- [x] 18 unit tests in `tests/test_k8sgpt_driver.py` -- all passing
- [ ] Verify `_handle_ask` with mocked subprocess output
- [ ] Verify missing k8sgpt binary produces clear error
- [ ] Verify empty results return "No issues detected"
- [ ] Verify findings formatting with multi-result output
- [ ] Verify `K8sGPTDriverClient` with mocked transport
- [ ] Verify kubeconfig validation rejects missing paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)