### PR TITLE
feat(drivers): implement Elicit and Mindgard agent drivers

### DIFF
--- a/rune_bench/agents/cybersec/mindgard.py
+++ b/rune_bench/agents/cybersec/mindgard.py
@@ -1,4 +1,4 @@
-"""Mindgard agentic runner stub.
+"""Mindgard agentic runner — delegates to the Mindgard driver for AI red-teaming.
 
 Scope:      Cybersec  |  Rank 3  |  Rating 4.0
 Capability: Autonomous "Red Teaming" for AI model safety.
@@ -10,28 +10,16 @@ Ecosystem:  AI Security
 Implementation notes:
 - Install:  pip install mindgard  (CLI + Python SDK)
             https://github.com/Mindgard/cli
-- Auth:     MINDGARD_API_KEY env var  (register at https://mindgard.ai/)
+- Auth:     RUNE_MINDGARD_API_KEY env var  (register at https://mindgard.ai/)
 - Approach: Run automated red-team attacks against an AI model endpoint.
             Mindgard tests for jailbreaks, prompt injection, data extraction, etc.
-- Key CLI/SDK usage:
-    mindgard test --target <model_url> --model <model_name>
-    # or via Python SDK:
-    from mindgard import test
-    result = test(target=ollama_url, model=model, prompt=question)
+- ``ollama_url`` is the model endpoint being **attacked** (target under test).
+- `model` identifies the target model.
 - `question` maps to the red-team prompt/objective.
-- `model` and `ollama_url` point to the AI model under test.
 """
 
+from rune_bench.drivers.mindgard import MindgardDriverClient
 
-class MindgardRunner:
-    """Cybersec agent: autonomous red-teaming for AI model safety via Mindgard."""
+MindgardRunner = MindgardDriverClient
 
-    def __init__(self) -> None:
-        pass
-
-    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
-        """Run a Mindgard red-team assessment and return the findings."""
-        raise NotImplementedError(
-            "MindgardRunner is not yet implemented. "
-            "See https://docs.mindgard.ai/ and https://github.com/Mindgard/cli for details."
-        )
+__all__ = ["MindgardRunner"]

--- a/rune_bench/agents/research/elicit.py
+++ b/rune_bench/agents/research/elicit.py
@@ -1,4 +1,4 @@
-"""Elicit agentic runner stub.
+"""Elicit agentic runner — delegates to the Elicit driver for literature review.
 
 Scope:      Research  |  Rank 3  |  Rating 4.0
 Capability: Automates literature review and data extraction.
@@ -7,28 +7,16 @@ Docs:       https://elicit.com/
 Ecosystem:  Open Science
 
 Implementation notes:
-- Auth:     ELICIT_API_KEY env var (request access at https://elicit.com/api)
-- SDK:      REST API (no public Python SDK)
+- Auth:     RUNE_ELICIT_API_KEY env var (request access at https://elicit.com/api)
+- SDK:      REST API via driver (no public Python SDK)
 - Approach: Submit a research question; Elicit searches academic databases,
             extracts structured data from papers, and returns a synthesis.
-- Key flow:
-    POST /tasks          # create a research task with question
-    GET  /tasks/{id}     # poll until complete
-    GET  /tasks/{id}/results  # structured paper + synthesis results
-- The `question` maps to the research task question.
-- `model` and `ollama_url` are not used (Elicit uses its own models).
+- The `question` maps to the research search query.
+- `model` and `ollama_url` are passed through but not used by Elicit.
 """
 
+from rune_bench.drivers.elicit import ElicitDriverClient
 
-class ElicitRunner:
-    """Research agent: automated literature review and data extraction via Elicit."""
+ElicitRunner = ElicitDriverClient
 
-    def __init__(self) -> None:
-        pass
-
-    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
-        """Submit a literature review task to Elicit and return the synthesis."""
-        raise NotImplementedError(
-            "ElicitRunner is not yet implemented. "
-            "See https://elicit.com/api for API access and details."
-        )
+__all__ = ["ElicitRunner"]

--- a/rune_bench/drivers/elicit/__init__.py
+++ b/rune_bench/drivers/elicit/__init__.py
@@ -1,0 +1,64 @@
+"""Elicit driver client — delegates literature-review queries to the elicit driver process.
+
+The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`
+(stdio subprocess by default, HTTP server in production).  The driver itself
+(``rune_bench.drivers.elicit.__main__``) calls the Elicit REST API and therefore
+only requires network access and a valid ``RUNE_ELICIT_API_KEY`` — no additional
+dependencies in the rune core process.
+"""
+
+from __future__ import annotations
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class ElicitDriverClient:
+    """Automate literature review by delegating to the elicit driver process.
+
+    The public interface mirrors the old ``ElicitRunner`` so existing call-sites
+    require no changes.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("elicit")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Dispatch a research question to the elicit driver and return the answer.
+
+        Args:
+            question: Natural-language research question for literature review.
+            model: Model identifier (passed through but not used by Elicit).
+            ollama_url: Ollama URL (passed through but not used by Elicit).
+
+        Returns:
+            Formatted text synthesising the search results.
+        """
+        params: dict = {
+            "question": question,
+            "model": model,
+        }
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"ElicitDriverClient.ask: question={question!r} model={model!r}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("Elicit driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("Elicit driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("Elicit driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/elicit/__main__.py
+++ b/rune_bench/drivers/elicit/__main__.py
@@ -1,0 +1,131 @@
+"""Elicit driver entry point — receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.elicit
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str), ollama_url (str, optional)
+    result: {"answer": str, "papers": list[dict]}
+
+info
+    params: (none)
+    result: {"name": "elicit", "version": "1", "actions": [...]}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _handle_ask(params: dict) -> dict:
+    """Search Elicit for papers matching the research question.
+
+    Reads ``RUNE_ELICIT_API_KEY`` from the environment, POSTs to the Elicit
+    search endpoint, and returns a formatted answer with the list of papers.
+    """
+    question: str = params["question"]
+
+    api_key = os.environ.get("RUNE_ELICIT_API_KEY", "")
+    if not api_key:
+        raise RuntimeError(
+            "RUNE_ELICIT_API_KEY environment variable is not set. "
+            "Request API access at https://elicit.com/api"
+        )
+
+    url = "https://elicit.com/api/v1/search"
+    body = json.dumps({"query": question, "limit": 10}).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode() if exc.fp else str(exc)
+        raise RuntimeError(f"Elicit API error ({exc.code}): {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Elicit API connection error: {exc.reason}") from exc
+
+    papers: list[dict] = data if isinstance(data, list) else data.get("papers", data.get("results", []))
+
+    lines: list[str] = []
+    for i, paper in enumerate(papers, 1):
+        title = paper.get("title", "Untitled")
+        abstract = paper.get("abstract", "No abstract available.")
+        authors = paper.get("authors", "")
+        year = paper.get("year", "")
+        header = f"{i}. {title}"
+        if authors:
+            header += f" — {authors}"
+        if year:
+            header += f" ({year})"
+        lines.append(header)
+        lines.append(f"   {abstract}")
+        lines.append("")
+
+    if not lines:
+        formatted = "No papers found for the given query."
+    else:
+        formatted = f"Found {len(papers)} paper(s) for: {question}\n\n" + "\n".join(lines)
+
+    return {"answer": formatted, "papers": papers}
+
+
+def _handle_info(_params: dict) -> dict:
+    return {"name": "elicit", "version": "1", "actions": ["ask", "info"]}
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/elicit/__main__.py
+++ b/rune_bench/drivers/elicit/__main__.py
@@ -43,7 +43,11 @@ def _handle_ask(params: dict) -> dict:
             "Request API access at https://elicit.com/api"
         )
 
-    url = f"{os.environ.get('RUNE_ELICIT_API_BASE', 'https://elicit.com').rstrip('/')}/api/v1/search"
+    base = os.environ.get("RUNE_ELICIT_API_BASE", "https://elicit.com").rstrip("/")
+    # Strip trailing /api to avoid double /api/api paths
+    if base.endswith("/api"):
+        base = base[:-4]
+    url = f"{base}/api/v1/search"
     body = json.dumps({"query": question, "limit": 10}).encode()
     req = urllib.request.Request(
         url,
@@ -57,12 +61,17 @@ def _handle_ask(params: dict) -> dict:
 
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-            data = json.loads(resp.read().decode())
+            raw = resp.read().decode()
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode() if exc.fp else str(exc)
         raise RuntimeError(f"Elicit API error ({exc.code}): {detail}") from exc
     except urllib.error.URLError as exc:
         raise RuntimeError(f"Elicit API connection error: {exc.reason}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Elicit API returned non-JSON response: {raw[:200]}") from exc
 
     papers: list[dict] = data if isinstance(data, list) else data.get("papers", data.get("results", []))
 

--- a/rune_bench/drivers/elicit/__main__.py
+++ b/rune_bench/drivers/elicit/__main__.py
@@ -43,7 +43,7 @@ def _handle_ask(params: dict) -> dict:
             "Request API access at https://elicit.com/api"
         )
 
-    url = "https://elicit.com/api/v1/search"
+    url = f"{os.environ.get('RUNE_ELICIT_API_BASE', 'https://elicit.com').rstrip('/')}/api/v1/search"
     body = json.dumps({"query": question, "limit": 10}).encode()
     req = urllib.request.Request(
         url,
@@ -56,7 +56,7 @@ def _handle_ask(params: dict) -> dict:
     )
 
     try:
-        with urllib.request.urlopen(req) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
             data = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode() if exc.fp else str(exc)

--- a/rune_bench/drivers/mindgard/__init__.py
+++ b/rune_bench/drivers/mindgard/__init__.py
@@ -1,0 +1,70 @@
+"""Mindgard driver client — delegates AI red-teaming to the mindgard driver process.
+
+The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`
+(stdio subprocess by default, HTTP server in production).  The driver itself
+(``rune_bench.drivers.mindgard.__main__``) invokes the ``mindgard`` CLI and
+therefore only requires the mindgard package to be installed in the *subprocess*
+environment — not in the rune core process.
+"""
+
+from __future__ import annotations
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class MindgardDriverClient:
+    """Run AI red-teaming assessments by delegating to the mindgard driver process.
+
+    The public interface mirrors the old ``MindgardRunner`` so existing call-sites
+    require no changes.
+
+    .. note::
+
+        Unlike most drivers, ``ollama_url`` here identifies the model endpoint
+        being **attacked** (the target under test), not a backend LLM.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("mindgard")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Dispatch a red-team assessment to the mindgard driver and return findings.
+
+        Args:
+            question: Objective or prompt for the red-team assessment.
+            model: Model identifier of the target under test.
+            ollama_url: Base URL of the model endpoint being **attacked**.
+
+        Returns:
+            Formatted text summarising risk scores and vulnerabilities.
+        """
+        params: dict = {
+            "question": question,
+            "model": model,
+        }
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"MindgardDriverClient.ask: question={question!r} model={model!r} "
+            f"ollama_url={ollama_url or '<none>'}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("Mindgard driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("Mindgard driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("Mindgard driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/mindgard/__main__.py
+++ b/rune_bench/drivers/mindgard/__main__.py
@@ -47,6 +47,7 @@ def _handle_ask(params: dict) -> dict:
         a backend LLM.  Mindgard tests the target model for vulnerabilities.
     """
     model: str = params["model"]
+    question: str = params.get("question", "")
     ollama_url: str | None = params.get("ollama_url")
 
     api_key = os.environ.get("RUNE_MINDGARD_API_KEY", "")
@@ -62,7 +63,10 @@ def _handle_ask(params: dict) -> dict:
             "Install with: pip install mindgard"
         )
 
-    target_url = f"{ollama_url}/v1" if ollama_url else "http://localhost:11434/v1"
+    from rune_bench.common.http_client import normalize_url  # local import avoids circular dep
+
+    base = normalize_url(ollama_url, "Ollama") if ollama_url else "http://localhost:11434"
+    target_url = f"{base.rstrip('/')}/v1"
 
     cmd: list[str] = [
         "mindgard",
@@ -77,7 +81,7 @@ def _handle_ask(params: dict) -> dict:
     ]
 
     proc = subprocess.run(  # noqa: S603
-        cmd, capture_output=True, text=True, check=False,
+        cmd, capture_output=True, text=True, check=False, timeout=600,
     )
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
@@ -94,9 +98,13 @@ def _handle_ask(params: dict) -> dict:
     lines: list[str] = [
         f"Mindgard Red-Team Assessment — model: {model}",
         f"Target: {target_url}",
+    ]
+    if question:
+        lines.append(f"Red-team objective: {question}")
+    lines.extend([
         f"Overall risk score: {risk_score:.1f}",
         "",
-    ]
+    ])
     if vulnerabilities:
         lines.append(f"Vulnerabilities ({len(vulnerabilities)}):")
         for i, vuln in enumerate(vulnerabilities, 1):

--- a/rune_bench/drivers/mindgard/__main__.py
+++ b/rune_bench/drivers/mindgard/__main__.py
@@ -1,0 +1,161 @@
+"""Mindgard driver entry point — receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.mindgard
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str), ollama_url (str, optional)
+    result: {"answer": str, "risk_score": float, "vulnerabilities": list}
+
+info
+    params: (none)
+    result: {"name": "mindgard", "version": "1", "actions": [...]}
+
+.. note::
+
+    ``ollama_url`` in this driver refers to the model endpoint being **attacked**
+    (the target under test), NOT a backend LLM.  Mindgard tests YOUR models for
+    vulnerabilities such as jailbreaks, prompt injection, and data extraction.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _handle_ask(params: dict) -> dict:
+    """Run a Mindgard red-team assessment against the target model.
+
+    Reads ``RUNE_MINDGARD_API_KEY`` from the environment, invokes the
+    ``mindgard`` CLI binary, parses the JSON output and returns a summary
+    of risk scores and vulnerabilities.
+
+    .. note::
+
+        ``ollama_url`` here is the model endpoint being **attacked**, not
+        a backend LLM.  Mindgard tests the target model for vulnerabilities.
+    """
+    model: str = params["model"]
+    ollama_url: str | None = params.get("ollama_url")
+
+    api_key = os.environ.get("RUNE_MINDGARD_API_KEY", "")
+    if not api_key:
+        raise RuntimeError(
+            "RUNE_MINDGARD_API_KEY environment variable is not set. "
+            "Register at https://mindgard.ai/ for API access."
+        )
+
+    if shutil.which("mindgard") is None:
+        raise RuntimeError(
+            "mindgard CLI binary not found on PATH. "
+            "Install with: pip install mindgard"
+        )
+
+    target_url = f"{ollama_url}/v1" if ollama_url else "http://localhost:11434/v1"
+
+    cmd: list[str] = [
+        "mindgard",
+        "test",
+        "--target",
+        target_url,
+        "--model",
+        model,
+        "--api-key",
+        api_key,
+        "--json",
+    ]
+
+    proc = subprocess.run(  # noqa: S603
+        cmd, capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        raise RuntimeError(f"Mindgard CLI failed: {detail}")
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse Mindgard JSON output: {exc}") from exc
+
+    risk_score: float = float(data.get("risk_score", 0.0))
+    vulnerabilities: list = data.get("vulnerabilities", data.get("findings", []))
+
+    lines: list[str] = [
+        f"Mindgard Red-Team Assessment — model: {model}",
+        f"Target: {target_url}",
+        f"Overall risk score: {risk_score:.1f}",
+        "",
+    ]
+    if vulnerabilities:
+        lines.append(f"Vulnerabilities ({len(vulnerabilities)}):")
+        for i, vuln in enumerate(vulnerabilities, 1):
+            name = vuln.get("name", vuln.get("type", "Unknown"))
+            severity = vuln.get("severity", vuln.get("risk", "N/A"))
+            desc = vuln.get("description", vuln.get("detail", ""))
+            lines.append(f"  {i}. [{severity}] {name}")
+            if desc:
+                lines.append(f"     {desc}")
+        lines.append("")
+    else:
+        lines.append("No vulnerabilities found.")
+
+    summary = "\n".join(lines)
+
+    return {
+        "answer": summary,
+        "risk_score": risk_score,
+        "vulnerabilities": vulnerabilities,
+    }
+
+
+def _handle_info(_params: dict) -> dict:
+    return {"name": "mindgard", "version": "1", "actions": ["ask", "info"]}
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/mindgard/__main__.py
+++ b/rune_bench/drivers/mindgard/__main__.py
@@ -65,7 +65,7 @@ def _handle_ask(params: dict) -> dict:
 
     from rune_bench.common.http_client import normalize_url  # local import avoids circular dep
 
-    base = normalize_url(ollama_url, "Ollama") if ollama_url else "http://localhost:11434"
+    base = normalize_url(ollama_url, "Mindgard target") if ollama_url else "http://localhost:11434"
     target_url = f"{base.rstrip('/')}/v1"
 
     cmd: list[str] = [
@@ -80,8 +80,9 @@ def _handle_ask(params: dict) -> dict:
         "--json",
     ]
 
+    timeout = int(os.environ.get("RUNE_MINDGARD_TIMEOUT", "600"))
     proc = subprocess.run(  # noqa: S603
-        cmd, capture_output=True, text=True, check=False, timeout=600,
+        cmd, capture_output=True, text=True, check=False, timeout=timeout,
     )
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"

--- a/tests/test_elicit_driver.py
+++ b/tests/test_elicit_driver.py
@@ -198,3 +198,11 @@ def test_main_skips_empty_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.
     elicit_main.main()
 
     assert capsys.readouterr().out.strip() == ""
+
+
+def test_main_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that calling main() as a script works (module-level coverage)."""
+    # We just want to make sure it doesn't crash and returns after EOF on stdin.
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    elicit_main.main()

--- a/tests/test_elicit_driver.py
+++ b/tests/test_elicit_driver.py
@@ -1,0 +1,200 @@
+"""Tests for rune_bench.drivers.elicit.__main__ — the driver entry point.
+
+The driver calls the Elicit REST API via urllib.request.  All HTTP calls are
+monkeypatched so no real network access or API key is required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+import rune_bench.drivers.elicit.__main__ as elicit_main
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask
+# ---------------------------------------------------------------------------
+
+
+def _make_urlopen_mock(response_data: dict | list, status: int = 200):
+    """Return a mock for urllib.request.urlopen that yields *response_data*."""
+
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.status = status
+
+        def read(self) -> bytes:
+            return json.dumps(response_data).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def fake_urlopen(req, **kwargs):
+        return FakeResponse()
+
+    return fake_urlopen
+
+
+def test_handle_ask_returns_formatted_papers(monkeypatch: pytest.MonkeyPatch) -> None:
+    papers = [
+        {"title": "Paper A", "abstract": "Abstract A", "authors": "Smith", "year": "2024"},
+        {"title": "Paper B", "abstract": "Abstract B", "authors": "", "year": ""},
+    ]
+    monkeypatch.setenv("RUNE_ELICIT_API_KEY", "test-key-123")
+    monkeypatch.setattr(elicit_main.urllib.request, "urlopen", _make_urlopen_mock({"papers": papers}))
+
+    result = elicit_main._handle_ask({"question": "What is X?", "model": "unused"})
+
+    assert "Paper A" in result["answer"]
+    assert "Paper B" in result["answer"]
+    assert "Smith" in result["answer"]
+    assert "2024" in result["answer"]
+    assert len(result["papers"]) == 2
+
+
+def test_handle_ask_handles_list_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    papers = [{"title": "Only Paper", "abstract": "The abstract"}]
+    monkeypatch.setenv("RUNE_ELICIT_API_KEY", "key")
+    monkeypatch.setattr(elicit_main.urllib.request, "urlopen", _make_urlopen_mock(papers))
+
+    result = elicit_main._handle_ask({"question": "q", "model": "m"})
+
+    assert "Only Paper" in result["answer"]
+    assert len(result["papers"]) == 1
+
+
+def test_handle_ask_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_ELICIT_API_KEY", "key")
+    monkeypatch.setattr(elicit_main.urllib.request, "urlopen", _make_urlopen_mock({"papers": []}))
+
+    result = elicit_main._handle_ask({"question": "q", "model": "m"})
+
+    assert "No papers found" in result["answer"]
+    assert result["papers"] == []
+
+
+def test_handle_ask_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RUNE_ELICIT_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="RUNE_ELICIT_API_KEY"):
+        elicit_main._handle_ask({"question": "q", "model": "m"})
+
+
+def test_handle_ask_raises_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_ELICIT_API_KEY", "key")
+
+    import urllib.error
+
+    def fake_urlopen(req, **kwargs):
+        raise urllib.error.HTTPError(
+            url=req.full_url, code=401, msg="Unauthorized", hdrs={}, fp=io.BytesIO(b"bad key")
+        )
+
+    monkeypatch.setattr(elicit_main.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="Elicit API error.*401"):
+        elicit_main._handle_ask({"question": "q", "model": "m"})
+
+
+def test_handle_ask_raises_on_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_ELICIT_API_KEY", "key")
+
+    import urllib.error
+
+    def fake_urlopen(req, **kwargs):
+        raise urllib.error.URLError("Connection refused")
+
+    monkeypatch.setattr(elicit_main.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="connection error"):
+        elicit_main._handle_ask({"question": "q", "model": "m"})
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = elicit_main._handle_info({})
+    assert result["name"] == "elicit"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(elicit_main, "_handle_ask", lambda p: {"answer": "synthesis", "papers": []})
+    monkeypatch.setattr(
+        elicit_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "q", "model": "m"},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    elicit_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "synthesis"
+    assert response["id"] == "test-id"
+
+
+def test_main_processes_info_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(
+        elicit_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "info", "params": {}, "id": "i1"}) + "\n"),
+    )
+
+    elicit_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["name"] == "elicit"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        elicit_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    elicit_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+def test_main_handles_invalid_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(elicit_main.sys, "stdin", io.StringIO("not-json\n"))
+
+    elicit_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+
+
+def test_main_skips_empty_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(elicit_main.sys, "stdin", io.StringIO("\n\n   \n"))
+
+    elicit_main.main()
+
+    assert capsys.readouterr().out.strip() == ""

--- a/tests/test_elicit_mindgard_clients.py
+++ b/tests/test_elicit_mindgard_clients.py
@@ -1,0 +1,96 @@
+"""Tests for Elicit and Mindgard driver clients (__init__.py coverage)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rune_bench.drivers.elicit import ElicitDriverClient
+from rune_bench.drivers.mindgard import MindgardDriverClient
+
+
+class TestElicitDriverClient:
+    def test_ask_success(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": "literature review result"}
+        client = ElicitDriverClient(transport=transport)
+
+        result = client.ask("What is X?", "m", ollama_url="http://localhost:11434")
+        assert result == "literature review result"
+        transport.call.assert_called_once()
+
+    def test_ask_without_ollama_url(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": "ok"}
+        client = ElicitDriverClient(transport=transport)
+
+        result = client.ask("q", "m")
+        assert result == "ok"
+
+    def test_ask_missing_answer(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"other": "data"}
+        client = ElicitDriverClient(transport=transport)
+
+        with pytest.raises(RuntimeError, match="did not include an answer"):
+            client.ask("q", "m")
+
+    def test_ask_none_answer(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": None}
+        client = ElicitDriverClient(transport=transport)
+
+        with pytest.raises(RuntimeError, match="empty answer"):
+            client.ask("q", "m")
+
+    def test_ask_empty_answer(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": ""}
+        client = ElicitDriverClient(transport=transport)
+
+        with pytest.raises(RuntimeError, match="empty answer"):
+            client.ask("q", "m")
+
+
+class TestMindgardDriverClient:
+    def test_ask_success(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": "security assessment"}
+        client = MindgardDriverClient(transport=transport)
+
+        result = client.ask("test the model", "llama3:8b", ollama_url="http://target:11434")
+        assert result == "security assessment"
+        transport.call.assert_called_once()
+
+    def test_ask_without_ollama_url(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": "ok"}
+        client = MindgardDriverClient(transport=transport)
+
+        result = client.ask("q", "m")
+        assert result == "ok"
+
+    def test_ask_missing_answer(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"other": "data"}
+        client = MindgardDriverClient(transport=transport)
+
+        with pytest.raises(RuntimeError, match="did not include an answer"):
+            client.ask("q", "m")
+
+    def test_ask_none_answer(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": None}
+        client = MindgardDriverClient(transport=transport)
+
+        with pytest.raises(RuntimeError, match="empty answer"):
+            client.ask("q", "m")
+
+    def test_ask_empty_answer(self) -> None:
+        transport = MagicMock()
+        transport.call.return_value = {"answer": ""}
+        client = MindgardDriverClient(transport=transport)
+
+        with pytest.raises(RuntimeError, match="empty answer"):
+            client.ask("q", "m")

--- a/tests/test_mindgard_driver.py
+++ b/tests/test_mindgard_driver.py
@@ -32,7 +32,7 @@ def _patch_mindgard(monkeypatch, stdout_data: dict, returncode: int = 0, stderr:
 
     captured: dict = {}
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output=False, text=False, check=False, **kwargs):
         captured["cmd"] = cmd
         return subprocess.CompletedProcess(
             cmd, returncode, stdout=json.dumps(stdout_data), stderr=stderr,

--- a/tests/test_mindgard_driver.py
+++ b/tests/test_mindgard_driver.py
@@ -1,0 +1,254 @@
+"""Tests for rune_bench.drivers.mindgard.__main__ — the driver entry point.
+
+The driver calls the ``mindgard`` CLI as a subprocess.  subprocess.run and
+shutil.which are monkeypatched throughout so no mindgard installation is
+required.
+
+Special attention is paid to the **inverted ollama_url semantics**: in this
+driver ``ollama_url`` is the model endpoint being *attacked* (the target under
+test), not a backend LLM.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+
+import pytest
+
+import rune_bench.drivers.mindgard.__main__ as mindgard_main
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask
+# ---------------------------------------------------------------------------
+
+
+def _patch_mindgard(monkeypatch, stdout_data: dict, returncode: int = 0, stderr: str = ""):
+    """Patch subprocess.run and shutil.which for mindgard tests."""
+    monkeypatch.setenv("RUNE_MINDGARD_API_KEY", "test-api-key")
+    monkeypatch.setattr(mindgard_main.shutil, "which", lambda name: "/usr/bin/mindgard")
+
+    captured: dict = {}
+
+    def fake_run(cmd, capture_output, text, check):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd, returncode, stdout=json.dumps(stdout_data), stderr=stderr,
+        )
+
+    monkeypatch.setattr(mindgard_main.subprocess, "run", fake_run)
+    return captured
+
+
+def test_handle_ask_calls_mindgard_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {
+        "risk_score": 7.5,
+        "vulnerabilities": [
+            {"name": "Jailbreak", "severity": "HIGH", "description": "Model can be jailbroken"},
+        ],
+    }
+    captured = _patch_mindgard(monkeypatch, data)
+
+    result = mindgard_main._handle_ask({
+        "question": "test the model",
+        "model": "llama3:8b",
+        "ollama_url": "http://target:11434",
+    })
+
+    # Verify CLI command structure
+    assert "mindgard" in captured["cmd"]
+    assert "--target" in captured["cmd"]
+    assert "http://target:11434/v1" in captured["cmd"]
+    assert "--model" in captured["cmd"]
+    assert "llama3:8b" in captured["cmd"]
+    assert "--api-key" in captured["cmd"]
+    assert "test-api-key" in captured["cmd"]
+    assert "--json" in captured["cmd"]
+
+    # Verify result
+    assert result["risk_score"] == 7.5
+    assert len(result["vulnerabilities"]) == 1
+    assert "Jailbreak" in result["answer"]
+    assert "7.5" in result["answer"]
+
+
+def test_handle_ask_inverted_ollama_url_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ollama_url is the ATTACK TARGET, not the LLM backend.
+
+    The URL should appear as --target with /v1 appended, meaning it points
+    to the model endpoint being tested for vulnerabilities.
+    """
+    captured = _patch_mindgard(monkeypatch, {"risk_score": 0.0, "vulnerabilities": []})
+
+    mindgard_main._handle_ask({
+        "question": "red team this",
+        "model": "gpt-4",
+        "ollama_url": "http://victim-model:8080",
+    })
+
+    target_idx = captured["cmd"].index("--target")
+    target_url = captured["cmd"][target_idx + 1]
+    assert target_url == "http://victim-model:8080/v1"
+
+
+def test_handle_ask_default_target_without_ollama_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _patch_mindgard(monkeypatch, {"risk_score": 0.0, "vulnerabilities": []})
+
+    mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+    target_idx = captured["cmd"].index("--target")
+    assert captured["cmd"][target_idx + 1] == "http://localhost:11434/v1"
+
+
+def test_handle_ask_no_vulnerabilities(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_mindgard(monkeypatch, {"risk_score": 0.0, "vulnerabilities": []})
+
+    result = mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+    assert "No vulnerabilities found" in result["answer"]
+    assert result["risk_score"] == 0.0
+    assert result["vulnerabilities"] == []
+
+
+def test_handle_ask_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RUNE_MINDGARD_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="RUNE_MINDGARD_API_KEY"):
+        mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+
+def test_handle_ask_raises_without_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_MINDGARD_API_KEY", "key")
+    monkeypatch.setattr(mindgard_main.shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="mindgard CLI binary not found"):
+        mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+
+def test_handle_ask_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_MINDGARD_API_KEY", "key")
+    monkeypatch.setattr(mindgard_main.shutil, "which", lambda name: "/usr/bin/mindgard")
+    monkeypatch.setattr(
+        mindgard_main.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 1, stdout="", stderr="auth failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="auth failed"):
+        mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+
+def test_handle_ask_raises_on_invalid_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_MINDGARD_API_KEY", "key")
+    monkeypatch.setattr(mindgard_main.shutil, "which", lambda name: "/usr/bin/mindgard")
+    monkeypatch.setattr(
+        mindgard_main.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0, stdout="not json", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError, match="parse Mindgard JSON"):
+        mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+
+def test_handle_ask_uses_findings_key_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Some Mindgard versions return 'findings' instead of 'vulnerabilities'."""
+    _patch_mindgard(monkeypatch, {
+        "risk_score": 3.0,
+        "findings": [{"type": "Prompt Injection", "risk": "MEDIUM", "detail": "Injected"}],
+    })
+
+    result = mindgard_main._handle_ask({"question": "q", "model": "m"})
+
+    assert len(result["vulnerabilities"]) == 1
+    assert "Prompt Injection" in result["answer"]
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = mindgard_main._handle_info({})
+    assert result["name"] == "mindgard"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(
+        mindgard_main,
+        "_handle_ask",
+        lambda p: {"answer": "summary", "risk_score": 1.0, "vulnerabilities": []},
+    )
+    monkeypatch.setattr(
+        mindgard_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "q", "model": "m"},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    mindgard_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "summary"
+    assert response["id"] == "test-id"
+
+
+def test_main_processes_info_request(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(
+        mindgard_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "info", "params": {}, "id": "i1"}) + "\n"),
+    )
+
+    mindgard_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["name"] == "mindgard"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        mindgard_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    mindgard_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+def test_main_handles_invalid_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(mindgard_main.sys, "stdin", io.StringIO("not-json\n"))
+
+    mindgard_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+
+
+def test_main_skips_empty_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setattr(mindgard_main.sys, "stdin", io.StringIO("\n\n   \n"))
+
+    mindgard_main.main()
+
+    assert capsys.readouterr().out.strip() == ""

--- a/tests/test_mindgard_driver.py
+++ b/tests/test_mindgard_driver.py
@@ -252,3 +252,11 @@ def test_main_skips_empty_lines(monkeypatch: pytest.MonkeyPatch, capsys: pytest.
     mindgard_main.main()
 
     assert capsys.readouterr().out.strip() == ""
+
+
+def test_main_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that calling main() as a script works (module-level coverage)."""
+    # We just want to make sure it doesn't crash and returns after EOF on stdin.
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    mindgard_main.main()


### PR DESCRIPTION
## Summary
- Implement **Elicit driver** (#66): Research/literature review via the Elicit REST API (`POST /api/v1/search`), using `urllib.request`. Auth via `RUNE_ELICIT_API_KEY`. Returns formatted paper results with title, abstract, authors, year.
- Implement **Mindgard driver** (#71): Cybersec/AI red-teaming via the `mindgard` CLI (`subprocess.run`). Auth via `RUNE_MINDGARD_API_KEY`. Returns risk scores and vulnerability findings. **Note:** `ollama_url` is the attack target, not the LLM backend.
- Both drivers follow the Holmes wire protocol pattern (JSON stdin/stdout, `ask`/`info` actions).
- Agent stubs (`ElicitRunner`, `MindgardRunner`) now alias the respective driver clients.

Closes #66, closes #71

## Test plan
- [x] `pytest tests/test_elicit_driver.py -v` — 12 tests (API mock, error paths, wire protocol)
- [x] `pytest tests/test_mindgard_driver.py -v` — 15 tests (subprocess mock, inverted ollama_url semantics, error paths, wire protocol)
- [ ] Manual: set `RUNE_ELICIT_API_KEY` and run a search query end-to-end
- [ ] Manual: install `mindgard` CLI, set `RUNE_MINDGARD_API_KEY`, run against a test model endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)