### PR TITLE
feat(drivers): implement PagerDuty AI SRE agent driver

### DIFF
--- a/rune_bench/drivers/pagerduty/__init__.py
+++ b/rune_bench/drivers/pagerduty/__init__.py
@@ -25,11 +25,11 @@ class PagerDutyDriverClient:
 
     def __init__(
         self,
-        kubeconfig: Path,
+        kubeconfig: Path | None = None,
         *,
         transport: DriverTransport | None = None,
     ) -> None:
-        if not kubeconfig.exists():
+        if kubeconfig is not None and not kubeconfig.exists():
             raise FileNotFoundError(f"kubeconfig not found: {kubeconfig}")
         self._kubeconfig = kubeconfig
         self._transport: DriverTransport = transport or make_driver_transport("pagerduty")

--- a/rune_bench/drivers/pagerduty/__init__.py
+++ b/rune_bench/drivers/pagerduty/__init__.py
@@ -3,7 +3,7 @@
 This is a hybrid agent: PagerDuty REST API for data retrieval plus Ollama for
 triage synthesis.  The driver process
 (``rune_bench.drivers.pagerduty.__main__``) calls the PagerDuty REST v2 API
-via :mod:`urllib.request` and therefore requires no external dependencies
+via :func:`~rune_bench.common.http_client.make_http_request` and therefore requires no external dependencies
 beyond a valid ``RUNE_PAGERDUTY_API_KEY`` env var.
 """
 
@@ -50,6 +50,8 @@ class PagerDutyDriverClient:
             "question": question,
             "model": model.strip(),
         }
+        if self._kubeconfig is not None:
+            params["kubeconfig_path"] = str(self._kubeconfig)
         if ollama_url:
             params["ollama_url"] = ollama_url
 

--- a/rune_bench/drivers/pagerduty/__main__.py
+++ b/rune_bench/drivers/pagerduty/__main__.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 import json
 import os
 import sys
-import urllib.request
+
+from rune_bench.common.http_client import make_http_request, normalize_url
 
 _PAGERDUTY_API_BASE = "https://api.pagerduty.com"
 
@@ -33,15 +34,15 @@ _PAGERDUTY_API_BASE = "https://api.pagerduty.com"
 def _pd_request(path: str, api_key: str) -> dict:
     """Make an authenticated GET request to the PagerDuty REST v2 API."""
     url = f"{_PAGERDUTY_API_BASE}{path}"
-    req = urllib.request.Request(
+    return make_http_request(
         url,
+        method="GET",
+        action="fetch PagerDuty incidents",
         headers={
             "Authorization": f"Token token={api_key}",
-            "Content-Type": "application/json",
+            "Accept": "application/vnd.pagerduty+json;version=2",
         },
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-        return json.loads(resp.read().decode())
 
 
 def _fetch_open_incidents(api_key: str) -> list[dict]:
@@ -86,16 +87,14 @@ def _format_incident_data(incidents: list[dict], alerts_by_incident: dict[str, l
 
 def _call_ollama(prompt: str, model: str, ollama_url: str) -> str:
     """Call the Ollama /api/generate endpoint for triage synthesis."""
-    url = f"{ollama_url.rstrip('/')}/api/generate"
-    payload = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode()
-    req = urllib.request.Request(
+    base = normalize_url(ollama_url, "Ollama")
+    url = f"{base.rstrip('/')}/api/generate"
+    result = make_http_request(
         url,
-        data=payload,
-        headers={"Content-Type": "application/json"},
         method="POST",
+        payload={"model": model, "prompt": prompt, "stream": False},
+        action="synthesize via Ollama",
     )
-    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
-        result = json.loads(resp.read().decode())
     return result.get("response", "")
 
 

--- a/rune_bench/drivers/pagerduty/__main__.py
+++ b/rune_bench/drivers/pagerduty/__main__.py
@@ -15,6 +15,9 @@ ask
             ollama_url (str, optional)
     result: {"answer": str, "incidents": list}
 
+    .. note:: The ``triage_actions`` field is not yet included in the result.
+       A future version will add recommended actions alongside the triage summary.
+
 info
     params: (none)
     result: {"name": "pagerduty", "version": "1", "actions": [...]}
@@ -31,13 +34,17 @@ from rune_bench.common.http_client import make_http_request, normalize_url
 _PAGERDUTY_API_BASE = "https://api.pagerduty.com"
 
 
-def _pd_request(path: str, api_key: str) -> dict:
+def _pd_request(path: str, api_key: str, *, action: str | None = None) -> dict:
     """Make an authenticated GET request to the PagerDuty REST v2 API."""
+    if action is None:
+        # Derive a human-readable action from the endpoint path.
+        segment = path.lstrip("/").split("?")[0].replace("/", " ")
+        action = f"fetch PagerDuty {segment}"
     url = f"{_PAGERDUTY_API_BASE}{path}"
     return make_http_request(
         url,
         method="GET",
-        action="fetch PagerDuty incidents",
+        action=action,
         headers={
             "Authorization": f"Token token={api_key}",
             "Accept": "application/vnd.pagerduty+json;version=2",
@@ -46,12 +53,25 @@ def _pd_request(path: str, api_key: str) -> dict:
 
 
 def _fetch_open_incidents(api_key: str) -> list[dict]:
-    """Fetch triggered and acknowledged incidents from PagerDuty."""
-    data = _pd_request(
-        "/incidents?statuses[]=triggered&statuses[]=acknowledged",
-        api_key,
-    )
-    return data.get("incidents", [])
+    """Fetch triggered and acknowledged incidents from PagerDuty.
+
+    Paginates through all result pages using the ``more`` flag and ``offset``
+    parameter returned by the PagerDuty REST v2 API.
+    """
+    all_incidents: list[dict] = []
+    limit = 25
+    offset = 0
+    while True:
+        data = _pd_request(
+            f"/incidents?statuses[]=triggered&statuses[]=acknowledged&limit={limit}&offset={offset}",
+            api_key,
+            action="fetch PagerDuty incidents",
+        )
+        all_incidents.extend(data.get("incidents", []))
+        if not data.get("more", False):
+            break
+        offset += limit
+    return all_incidents
 
 
 def _fetch_alerts_for_incident(incident_id: str, api_key: str) -> list[dict]:
@@ -111,6 +131,10 @@ def _handle_ask(params: dict) -> dict:
         )
 
     incidents = _fetch_open_incidents(api_key)
+
+    # Short-circuit: skip alert fetching and LLM synthesis when there are no incidents.
+    if not incidents:
+        return {"answer": "No open incidents found.", "incidents": []}
 
     alerts_by_incident: dict[str, list[dict]] = {}
     for inc in incidents:

--- a/tests/test_pagerduty_driver.py
+++ b/tests/test_pagerduty_driver.py
@@ -89,12 +89,17 @@ def test_handle_ask_raises_when_api_key_missing(monkeypatch: pytest.MonkeyPatch)
 def test_handle_ask_fetches_incidents(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
 
-    mock = _mock_urlopen({
+    responses = {
         "/incidents?statuses": {"incidents": _SAMPLE_INCIDENTS},
         "/incidents/P1234/alerts": {"alerts": _SAMPLE_ALERTS},
         "/incidents/P5678/alerts": {"alerts": []},
-    })
-    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+    }
+    def fake_request(url, **kwargs):
+        for key, payload in responses.items():
+            if key in url:
+                return payload
+        raise RuntimeError(f"Unmocked URL: {url}")
+    monkeypatch.setattr(pd_main, "make_http_request", fake_request)
 
     result = pd_main._handle_ask({"question": "triage", "model": ""})
 
@@ -113,13 +118,18 @@ def test_handle_ask_fetches_incidents(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_handle_ask_calls_ollama_for_synthesis(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
 
-    mock = _mock_urlopen({
+    responses = {
         "/incidents?statuses": {"incidents": _SAMPLE_INCIDENTS},
         "/incidents/P1234/alerts": {"alerts": _SAMPLE_ALERTS},
         "/incidents/P5678/alerts": {"alerts": []},
         "/api/generate": {"response": "Triage: CPU incident is P1, disk is P2."},
-    })
-    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+    }
+    def fake_request(url, **kwargs):
+        for key, payload in responses.items():
+            if key in url:
+                return payload
+        raise RuntimeError(f"Unmocked URL: {url}")
+    monkeypatch.setattr(pd_main, "make_http_request", fake_request)
 
     result = pd_main._handle_ask({
         "question": "what should I fix first?",
@@ -139,12 +149,17 @@ def test_handle_ask_calls_ollama_for_synthesis(monkeypatch: pytest.MonkeyPatch) 
 def test_handle_ask_returns_raw_data_without_llm(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
 
-    mock = _mock_urlopen({
+    responses = {
         "/incidents?statuses": {"incidents": _SAMPLE_INCIDENTS},
         "/incidents/P1234/alerts": {"alerts": _SAMPLE_ALERTS},
         "/incidents/P5678/alerts": {"alerts": []},
-    })
-    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+    }
+    def fake_request(url, **kwargs):
+        for key, payload in responses.items():
+            if key in url:
+                return payload
+        raise RuntimeError(f"Unmocked URL: {url}")
+    monkeypatch.setattr(pd_main, "make_http_request", fake_request)
 
     # No model or ollama_url — should return formatted raw data
     result = pd_main._handle_ask({"question": "triage", "model": ""})
@@ -163,10 +178,11 @@ def test_handle_ask_returns_raw_data_without_llm(monkeypatch: pytest.MonkeyPatch
 def test_handle_ask_no_incidents(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RUNE_PAGERDUTY_API_KEY", "test-token")
 
-    mock = _mock_urlopen({
-        "/incidents?statuses": {"incidents": []},
-    })
-    monkeypatch.setattr(pd_main.urllib.request, "urlopen", mock)
+    def fake_request(url, **kwargs):
+        if "/incidents" in url:
+            return {"incidents": []}
+        raise RuntimeError(f"Unmocked URL: {url}")
+    monkeypatch.setattr(pd_main, "make_http_request", fake_request)
 
     result = pd_main._handle_ask({"question": "any issues?", "model": ""})
 

--- a/tests/test_pagerduty_driver.py
+++ b/tests/test_pagerduty_driver.py
@@ -44,32 +44,6 @@ _SAMPLE_ALERTS = [
 ]
 
 
-def _mock_urlopen(responses: dict):
-    """Return a context-manager factory that returns canned JSON responses keyed by URL substring."""
-
-    class FakeResponse:
-        def __init__(self, data: bytes) -> None:
-            self._data = data
-
-        def read(self) -> bytes:
-            return self._data
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *a):
-            pass
-
-    def _urlopen(req, *args, **kwargs):
-        url = req.full_url if hasattr(req, "full_url") else str(req)
-        for key, payload in responses.items():
-            if key in url:
-                return FakeResponse(json.dumps(payload).encode())
-        raise RuntimeError(f"Unmocked URL: {url}")
-
-    return _urlopen
-
-
 # ---------------------------------------------------------------------------
 # _handle_ask — missing API key
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Implement PagerDuty driver (`rune_bench/drivers/pagerduty/`) as a hybrid agent: PagerDuty REST v2 API for incident data + Ollama for triage synthesis
- Replace stub in `rune_bench/agents/sre/pagerduty.py` with re-export of `PagerDutyDriverClient`
- Add 12 tests covering missing API key, mocked HTTP fetching, Ollama synthesis, raw-data fallback, and client transport

## Test plan
- [x] `python -m pytest tests/test_pagerduty_driver.py -v` — 12/12 passing
- [ ] Integration test with live PagerDuty API key and Ollama instance

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)