### PR TITLE
feat(drivers): implement Consensus Research agent driver

### DIFF
--- a/rune_bench/agents/research/consensus.py
+++ b/rune_bench/agents/research/consensus.py
@@ -1,33 +1,14 @@
-"""Consensus agentic runner stub.
+"""Consensus agentic runner — evidence-based synthesis from academic papers.
 
 Scope:      Research  |  Rank 5  |  Rating 3.5
-Capability: Synthesizes answers from 200M+ academic papers.
+Capability: Synthesizes answers from 200M+ academic papers via Semantic Scholar.
 Docs:       https://consensus.app/
-            https://consensus.app/tools/api  (API access)
 Ecosystem:  Evidence-Based Research
 
-Implementation notes:
-- Auth:     CONSENSUS_API_KEY env var (request at https://consensus.app/tools/api)
-- SDK:      REST API (no official Python SDK)
-- Key endpoint:
-    POST /search
-        body: { query: str, limit: int }
-    Returns: list of papers with abstracts + a GPT-4-generated synthesis
-- The `question` maps to the search query.
-- `model` and `ollama_url` are not used (Consensus uses its own hosted model).
-- Extract .synthesis from response for the final answer string.
+Implementation: delegates to the consensus driver process which queries the
+Semantic Scholar API and optionally synthesizes answers via Ollama.
 """
 
+from rune_bench.drivers.consensus import ConsensusDriverClient
 
-class ConsensusRunner:
-    """Research agent: evidence-based synthesis from 200M+ academic papers."""
-
-    def __init__(self) -> None:
-        pass
-
-    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
-        """Search Consensus and return the paper-backed synthesised answer."""
-        raise NotImplementedError(
-            "ConsensusRunner is not yet implemented. "
-            "See https://consensus.app/tools/api for API access details."
-        )
+ConsensusRunner = ConsensusDriverClient

--- a/rune_bench/agents/sre/pagerduty.py
+++ b/rune_bench/agents/sre/pagerduty.py
@@ -1,4 +1,4 @@
-"""PagerDuty AI agentic runner stub.
+"""PagerDuty AI agentic runner — delegates to the pagerduty driver.
 
 Scope:      SRE  |  Rank 3  |  Rating 4.5
 Capability: Autonomous alert correlation and triage automation.
@@ -6,34 +6,10 @@ Docs:       https://support.pagerduty.com/
             https://developer.pagerduty.com/api-reference/
 Ecosystem:  LSF Security Standards
 
-Implementation notes:
-- Auth:     PAGERDUTY_API_KEY env var (REST API v2 token)
-- SDK:      pip install pdpyras  (PagerDuty Python REST API Sessions)
-            https://github.com/PagerDuty/pdpyras
-- Key endpoints:
-    GET  /incidents                  # list open incidents
-    GET  /incidents/{id}/alerts      # alerts within an incident
-    POST /incidents/{id}/notes       # add AI-generated triage note
-    GET  /services                   # map alerts to services
-- The `question` parameter maps to an incident/alert query or free-text triage prompt.
-- `model` and `ollama_url` are used to drive the summarisation/triage via a local LLM.
+This module re-exports :class:`~rune_bench.drivers.pagerduty.PagerDutyDriverClient`
+as ``PagerDutyAIRunner`` so existing call-sites continue to work unchanged.
 """
 
-from pathlib import Path
+from rune_bench.drivers.pagerduty import PagerDutyDriverClient
 
-
-class PagerDutyAIRunner:
-    """SRE agent: correlates and triages PagerDuty alerts autonomously."""
-
-    def __init__(self, kubeconfig: Path) -> None:
-        if not kubeconfig.exists():
-            raise FileNotFoundError(f"kubeconfig not found: {kubeconfig}")
-        self._kubeconfig = kubeconfig
-
-    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
-        """Fetch open incidents and return an AI-generated triage summary."""
-        raise NotImplementedError(
-            "PagerDutyAIRunner is not yet implemented. "
-            "See https://developer.pagerduty.com/api-reference/ and "
-            "https://github.com/PagerDuty/pdpyras for implementation details."
-        )
+PagerDutyAIRunner = PagerDutyDriverClient

--- a/rune_bench/drivers/consensus/__init__.py
+++ b/rune_bench/drivers/consensus/__init__.py
@@ -28,13 +28,20 @@ class ConsensusDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("consensus")
 
-    def ask(self, question: str, model: str = "", ollama_url: str | None = None) -> str:
+    def ask(
+        self,
+        question: str,
+        model: str = "",
+        ollama_url: str | None = None,
+        limit: int | None = None,
+    ) -> str:
         """Dispatch a research question to the consensus driver and return the answer.
 
         Args:
             question: Natural-language research question.
             model: Ollama model identifier for synthesis (optional).
             ollama_url: Base URL of the Ollama server (optional).
+            limit: Maximum number of papers to retrieve (optional, driver default 10).
 
         Returns:
             Synthesized answer (if model + ollama_url provided) or a
@@ -46,6 +53,8 @@ class ConsensusDriverClient:
             params["model"] = normalized_model
         if ollama_url:
             params["ollama_url"] = ollama_url
+        if limit is not None:
+            params["limit"] = limit
 
         debug_log(
             f"ConsensusDriverClient.ask: question={question!r} model={model!r} "

--- a/rune_bench/drivers/consensus/__init__.py
+++ b/rune_bench/drivers/consensus/__init__.py
@@ -1,0 +1,66 @@
+"""Consensus driver client — delegates research queries to the consensus driver process.
+
+The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`
+(stdio subprocess by default, HTTP server in production).  The driver itself
+(``rune_bench.drivers.consensus.__main__``) queries the Semantic Scholar API
+and optionally synthesizes answers via Ollama — no external Python packages
+are required.
+"""
+
+from __future__ import annotations
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class ConsensusDriverClient:
+    """Research agent: evidence-based synthesis from academic papers.
+
+    Uses the Semantic Scholar API for paper search and optionally Ollama
+    for answer synthesis.  The public interface mirrors the old
+    ``ConsensusRunner`` stub so existing call-sites require no changes.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("consensus")
+
+    def ask(self, question: str, model: str = "", ollama_url: str | None = None) -> str:
+        """Dispatch a research question to the consensus driver and return the answer.
+
+        Args:
+            question: Natural-language research question.
+            model: Ollama model identifier for synthesis (optional).
+            ollama_url: Base URL of the Ollama server (optional).
+
+        Returns:
+            Synthesized answer (if model + ollama_url provided) or a
+            formatted list of relevant papers.
+        """
+        params: dict = {"question": question}
+        if model:
+            params["model"] = model
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"ConsensusDriverClient.ask: question={question!r} model={model!r} "
+            f"ollama_url={ollama_url or '<none>'}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("Consensus driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("Consensus driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("Consensus driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/consensus/__init__.py
+++ b/rune_bench/drivers/consensus/__init__.py
@@ -41,8 +41,9 @@ class ConsensusDriverClient:
             formatted list of relevant papers.
         """
         params: dict = {"question": question}
-        if model:
-            params["model"] = model
+        normalized_model = model.strip()
+        if normalized_model:
+            params["model"] = normalized_model
         if ollama_url:
             params["ollama_url"] = ollama_url
 

--- a/rune_bench/drivers/consensus/__main__.py
+++ b/rune_bench/drivers/consensus/__main__.py
@@ -11,8 +11,9 @@ Wire protocol (v1):
 Supported actions
 -----------------
 ask
-    params: question (str), model (str, optional), ollama_url (str, optional)
-    result: {"answer": str, "papers": list[dict]}
+    params: question (str), model (str, optional), ollama_url (str, optional),
+            limit (int, optional, default 10)
+    result: {"answer": str, "papers": list[dict], "consensus_score": null}
 
 info
     params: (none)
@@ -25,7 +26,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -45,11 +45,11 @@ SYNTHESIS_PROMPT = (
 )
 
 
-def _search_semantic_scholar(question: str) -> list[dict]:
+def _search_semantic_scholar(question: str, *, limit: int = SEARCH_LIMIT) -> list[dict]:
     """Query the Semantic Scholar paper search endpoint."""
     params = urllib.parse.urlencode({
         "query": question,
-        "limit": SEARCH_LIMIT,
+        "limit": limit,
         "fields": SEARCH_FIELDS,
     })
     url = f"{SEMANTIC_SCHOLAR_BASE}/paper/search?{params}"
@@ -132,18 +132,19 @@ def _handle_ask(params: dict) -> dict:
     question: str = params["question"]
     model: str | None = params.get("model")
     ollama_url: str | None = params.get("ollama_url")
+    limit: int = int(params.get("limit", SEARCH_LIMIT))
 
-    papers = _search_semantic_scholar(question)
+    papers = _search_semantic_scholar(question, limit=limit)
 
     if not papers:
-        return {"answer": "No papers found for the given query.", "papers": []}
+        return {"answer": "No papers found for the given query.", "papers": [], "consensus_score": None}
 
     if model and ollama_url:
         answer = _synthesize_via_ollama(question, papers, model, ollama_url)
     else:
         answer = _format_papers(papers)
 
-    return {"answer": answer, "papers": _simplify_papers(papers)}
+    return {"answer": answer, "papers": _simplify_papers(papers), "consensus_score": None}
 
 
 def _handle_info(_params: dict) -> dict:

--- a/rune_bench/drivers/consensus/__main__.py
+++ b/rune_bench/drivers/consensus/__main__.py
@@ -105,7 +105,7 @@ def _synthesize_via_ollama(question: str, papers: list[dict], model: str, ollama
 
     payload = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode()
     url = f"{ollama_url.rstrip('/')}/api/generate"
-    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"}, method="POST")
 
     with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
         data = json.loads(resp.read().decode())

--- a/rune_bench/drivers/consensus/__main__.py
+++ b/rune_bench/drivers/consensus/__main__.py
@@ -1,0 +1,193 @@
+"""Consensus driver entry point — receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.consensus
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str, optional), ollama_url (str, optional)
+    result: {"answer": str, "papers": list[dict]}
+
+info
+    params: (none)
+    result: {"name": "consensus", "version": "1", "actions": [...],
+             "note": "uses Semantic Scholar API"}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+SEMANTIC_SCHOLAR_BASE = "https://api.semanticscholar.org/graph/v1"
+SEARCH_FIELDS = "title,abstract,year,authors,citationCount,url"
+SEARCH_LIMIT = 10
+
+SYNTHESIS_PROMPT = (
+    "You are a research synthesis agent. Given these paper abstracts, provide:\n"
+    "1. A clear answer to the research question\n"
+    "2. The level of scientific consensus (strong/moderate/weak/conflicting)\n"
+    "3. Key citations supporting each position\n"
+    "\n"
+    "Question: {question}\n"
+    "\n"
+    "Papers:\n{formatted_abstracts}"
+)
+
+
+def _search_semantic_scholar(question: str) -> list[dict]:
+    """Query the Semantic Scholar paper search endpoint."""
+    params = urllib.parse.urlencode({
+        "query": question,
+        "limit": SEARCH_LIMIT,
+        "fields": SEARCH_FIELDS,
+    })
+    url = f"{SEMANTIC_SCHOLAR_BASE}/paper/search?{params}"
+
+    req = urllib.request.Request(url)
+    api_key = os.environ.get("RUNE_CONSENSUS_API_KEY", "")
+    if api_key:
+        req.add_header("x-api-key", api_key)
+
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        data = json.loads(resp.read().decode())
+
+    return data.get("data") or []
+
+
+def _format_papers(papers: list[dict]) -> str:
+    """Format papers into a human-readable text block."""
+    lines: list[str] = []
+    for i, p in enumerate(papers, 1):
+        authors = ", ".join(a.get("name", "Unknown") for a in (p.get("authors") or []))
+        title = p.get("title", "Untitled")
+        year = p.get("year", "n/a")
+        citations = p.get("citationCount", 0)
+        abstract = p.get("abstract") or "No abstract available."
+        paper_url = p.get("url", "")
+
+        lines.append(f"[{i}] {title}")
+        lines.append(f"    Authors: {authors}")
+        lines.append(f"    Year: {year}  |  Citations: {citations}")
+        if paper_url:
+            lines.append(f"    URL: {paper_url}")
+        lines.append(f"    Abstract: {abstract}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _format_abstracts_for_synthesis(papers: list[dict]) -> str:
+    """Format paper abstracts for the synthesis prompt."""
+    parts: list[str] = []
+    for i, p in enumerate(papers, 1):
+        authors = ", ".join(a.get("name", "Unknown") for a in (p.get("authors") or []))
+        title = p.get("title", "Untitled")
+        year = p.get("year", "n/a")
+        abstract = p.get("abstract") or "No abstract available."
+        parts.append(f"[{i}] {title} ({authors}, {year})\n{abstract}")
+    return "\n\n".join(parts)
+
+
+def _synthesize_via_ollama(question: str, papers: list[dict], model: str, ollama_url: str) -> str:
+    """Call Ollama to synthesize an answer from the paper abstracts."""
+    formatted = _format_abstracts_for_synthesis(papers)
+    prompt = SYNTHESIS_PROMPT.format(question=question, formatted_abstracts=formatted)
+
+    payload = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode()
+    url = f"{ollama_url.rstrip('/')}/api/generate"
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
+        data = json.loads(resp.read().decode())
+
+    return data.get("response", "")
+
+
+def _simplify_papers(papers: list[dict]) -> list[dict]:
+    """Return a simplified list of paper dicts suitable for the result payload."""
+    simplified: list[dict] = []
+    for p in papers:
+        simplified.append({
+            "title": p.get("title", "Untitled"),
+            "abstract": p.get("abstract") or "",
+            "year": p.get("year"),
+            "authors": [a.get("name", "Unknown") for a in (p.get("authors") or [])],
+            "citationCount": p.get("citationCount", 0),
+            "url": p.get("url", ""),
+        })
+    return simplified
+
+
+def _handle_ask(params: dict) -> dict:
+    question: str = params["question"]
+    model: str | None = params.get("model")
+    ollama_url: str | None = params.get("ollama_url")
+
+    papers = _search_semantic_scholar(question)
+
+    if not papers:
+        return {"answer": "No papers found for the given query.", "papers": []}
+
+    if model and ollama_url:
+        answer = _synthesize_via_ollama(question, papers, model, ollama_url)
+    else:
+        answer = _format_papers(papers)
+
+    return {"answer": answer, "papers": _simplify_papers(papers)}
+
+
+def _handle_info(_params: dict) -> dict:
+    return {
+        "name": "consensus",
+        "version": "1",
+        "actions": ["ask", "info"],
+        "note": "uses Semantic Scholar API",
+    }
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/pagerduty/__init__.py
+++ b/rune_bench/drivers/pagerduty/__init__.py
@@ -49,7 +49,6 @@ class PagerDutyDriverClient:
         params: dict = {
             "question": question,
             "model": model.strip(),
-            "kubeconfig_path": str(self._kubeconfig),
         }
         if ollama_url:
             params["ollama_url"] = ollama_url

--- a/rune_bench/drivers/pagerduty/__init__.py
+++ b/rune_bench/drivers/pagerduty/__init__.py
@@ -1,0 +1,74 @@
+"""PagerDuty driver client -- delegates incident triage queries to the pagerduty driver process.
+
+This is a hybrid agent: PagerDuty REST API for data retrieval plus Ollama for
+triage synthesis.  The driver process
+(``rune_bench.drivers.pagerduty.__main__``) calls the PagerDuty REST v2 API
+via :mod:`urllib.request` and therefore requires no external dependencies
+beyond a valid ``RUNE_PAGERDUTY_API_KEY`` env var.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class PagerDutyDriverClient:
+    """Fetch and triage PagerDuty incidents by delegating to the pagerduty driver.
+
+    The public interface mirrors :class:`~rune_bench.drivers.holmes.HolmesDriverClient`
+    so existing call-sites in :mod:`rune_bench.api_backend` and the CLI require
+    no changes.
+    """
+
+    def __init__(
+        self,
+        kubeconfig: Path,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        if not kubeconfig.exists():
+            raise FileNotFoundError(f"kubeconfig not found: {kubeconfig}")
+        self._kubeconfig = kubeconfig
+        self._transport: DriverTransport = transport or make_driver_transport("pagerduty")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Dispatch a triage question to the pagerduty driver and return the answer.
+
+        Args:
+            question: Natural-language triage question.
+            model: Ollama model identifier (e.g. ``"llama3.1:8b"``).
+            ollama_url: Base URL of the Ollama server (optional).
+
+        Returns:
+            A triage summary (LLM-synthesised when Ollama is available) or
+            formatted raw incident data.
+        """
+        params: dict = {
+            "question": question,
+            "model": model.strip(),
+            "kubeconfig_path": str(self._kubeconfig),
+        }
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"PagerDutyDriverClient.ask: question={question!r} model={model!r} "
+            f"ollama_url={ollama_url or '<none>'}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("PagerDuty driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("PagerDuty driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("PagerDuty driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/pagerduty/__main__.py
+++ b/rune_bench/drivers/pagerduty/__main__.py
@@ -11,7 +11,7 @@ Wire protocol (v1):
 Supported actions
 -----------------
 ask
-    params: question (str), model (str), kubeconfig_path (str),
+    params: question (str), model (str, optional),
             ollama_url (str, optional)
     result: {"answer": str, "incidents": list}
 

--- a/rune_bench/drivers/pagerduty/__main__.py
+++ b/rune_bench/drivers/pagerduty/__main__.py
@@ -1,0 +1,189 @@
+"""PagerDuty driver entry point -- receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.pagerduty
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str), kubeconfig_path (str),
+            ollama_url (str, optional)
+    result: {"answer": str, "incidents": list}
+
+info
+    params: (none)
+    result: {"name": "pagerduty", "version": "1", "actions": [...]}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+
+_PAGERDUTY_API_BASE = "https://api.pagerduty.com"
+
+
+def _pd_request(path: str, api_key: str) -> dict:
+    """Make an authenticated GET request to the PagerDuty REST v2 API."""
+    url = f"{_PAGERDUTY_API_BASE}{path}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Token token={api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        return json.loads(resp.read().decode())
+
+
+def _fetch_open_incidents(api_key: str) -> list[dict]:
+    """Fetch triggered and acknowledged incidents from PagerDuty."""
+    data = _pd_request(
+        "/incidents?statuses[]=triggered&statuses[]=acknowledged",
+        api_key,
+    )
+    return data.get("incidents", [])
+
+
+def _fetch_alerts_for_incident(incident_id: str, api_key: str) -> list[dict]:
+    """Fetch alerts associated with a specific incident."""
+    data = _pd_request(f"/incidents/{incident_id}/alerts", api_key)
+    return data.get("alerts", [])
+
+
+def _format_incident_data(incidents: list[dict], alerts_by_incident: dict[str, list[dict]]) -> str:
+    """Format incident and alert data as structured text for LLM consumption."""
+    if not incidents:
+        return "No open incidents found."
+
+    lines: list[str] = []
+    for inc in incidents:
+        inc_id = inc.get("id", "unknown")
+        lines.append(f"Incident: {inc.get('title', 'N/A')} (ID: {inc_id})")
+        lines.append(f"  Status: {inc.get('status', 'N/A')}")
+        lines.append(f"  Urgency: {inc.get('urgency', 'N/A')}")
+        lines.append(f"  Service: {inc.get('service', {}).get('summary', 'N/A')}")
+        lines.append(f"  Created: {inc.get('created_at', 'N/A')}")
+
+        alerts = alerts_by_incident.get(inc_id, [])
+        if alerts:
+            lines.append(f"  Alerts ({len(alerts)}):")
+            for alert in alerts:
+                lines.append(f"    - {alert.get('summary', 'N/A')} "
+                             f"(severity: {alert.get('severity', 'N/A')})")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _call_ollama(prompt: str, model: str, ollama_url: str) -> str:
+    """Call the Ollama /api/generate endpoint for triage synthesis."""
+    url = f"{ollama_url.rstrip('/')}/api/generate"
+    payload = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        result = json.loads(resp.read().decode())
+    return result.get("response", "")
+
+
+def _handle_ask(params: dict) -> dict:
+    question: str = params["question"]
+    model: str = params.get("model", "")
+    ollama_url: str | None = params.get("ollama_url")
+
+    api_key = os.environ.get("RUNE_PAGERDUTY_API_KEY", "")
+    if not api_key:
+        raise RuntimeError(
+            "RUNE_PAGERDUTY_API_KEY environment variable is not set. "
+            "A PagerDuty REST API v2 token is required."
+        )
+
+    incidents = _fetch_open_incidents(api_key)
+
+    alerts_by_incident: dict[str, list[dict]] = {}
+    for inc in incidents:
+        inc_id = inc.get("id", "")
+        if inc_id:
+            alerts_by_incident[inc_id] = _fetch_alerts_for_incident(inc_id, api_key)
+
+    formatted_data = _format_incident_data(incidents, alerts_by_incident)
+
+    if model and ollama_url:
+        prompt = (
+            "You are an SRE triage agent. Given these PagerDuty incidents, provide: "
+            "1) Prioritized triage summary, 2) Correlation between related incidents, "
+            "3) Recommended immediate actions.\n\n"
+            f"Question: {question}\n\n"
+            f"Incidents:\n{formatted_data}"
+        )
+        answer = _call_ollama(prompt, model, ollama_url)
+    else:
+        answer = formatted_data
+
+    # Build a minimal incident summary list for structured consumers.
+    incidents_list = [
+        {
+            "id": inc.get("id", ""),
+            "title": inc.get("title", ""),
+            "status": inc.get("status", ""),
+            "urgency": inc.get("urgency", ""),
+        }
+        for inc in incidents
+    ]
+
+    return {"answer": answer, "incidents": incidents_list}
+
+
+def _handle_info(_params: dict) -> dict:
+    return {"name": "pagerduty", "version": "1", "actions": ["ask", "info"]}
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/pagerduty/__main__.py
+++ b/rune_bench/drivers/pagerduty/__main__.py
@@ -40,7 +40,7 @@ def _pd_request(path: str, api_key: str) -> dict:
             "Content-Type": "application/json",
         },
     )
-    with urllib.request.urlopen(req) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
         return json.loads(resp.read().decode())
 
 
@@ -94,7 +94,7 @@ def _call_ollama(prompt: str, model: str, ollama_url: str) -> str:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
         result = json.loads(resp.read().decode())
     return result.get("response", "")
 

--- a/tests/test_consensus_driver.py
+++ b/tests/test_consensus_driver.py
@@ -85,7 +85,7 @@ def test_handle_ask_searches_semantic_scholar(monkeypatch: pytest.MonkeyPatch) -
     assert "answer" in result
     assert "papers" in result
     assert len(result["papers"]) == 2
-    assert "semanticscholar.org" in captured_url[0]
+    assert captured_url[0].startswith("https://api.semanticscholar.org/")
     assert "deep+learning+NLP" in captured_url[0] or "deep%20learning%20NLP" in captured_url[0] or "deep+learning" in captured_url[0]
 
 

--- a/tests/test_consensus_driver.py
+++ b/tests/test_consensus_driver.py
@@ -1,0 +1,314 @@
+"""Tests for rune_bench.drivers.consensus — driver entry point and client.
+
+All HTTP calls (Semantic Scholar + Ollama) are monkeypatched so no network
+access is required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+import rune_bench.drivers.consensus.__main__ as consensus_main
+from rune_bench.drivers.consensus import ConsensusDriverClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_PAPERS = [
+    {
+        "paperId": "abc123",
+        "title": "Deep Learning for NLP",
+        "abstract": "We survey deep learning methods for NLP tasks.",
+        "year": 2023,
+        "authors": [{"name": "Alice Smith"}, {"name": "Bob Jones"}],
+        "citationCount": 150,
+        "url": "https://semanticscholar.org/paper/abc123",
+    },
+    {
+        "paperId": "def456",
+        "title": "Transformers Revisited",
+        "abstract": "A comprehensive review of transformer architectures.",
+        "year": 2024,
+        "authors": [{"name": "Carol Lee"}],
+        "citationCount": 42,
+        "url": "https://semanticscholar.org/paper/def456",
+    },
+]
+
+
+def _mock_urlopen_factory(response_data: dict, status: int = 200):
+    """Return a context-manager mock that yields response_data as JSON."""
+
+    class FakeResponse:
+        def __init__(self):
+            self._data = json.dumps(response_data).encode()
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def mock_urlopen(req, timeout=None):
+        return FakeResponse()
+
+    return mock_urlopen
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — Semantic Scholar search
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_searches_semantic_scholar(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_url: list[str] = []
+
+    original_factory = _mock_urlopen_factory({"data": SAMPLE_PAPERS})
+
+    def capturing_urlopen(req, timeout=None):
+        captured_url.append(req.full_url if hasattr(req, "full_url") else str(req))
+        return original_factory(req, timeout)
+
+    monkeypatch.setattr(consensus_main.urllib.request, "urlopen", capturing_urlopen)
+
+    result = consensus_main._handle_ask({"question": "deep learning NLP"})
+
+    assert "answer" in result
+    assert "papers" in result
+    assert len(result["papers"]) == 2
+    assert "semanticscholar.org" in captured_url[0]
+    assert "deep+learning+NLP" in captured_url[0] or "deep%20learning%20NLP" in captured_url[0] or "deep+learning" in captured_url[0]
+
+
+def test_handle_ask_parses_paper_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        consensus_main.urllib.request,
+        "urlopen",
+        _mock_urlopen_factory({"data": SAMPLE_PAPERS}),
+    )
+
+    result = consensus_main._handle_ask({"question": "transformers"})
+    papers = result["papers"]
+
+    assert papers[0]["title"] == "Deep Learning for NLP"
+    assert papers[0]["abstract"] == "We survey deep learning methods for NLP tasks."
+    assert papers[0]["authors"] == ["Alice Smith", "Bob Jones"]
+    assert papers[0]["citationCount"] == 150
+    assert papers[0]["year"] == 2023
+    assert papers[0]["url"] == "https://semanticscholar.org/paper/abc123"
+
+    assert papers[1]["title"] == "Transformers Revisited"
+    assert papers[1]["authors"] == ["Carol Lee"]
+    assert papers[1]["citationCount"] == 42
+
+
+def test_handle_ask_ollama_synthesis(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When model + ollama_url are provided, the driver synthesizes via Ollama."""
+    call_count = {"n": 0}
+
+    def mock_urlopen(req, timeout=None):
+        call_count["n"] += 1
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "semanticscholar" in url:
+            return _mock_urlopen_factory({"data": SAMPLE_PAPERS})(req, timeout)
+        # Ollama call
+        assert "/api/generate" in url
+        body = json.loads(req.data.decode())
+        assert body["model"] == "llama3:8b"
+        assert "deep learning" in body["prompt"].lower()
+        return _mock_urlopen_factory({"response": "Synthesized answer from papers."})(req, timeout)
+
+    monkeypatch.setattr(consensus_main.urllib.request, "urlopen", mock_urlopen)
+
+    result = consensus_main._handle_ask({
+        "question": "deep learning NLP",
+        "model": "llama3:8b",
+        "ollama_url": "http://localhost:11434",
+    })
+
+    assert result["answer"] == "Synthesized answer from papers."
+    assert call_count["n"] == 2  # Semantic Scholar + Ollama
+
+
+def test_handle_ask_fallback_no_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without model/ollama_url, return a formatted paper list."""
+    monkeypatch.setattr(
+        consensus_main.urllib.request,
+        "urlopen",
+        _mock_urlopen_factory({"data": SAMPLE_PAPERS}),
+    )
+
+    result = consensus_main._handle_ask({"question": "transformers"})
+
+    # Should be a formatted text answer, not a synthesis
+    assert "Deep Learning for NLP" in result["answer"]
+    assert "Transformers Revisited" in result["answer"]
+    assert "Alice Smith" in result["answer"]
+    assert "Carol Lee" in result["answer"]
+
+
+def test_handle_ask_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        consensus_main.urllib.request,
+        "urlopen",
+        _mock_urlopen_factory({"data": []}),
+    )
+
+    result = consensus_main._handle_ask({"question": "xyznonexistent"})
+
+    assert "No papers found" in result["answer"]
+    assert result["papers"] == []
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = consensus_main._handle_info({})
+    assert result["name"] == "consensus"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+    assert "Semantic Scholar" in result["note"]
+
+
+# ---------------------------------------------------------------------------
+# ConsensusDriverClient
+# ---------------------------------------------------------------------------
+
+
+def test_client_ask_delegates_to_transport() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "The answer", "papers": []}
+
+    client = ConsensusDriverClient(transport=mock_transport)
+    answer = client.ask("What is X?", model="llama3:8b", ollama_url="http://ollama:11434")
+
+    assert answer == "The answer"
+    mock_transport.call.assert_called_once_with("ask", {
+        "question": "What is X?",
+        "model": "llama3:8b",
+        "ollama_url": "http://ollama:11434",
+    })
+
+
+def test_client_ask_without_model() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "Paper list here"}
+
+    client = ConsensusDriverClient(transport=mock_transport)
+    answer = client.ask("What is Y?")
+
+    assert answer == "Paper list here"
+    mock_transport.call.assert_called_once_with("ask", {"question": "What is Y?"})
+
+
+def test_client_raises_on_missing_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"papers": []}
+
+    client = ConsensusDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="did not include an answer"):
+        client.ask("Question?")
+
+
+def test_client_raises_on_empty_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": ""}
+
+    client = ConsensusDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="empty answer"):
+        client.ask("Question?")
+
+
+def test_client_raises_on_none_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": None}
+
+    client = ConsensusDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="empty answer"):
+        client.ask("Question?")
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(consensus_main, "_handle_ask", lambda p: {"answer": "research answer", "papers": []})
+    monkeypatch.setattr(
+        consensus_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "test question"},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    consensus_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "research answer"
+    assert response["id"] == "test-id"
+
+
+def test_main_processes_info_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(
+        consensus_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "info", "params": {}, "id": "i1"}) + "\n"),
+    )
+
+    consensus_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["name"] == "consensus"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        consensus_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    consensus_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+def test_main_skips_empty_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(consensus_main.sys, "stdin", io.StringIO("\n\n   \n"))
+
+    consensus_main.main()
+
+    assert capsys.readouterr().out.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# ConsensusRunner alias
+# ---------------------------------------------------------------------------
+
+
+def test_consensus_runner_alias() -> None:
+    from rune_bench.agents.research.consensus import ConsensusRunner
+
+    assert ConsensusRunner is ConsensusDriverClient

--- a/tests/test_pagerduty_driver.py
+++ b/tests/test_pagerduty_driver.py
@@ -1,0 +1,287 @@
+"""Tests for rune_bench.drivers.pagerduty — driver client and subprocess entry point.
+
+All HTTP calls to PagerDuty and Ollama are mocked so no external services
+are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import rune_bench.drivers.pagerduty.__main__ as pd_main
+
+
+# ---------------------------------------------------------------------------
+# Sample fixtures
+# ---------------------------------------------------------------------------
+
+_SAMPLE_INCIDENTS = [
+    {
+        "id": "P1234",
+        "title": "High CPU on web-01",
+        "status": "triggered",
+        "urgency": "high",
+        "service": {"summary": "web-service"},
+        "created_at": "2026-04-04T10:00:00Z",
+    },
+    {
+        "id": "P5678",
+        "title": "Disk full on db-02",
+        "status": "acknowledged",
+        "urgency": "low",
+        "service": {"summary": "database-service"},
+        "created_at": "2026-04-04T09:30:00Z",
+    },
+]
+
+_SAMPLE_ALERTS = [
+    {"summary": "CPU usage above 95%", "severity": "critical"},
+]
+
+
+def _mock_urlopen(responses: dict):
+    """Return a context-manager factory that returns canned JSON responses keyed by URL substring."""
+
+    class FakeResponse:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def read(self) -> bytes:
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def _urlopen(req, *args, **kwargs):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for key, payload in responses.items():
+            if key in url:
+                return FakeResponse(json.dumps(payload).encode())
+        raise RuntimeError(f"Unmocked URL: {url}")
+
+    return _urlopen
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — missing API key
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_raises_when_api_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RUNE_PAGERDUTY_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="RUNE_PAGERDUTY_API_KEY"):
+        pd_main._handle_ask({"question": "triage", "model": "m"})
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — incident fetching with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_fetches_incidents(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
+
+    mock = _mock_urlopen({
+        "/incidents?statuses": {"incidents": _SAMPLE_INCIDENTS},
+        "/incidents/P1234/alerts": {"alerts": _SAMPLE_ALERTS},
+        "/incidents/P5678/alerts": {"alerts": []},
+    })
+    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+
+    result = pd_main._handle_ask({"question": "triage", "model": ""})
+
+    assert "incidents" in result
+    assert len(result["incidents"]) == 2
+    assert result["incidents"][0]["id"] == "P1234"
+    assert "High CPU on web-01" in result["answer"]
+    assert "Disk full on db-02" in result["answer"]
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — triage synthesis with mocked Ollama
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_calls_ollama_for_synthesis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
+
+    mock = _mock_urlopen({
+        "/incidents?statuses": {"incidents": _SAMPLE_INCIDENTS},
+        "/incidents/P1234/alerts": {"alerts": _SAMPLE_ALERTS},
+        "/incidents/P5678/alerts": {"alerts": []},
+        "/api/generate": {"response": "Triage: CPU incident is P1, disk is P2."},
+    })
+    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+
+    result = pd_main._handle_ask({
+        "question": "what should I fix first?",
+        "model": "llama3.1:8b",
+        "ollama_url": "http://ollama:11434",
+    })
+
+    assert result["answer"] == "Triage: CPU incident is P1, disk is P2."
+    assert len(result["incidents"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — fallback without LLM (raw data)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_returns_raw_data_without_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
+
+    mock = _mock_urlopen({
+        "/incidents?statuses": {"incidents": _SAMPLE_INCIDENTS},
+        "/incidents/P1234/alerts": {"alerts": _SAMPLE_ALERTS},
+        "/incidents/P5678/alerts": {"alerts": []},
+    })
+    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+
+    # No model or ollama_url — should return formatted raw data
+    result = pd_main._handle_ask({"question": "triage", "model": ""})
+
+    assert "High CPU on web-01" in result["answer"]
+    assert "Disk full on db-02" in result["answer"]
+    # Verify structured incident list is present
+    assert result["incidents"][0]["title"] == "High CPU on web-01"
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — no open incidents
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_no_incidents(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
+
+    mock = _mock_urlopen({
+        "/incidents?statuses": {"incidents": []},
+    })
+    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+
+    result = pd_main._handle_ask({"question": "any issues?", "model": ""})
+
+    assert "No open incidents" in result["answer"]
+    assert result["incidents"] == []
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = pd_main._handle_info({})
+    assert result["name"] == "pagerduty"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(pd_main, "_handle_ask", lambda p: {"answer": "triage done", "incidents": []})
+    monkeypatch.setattr(
+        pd_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "q", "model": "m"},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    pd_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "triage done"
+    assert response["id"] == "test-id"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        pd_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    pd_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# PagerDutyDriverClient — with mocked transport
+# ---------------------------------------------------------------------------
+
+
+def test_driver_client_ask_returns_answer(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "all clear", "incidents": []}
+
+    from rune_bench.drivers.pagerduty import PagerDutyDriverClient
+
+    client = PagerDutyDriverClient(kubeconfig, transport=mock_transport)
+    result = client.ask("what is happening?", "llama3.1:8b", "http://ollama:11434")
+
+    assert result == "all clear"
+    mock_transport.call.assert_called_once()
+    call_args = mock_transport.call.call_args
+    assert call_args[0][0] == "ask"
+    assert call_args[0][1]["question"] == "what is happening?"
+    assert call_args[0][1]["ollama_url"] == "http://ollama:11434"
+
+
+def test_driver_client_raises_on_missing_kubeconfig(tmp_path: Path) -> None:
+    from rune_bench.drivers.pagerduty import PagerDutyDriverClient
+
+    with pytest.raises(FileNotFoundError, match="kubeconfig not found"):
+        PagerDutyDriverClient(tmp_path / "nonexistent")
+
+
+def test_driver_client_raises_on_missing_answer(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"incidents": []}
+
+    from rune_bench.drivers.pagerduty import PagerDutyDriverClient
+
+    client = PagerDutyDriverClient(kubeconfig, transport=mock_transport)
+    with pytest.raises(RuntimeError, match="did not include an answer"):
+        client.ask("q", "m")
+
+
+def test_driver_client_raises_on_empty_answer(tmp_path: Path) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1")
+
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": ""}
+
+    from rune_bench.drivers.pagerduty import PagerDutyDriverClient
+
+    client = PagerDutyDriverClient(kubeconfig, transport=mock_transport)
+    with pytest.raises(RuntimeError, match="empty answer"):
+        client.ask("q", "m")


### PR DESCRIPTION
## Summary
- Implement the Consensus Research agent driver using Semantic Scholar API for paper search and optional Ollama-based answer synthesis
- Create `ConsensusDriverClient` (client) and `__main__.py` (subprocess) following the Holmes driver wire protocol pattern
- Replace the `ConsensusRunner` stub with an alias to `ConsensusDriverClient`
- Add 16 tests covering search, paper parsing, Ollama synthesis, fallback formatting, empty results, client transport delegation, and the stdin/stdout main loop

Closes #68

## Test plan
- [x] `python -m pytest tests/test_consensus_driver.py -v --no-cov` — 16/16 passing
- [ ] Manual integration test with live Semantic Scholar API
- [ ] Manual integration test with Ollama synthesis endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)