### PR TITLE
feat(drivers): add PentestGPT and BurpGPT cybersec agent drivers

### DIFF
--- a/rune_bench/agents/cybersec/burpgpt.py
+++ b/rune_bench/agents/cybersec/burpgpt.py
@@ -1,4 +1,4 @@
-"""BurpGPT agentic runner stub.
+"""BurpGPT agentic runner -- delegates to the burpgpt driver.
 
 Scope:      Cybersec  |  Rank 4  |  Rating 3.5
 Capability: Autonomous web vulnerability scanning via LLM.
@@ -21,16 +21,18 @@ Implementation notes:
 - `model` and `ollama_url` configure the LLM backend within Burp/BurpGPT.
 """
 
+from rune_bench.drivers.burpgpt import BurpGPTDriverClient
+
 
 class BurpGPTRunner:
-    """Cybersec agent: autonomous web vulnerability scanning via BurpGPT + LLM."""
+    """Cybersec agent: autonomous web vulnerability scanning via BurpGPT + LLM.
+
+    Delegates to :class:`~rune_bench.drivers.burpgpt.BurpGPTDriverClient`.
+    """
 
     def __init__(self) -> None:
-        pass
+        self._client = BurpGPTDriverClient()
 
     def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
         """Run a BurpGPT-assisted scan and return identified vulnerabilities."""
-        raise NotImplementedError(
-            "BurpGPTRunner is not yet implemented. "
-            "See https://github.com/v87/burpgpt — note: requires Burp Suite installation."
-        )
+        return self._client.ask(question, model, ollama_url)

--- a/rune_bench/agents/cybersec/pentestgpt.py
+++ b/rune_bench/agents/cybersec/pentestgpt.py
@@ -1,4 +1,4 @@
-"""PentestGPT agentic runner stub.
+"""PentestGPT agentic runner -- delegates to the pentestgpt driver.
 
 Scope:      Cybersec  |  Rank 1  |  Rating 4.5
 Capability: Automates penetration testing workflows.
@@ -21,16 +21,18 @@ Implementation notes:
 - Note: only run against systems you own or have explicit written permission to test.
 """
 
+from rune_bench.drivers.pentestgpt import PentestGPTDriverClient
+
 
 class PentestGPTRunner:
-    """Cybersec agent: automated penetration testing workflow orchestration."""
+    """Cybersec agent: automated penetration testing workflow orchestration.
+
+    Delegates to :class:`~rune_bench.drivers.pentestgpt.PentestGPTDriverClient`.
+    """
 
     def __init__(self) -> None:
-        pass
+        self._client = PentestGPTDriverClient()
 
     def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
         """Run a PentestGPT session and return the findings/recommendations."""
-        raise NotImplementedError(
-            "PentestGPTRunner is not yet implemented. "
-            "See https://github.com/GreyD0ne/PentestGPT for details."
-        )
+        return self._client.ask(question, model, ollama_url)

--- a/rune_bench/drivers/burpgpt/__init__.py
+++ b/rune_bench/drivers/burpgpt/__init__.py
@@ -1,0 +1,71 @@
+"""BurpGPT driver client -- delegates web vulnerability scanning to the burpgpt driver process.
+
+The driver process (``rune_bench.drivers.burpgpt.__main__``) talks to the
+Burp Suite REST API to launch scans and retrieve findings.  Burp Suite Pro
+must be running locally (or remotely) with the REST API enabled.
+
+Configuration:
+    RUNE_BURPGPT_BURP_API_URL  Base URL of the Burp REST API
+                                (default: http://localhost:1337)
+
+Security notice: only scan targets you own or have explicit written
+authorization to test.
+"""
+
+from __future__ import annotations
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class BurpGPTDriverClient:
+    """Run web vulnerability scans by delegating to the burpgpt driver.
+
+    Unlike Holmes, BurpGPT does **not** require a kubeconfig -- it operates
+    against the Burp Suite REST API.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("burpgpt")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Dispatch a scan request to the burpgpt driver and return findings.
+
+        Args:
+            question: Target URL or scan objective.
+            model: Ollama model identifier (currently unused by BurpGPT but
+                   kept for interface consistency).
+            ollama_url: Base URL of the Ollama server (currently unused).
+
+        Returns:
+            Formatted vulnerability findings from the Burp scan.
+        """
+        params: dict = {
+            "question": question,
+            "model": model.strip(),
+        }
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"BurpGPTDriverClient.ask: question={question!r} model={model!r} "
+            f"ollama_url={ollama_url or '<none>'}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("BurpGPT driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("BurpGPT driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("BurpGPT driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/burpgpt/__main__.py
+++ b/rune_bench/drivers/burpgpt/__main__.py
@@ -31,11 +31,30 @@ import os
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 _DEFAULT_BURP_API_URL = "http://localhost:1337"
 _POLL_INTERVAL_SECONDS = 2
 _SCAN_TIMEOUT_SECONDS = 300
+
+
+def _check_authorization(target: str) -> None:
+    """Raise RuntimeError if target is not in RUNE_BURPGPT_ALLOWED_TARGETS allowlist.
+
+    Reads RUNE_BURPGPT_ALLOWED_TARGETS (comma-separated hostnames).
+    If the env var is empty/unset, the check is skipped (trust the caller).
+    """
+    allowlist_raw = os.environ.get("RUNE_BURPGPT_ALLOWED_TARGETS", "").strip()
+    if not allowlist_raw:
+        return
+    allowed = {h.strip().lower() for h in allowlist_raw.split(",") if h.strip()}
+    host = urllib.parse.urlparse(target).hostname or target.lower()
+    if host not in allowed:
+        raise RuntimeError(
+            f"Target {host!r} is not in RUNE_BURPGPT_ALLOWED_TARGETS. "
+            "Add it to the allowlist before running a scan."
+        )
 
 
 def _burp_request(
@@ -51,9 +70,16 @@ def _burp_request(
         method=method,
     )
     try:
-        with urllib.request.urlopen(req) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
             raw = resp.read().decode()
-            return json.loads(raw) if raw.strip() else {}
+            if not raw.strip():
+                return {}
+            result = json.loads(raw)
+            if not isinstance(result, dict):
+                raise RuntimeError(
+                    f"Burp API returned unexpected response type: {type(result).__name__}"
+                )
+            return result
     except urllib.error.URLError as exc:
         raise RuntimeError(
             f"Cannot connect to Burp Suite REST API at {burp_url}. "
@@ -101,6 +127,8 @@ def _handle_ask(params: dict) -> dict:
 
     burp_url = os.environ.get("RUNE_BURPGPT_BURP_API_URL", _DEFAULT_BURP_API_URL)
     target_url = _extract_target_url(question)
+
+    _check_authorization(target_url)
 
     # Start a scan
     scan_response = _burp_request(

--- a/rune_bench/drivers/burpgpt/__main__.py
+++ b/rune_bench/drivers/burpgpt/__main__.py
@@ -1,0 +1,186 @@
+"""BurpGPT driver entry point -- receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.burpgpt
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str), ollama_url (str, optional)
+    result: {"answer": str, "findings": list}
+
+info
+    params: (none)
+    result: {"name": "burpgpt", "version": "1", "actions": [...]}
+
+Security notice
+---------------
+Only scan targets you own or have explicit written authorization to test.
+Burp Suite Pro must be running with the REST API enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+_DEFAULT_BURP_API_URL = "http://localhost:1337"
+_POLL_INTERVAL_SECONDS = 2
+_SCAN_TIMEOUT_SECONDS = 300
+
+
+def _burp_request(
+    method: str, path: str, burp_url: str, *, data: dict | None = None
+) -> dict:
+    """Make a request to the Burp Suite REST API."""
+    url = f"{burp_url.rstrip('/')}{path}"
+    body = json.dumps(data).encode() if data is not None else None
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"} if body else {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            raw = resp.read().decode()
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Cannot connect to Burp Suite REST API at {burp_url}. "
+            f"Ensure Burp Suite Pro is running with the REST API enabled. "
+            f"Detail: {exc}"
+        ) from exc
+
+
+def _extract_target_url(question: str) -> str:
+    """Extract a URL from the question text.
+
+    Looks for the first token that starts with ``http://`` or ``https://``.
+    Falls back to the whole question string (the Burp API will validate it).
+    """
+    for token in question.split():
+        if token.startswith(("http://", "https://")):
+            return token.strip("\"'<>")
+    return question.strip()
+
+
+def _format_findings(findings: list[dict]) -> str:
+    """Format scan findings as human-readable text."""
+    if not findings:
+        return "Scan completed. No vulnerabilities found."
+
+    lines: list[str] = [f"Found {len(findings)} issue(s):\n"]
+    for i, finding in enumerate(findings, 1):
+        name = finding.get("name", finding.get("type", "Unknown"))
+        severity = finding.get("severity", "info")
+        confidence = finding.get("confidence", "unknown")
+        path = finding.get("path", finding.get("url", "N/A"))
+        description = finding.get("description", "")
+        lines.append(f"{i}. [{severity.upper()}] {name}")
+        lines.append(f"   Path: {path}")
+        lines.append(f"   Confidence: {confidence}")
+        if description:
+            lines.append(f"   Description: {description[:200]}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _handle_ask(params: dict) -> dict:
+    question: str = params["question"]
+
+    burp_url = os.environ.get("RUNE_BURPGPT_BURP_API_URL", _DEFAULT_BURP_API_URL)
+    target_url = _extract_target_url(question)
+
+    # Start a scan
+    scan_response = _burp_request(
+        "POST", "/v0.1/scan", burp_url, data={"urls": [target_url]}
+    )
+    scan_id = scan_response.get("task_id") or scan_response.get("scan_id")
+    if scan_id is None:
+        # Some Burp versions return the scan id at top level
+        scan_id = scan_response.get("id")
+    if scan_id is None:
+        raise RuntimeError(
+            f"Burp API did not return a scan ID. Response: {scan_response}"
+        )
+
+    # Poll for completion
+    deadline = time.monotonic() + _SCAN_TIMEOUT_SECONDS
+    scan_result: dict = {}
+    while time.monotonic() < deadline:
+        scan_result = _burp_request("GET", f"/v0.1/scan/{scan_id}", burp_url)
+        status = scan_result.get("status", "").lower()
+        if status in ("succeeded", "finished", "complete"):
+            break
+        if status in ("failed", "error"):
+            raise RuntimeError(
+                f"Burp scan {scan_id} failed: {scan_result.get('message', status)}"
+            )
+        time.sleep(_POLL_INTERVAL_SECONDS)
+    else:
+        raise RuntimeError(
+            f"Burp scan {scan_id} timed out after {_SCAN_TIMEOUT_SECONDS}s."
+        )
+
+    # Extract findings
+    findings: list[dict] = scan_result.get("issue_events", [])
+    if not findings:
+        findings = scan_result.get("issues", [])
+    if not findings:
+        findings = scan_result.get("findings", [])
+
+    answer = _format_findings(findings)
+    return {"answer": answer, "findings": findings}
+
+
+def _handle_info(_params: dict) -> dict:
+    return {"name": "burpgpt", "version": "1", "actions": ["ask", "info"]}
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/pentestgpt/__init__.py
+++ b/rune_bench/drivers/pentestgpt/__init__.py
@@ -35,17 +35,18 @@ class PentestGPTDriverClient:
         Args:
             question: Natural-language pentest objective or question.
             model: Ollama model identifier (e.g. ``"llama3.1:8b"``).
-            ollama_url: Base URL of the Ollama server (optional).
+            ollama_url: Base URL of the Ollama server. Defaults to
+                ``"http://localhost:11434"`` when not provided.
 
         Returns:
             PentestGPT's textual answer with step-by-step guidance.
         """
+        effective_ollama_url = (ollama_url or "http://localhost:11434").strip()
         params: dict = {
             "question": question,
             "model": model.strip(),
+            "ollama_url": effective_ollama_url,
         }
-        if ollama_url:
-            params["ollama_url"] = ollama_url
 
         debug_log(
             f"PentestGPTDriverClient.ask: question={question!r} model={model!r} "

--- a/rune_bench/drivers/pentestgpt/__init__.py
+++ b/rune_bench/drivers/pentestgpt/__init__.py
@@ -1,0 +1,67 @@
+"""PentestGPT driver client -- delegates pentest queries to the pentestgpt driver process.
+
+The driver process (``rune_bench.drivers.pentestgpt.__main__``) calls the
+Ollama OpenAI-compatible chat API with a pentest-focused system prompt,
+replicating PentestGPT's core behaviour without requiring the pentestgpt
+package to be installed in the RUNE core process.
+
+Security notice: only use against systems you own or have explicit written
+permission to test.
+"""
+
+from __future__ import annotations
+
+from rune_bench.debug import debug_log
+from rune_bench.drivers import DriverTransport, make_driver_transport
+
+
+class PentestGPTDriverClient:
+    """Automate penetration testing queries by delegating to the pentestgpt driver.
+
+    Unlike Holmes or PagerDuty drivers, PentestGPT does **not** require a
+    kubeconfig -- it operates purely against the Ollama LLM backend.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: DriverTransport | None = None,
+    ) -> None:
+        self._transport: DriverTransport = transport or make_driver_transport("pentestgpt")
+
+    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+        """Dispatch a pentest question to the pentestgpt driver and return the answer.
+
+        Args:
+            question: Natural-language pentest objective or question.
+            model: Ollama model identifier (e.g. ``"llama3.1:8b"``).
+            ollama_url: Base URL of the Ollama server (optional).
+
+        Returns:
+            PentestGPT's textual answer with step-by-step guidance.
+        """
+        params: dict = {
+            "question": question,
+            "model": model.strip(),
+        }
+        if ollama_url:
+            params["ollama_url"] = ollama_url
+
+        debug_log(
+            f"PentestGPTDriverClient.ask: question={question!r} model={model!r} "
+            f"ollama_url={ollama_url or '<none>'}"
+        )
+        result = self._transport.call("ask", params)
+
+        if "answer" not in result:
+            raise RuntimeError("PentestGPT driver response did not include an answer.")
+
+        answer = result["answer"]
+        if answer is None:
+            raise RuntimeError("PentestGPT driver returned an empty answer.")
+
+        answer_text = str(answer)
+        if not answer_text:
+            raise RuntimeError("PentestGPT driver returned an empty answer.")
+
+        return answer_text

--- a/rune_bench/drivers/pentestgpt/__main__.py
+++ b/rune_bench/drivers/pentestgpt/__main__.py
@@ -1,0 +1,129 @@
+"""PentestGPT driver entry point -- receives JSON actions on stdin, writes results to stdout.
+
+Run as::
+
+    python -m rune_bench.drivers.pentestgpt
+
+Wire protocol (v1):
+    stdin  line: {"action": "ACTION", "params": {...}, "id": "UUID"}
+    stdout line: {"status": "ok"|"error", "result": {...}, "error": "...", "id": "UUID"}
+
+Supported actions
+-----------------
+ask
+    params: question (str), model (str), ollama_url (str, optional)
+    result: {"answer": str}
+
+info
+    params: (none)
+    result: {"name": "pentestgpt", "version": "1", "actions": [...]}
+
+Security notice
+---------------
+This driver is intended for authorized penetration testing only.  Never use
+against systems without explicit written permission from the system owner.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+
+_SYSTEM_PROMPT = (
+    "You are PentestGPT, an automated penetration testing assistant. "
+    "Guide the user through a penetration test step by step. "
+    "Maintain a task tree and suggest next actions. "
+    "For each step, explain the tool to use, the exact command, "
+    "and what to look for in the output. "
+    "Always remind the user to only test systems they have authorization to test."
+)
+
+
+def _call_ollama_chat(question: str, model: str, ollama_url: str) -> str:
+    """Call the Ollama OpenAI-compatible chat completions endpoint."""
+    url = f"{ollama_url.rstrip('/')}/v1/chat/completions"
+    payload = json.dumps({
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        result = json.loads(resp.read().decode())
+    # OpenAI-compatible response format
+    choices = result.get("choices", [])
+    if not choices:
+        raise RuntimeError("Ollama returned no choices in chat completion response.")
+    return choices[0].get("message", {}).get("content", "")
+
+
+def _handle_ask(params: dict) -> dict:
+    question: str = params["question"]
+    model: str = params.get("model", "")
+    ollama_url: str | None = params.get("ollama_url")
+
+    if not model:
+        raise RuntimeError("A model name is required for PentestGPT queries.")
+
+    if not ollama_url:
+        raise RuntimeError(
+            "An ollama_url is required for PentestGPT queries. "
+            "PentestGPT uses Ollama as its LLM backend via the OpenAI-compatible API."
+        )
+
+    answer = _call_ollama_chat(question, model, ollama_url)
+    if not answer:
+        raise RuntimeError("PentestGPT received an empty response from the LLM.")
+
+    return {"answer": answer}
+
+
+def _handle_info(_params: dict) -> dict:
+    return {"name": "pentestgpt", "version": "1", "actions": ["ask", "info"]}
+
+
+_HANDLERS: dict = {
+    "ask": "_handle_ask",
+    "info": "_handle_info",
+}
+
+
+def main() -> None:
+    """Read JSON requests from stdin and write JSON responses to stdout."""
+    current_module = sys.modules[__name__]
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        req_id = ""
+        try:
+            request = json.loads(line)
+            req_id = str(request.get("id", ""))
+            action = str(request.get("action", ""))
+            params = request.get("params") or {}
+
+            handler_name = _HANDLERS.get(action)
+            if handler_name is None:
+                raise RuntimeError(f"Unknown action: {action!r}")
+            handler = getattr(current_module, handler_name)
+
+            result = handler(params)
+            print(json.dumps({"status": "ok", "result": result, "id": req_id}), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps({"status": "error", "error": str(exc), "id": req_id}),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/rune_bench/drivers/pentestgpt/__main__.py
+++ b/rune_bench/drivers/pentestgpt/__main__.py
@@ -11,7 +11,7 @@ Wire protocol (v1):
 Supported actions
 -----------------
 ask
-    params: question (str), model (str), ollama_url (str, optional)
+    params: question (str), model (str), ollama_url (str, required)
     result: {"answer": str}
 
 info
@@ -20,14 +20,18 @@ info
 
 Security notice
 ---------------
-This driver is intended for authorized penetration testing only.  Never use
+This driver is intended for authorized penetration testing only.  Set
+``RUNE_PENTESTGPT_ALLOWED_TARGETS`` to a comma-separated list of permitted
+hostnames.  Requests mentioning unlisted targets are rejected.  Never use
 against systems without explicit written permission from the system owner.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sys
+import urllib.parse
 import urllib.request
 
 _SYSTEM_PROMPT = (
@@ -39,12 +43,43 @@ _SYSTEM_PROMPT = (
     "Always remind the user to only test systems they have authorization to test."
 )
 
+_MODEL_PREFIXES = ("ollama/", "ollama_chat/")
+
+
+def _normalize_model(model: str) -> str:
+    """Strip provider prefixes (e.g. 'ollama/', 'ollama_chat/') from model name."""
+    for prefix in _MODEL_PREFIXES:
+        if model.startswith(prefix):
+            return model[len(prefix):]
+    return model
+
+
+def _check_authorization(question: str) -> None:
+    """Raise RuntimeError if the question mentions an unauthorized target.
+
+    Reads RUNE_PENTESTGPT_ALLOWED_TARGETS (comma-separated hostnames).
+    If the env var is empty/unset, the check is skipped (trust the caller).
+    """
+    allowlist_raw = os.environ.get("RUNE_PENTESTGPT_ALLOWED_TARGETS", "").strip()
+    if not allowlist_raw:
+        return
+    allowed = {h.strip().lower() for h in allowlist_raw.split(",") if h.strip()}
+    for token in question.split():
+        token_clean = token.strip("\"'<>")
+        if token_clean.startswith(("http://", "https://")):
+            host = urllib.parse.urlparse(token_clean).hostname or ""
+            if host.lower() not in allowed:
+                raise RuntimeError(
+                    f"Target {host!r} is not in RUNE_PENTESTGPT_ALLOWED_TARGETS. "
+                    "Add it to the allowlist before running a pentest."
+                )
+
 
 def _call_ollama_chat(question: str, model: str, ollama_url: str) -> str:
     """Call the Ollama OpenAI-compatible chat completions endpoint."""
     url = f"{ollama_url.rstrip('/')}/v1/chat/completions"
     payload = json.dumps({
-        "model": model,
+        "model": _normalize_model(model),
         "messages": [
             {"role": "system", "content": _SYSTEM_PROMPT},
             {"role": "user", "content": question},
@@ -57,7 +92,7 @@ def _call_ollama_chat(question: str, model: str, ollama_url: str) -> str:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
         result = json.loads(resp.read().decode())
     # OpenAI-compatible response format
     choices = result.get("choices", [])
@@ -76,9 +111,11 @@ def _handle_ask(params: dict) -> dict:
 
     if not ollama_url:
         raise RuntimeError(
-            "An ollama_url is required for PentestGPT queries. "
+            "ollama_url is required for PentestGPT queries. "
             "PentestGPT uses Ollama as its LLM backend via the OpenAI-compatible API."
         )
+
+    _check_authorization(question)
 
     answer = _call_ollama_chat(question, model, ollama_url)
     if not answer:

--- a/tests/test_burpgpt_driver.py
+++ b/tests/test_burpgpt_driver.py
@@ -1,0 +1,385 @@
+"""Tests for rune_bench.drivers.burpgpt — driver client and subprocess entry point.
+
+All HTTP calls to Burp Suite REST API are mocked so no external services
+are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+import rune_bench.drivers.burpgpt.__main__ as burp_main
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+_SCAN_START_RESPONSE = {"task_id": "scan-42"}
+
+_SCAN_RUNNING_RESPONSE = {"status": "running"}
+
+_SCAN_SUCCEEDED_RESPONSE = {
+    "status": "succeeded",
+    "issue_events": [
+        {
+            "name": "SQL Injection",
+            "severity": "high",
+            "confidence": "certain",
+            "path": "/api/login",
+            "description": "Parameter 'username' is vulnerable to SQL injection.",
+        },
+        {
+            "name": "Cross-Site Scripting",
+            "severity": "medium",
+            "confidence": "firm",
+            "path": "/search",
+            "description": "Reflected XSS in search parameter.",
+        },
+    ],
+}
+
+_SCAN_NO_FINDINGS_RESPONSE = {"status": "succeeded", "issue_events": []}
+
+
+def _mock_urlopen(responses: list):
+    """Return a context-manager factory that pops responses in order."""
+
+    class FakeResponse:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def read(self) -> bytes:
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    call_idx = [0]
+
+    def _urlopen(req, *args, **kwargs):
+        idx = call_idx[0]
+        call_idx[0] += 1
+        if idx < len(responses):
+            payload = responses[idx]
+            if isinstance(payload, Exception):
+                raise payload
+            return FakeResponse(json.dumps(payload).encode())
+        raise RuntimeError(f"Unmocked call #{idx}")
+
+    return _urlopen
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — scan + poll cycle
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_runs_scan_and_returns_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNE_BURPGPT_BURP_API_URL", "http://burp:1337")
+    # time.sleep is a no-op for tests
+    monkeypatch.setattr(burp_main.time, "sleep", lambda _: None)
+
+    mock = _mock_urlopen([
+        _SCAN_START_RESPONSE,       # POST /v0.1/scan
+        _SCAN_RUNNING_RESPONSE,     # GET /v0.1/scan/scan-42 (1st poll)
+        _SCAN_SUCCEEDED_RESPONSE,   # GET /v0.1/scan/scan-42 (2nd poll)
+    ])
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", mock)
+
+    result = burp_main._handle_ask({
+        "question": "Scan https://target.local",
+        "model": "",
+    })
+
+    assert "SQL Injection" in result["answer"]
+    assert "Cross-Site Scripting" in result["answer"]
+    assert len(result["findings"]) == 2
+    assert result["findings"][0]["severity"] == "high"
+
+
+def test_handle_ask_extracts_url_from_question(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(burp_main.time, "sleep", lambda _: None)
+
+    captured_data: list = []
+
+    class FakeResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    call_idx = [0]
+    responses = [_SCAN_START_RESPONSE, _SCAN_SUCCEEDED_RESPONSE]
+
+    def capture_urlopen(req, *args, **kwargs):
+        if req.data:
+            captured_data.append(json.loads(req.data.decode()))
+        idx = call_idx[0]
+        call_idx[0] += 1
+        return FakeResponse(json.dumps(responses[idx]).encode())
+
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", capture_urlopen)
+
+    burp_main._handle_ask({
+        "question": "Please scan https://example.com/app for vulnerabilities",
+        "model": "",
+    })
+
+    assert captured_data[0]["urls"] == ["https://example.com/app"]
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — no findings
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_no_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(burp_main.time, "sleep", lambda _: None)
+
+    mock = _mock_urlopen([_SCAN_START_RESPONSE, _SCAN_NO_FINDINGS_RESPONSE])
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", mock)
+
+    result = burp_main._handle_ask({
+        "question": "https://safe.local",
+        "model": "",
+    })
+
+    assert "No vulnerabilities found" in result["answer"]
+    assert result["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — Burp not running
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_burp_not_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    mock = _mock_urlopen([
+        urllib.error.URLError("Connection refused"),
+    ])
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", mock)
+
+    with pytest.raises(RuntimeError, match="Cannot connect to Burp Suite"):
+        burp_main._handle_ask({
+            "question": "https://target.local",
+            "model": "",
+        })
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — scan timeout
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_scan_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(burp_main.time, "sleep", lambda _: None)
+    # Make monotonic return values that exceed the timeout
+    times = iter([0, 0, 999999])
+    monkeypatch.setattr(burp_main.time, "monotonic", lambda: next(times))
+
+    mock = _mock_urlopen([
+        _SCAN_START_RESPONSE,
+        _SCAN_RUNNING_RESPONSE,
+    ])
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", mock)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        burp_main._handle_ask({
+            "question": "https://target.local",
+            "model": "",
+        })
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — scan failed
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_scan_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(burp_main.time, "sleep", lambda _: None)
+
+    mock = _mock_urlopen([
+        _SCAN_START_RESPONSE,
+        {"status": "failed", "message": "Invalid target"},
+    ])
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", mock)
+
+    with pytest.raises(RuntimeError, match="scan.*failed"):
+        burp_main._handle_ask({
+            "question": "https://target.local",
+            "model": "",
+        })
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — no scan ID returned
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_no_scan_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = _mock_urlopen([{"unexpected": "response"}])
+    monkeypatch.setattr(burp_main.urllib.request, "urlopen", mock)
+
+    with pytest.raises(RuntimeError, match="did not return a scan ID"):
+        burp_main._handle_ask({
+            "question": "https://target.local",
+            "model": "",
+        })
+
+
+# ---------------------------------------------------------------------------
+# _extract_target_url
+# ---------------------------------------------------------------------------
+
+
+def test_extract_target_url_from_sentence() -> None:
+    assert burp_main._extract_target_url(
+        "Scan https://example.com/app for XSS"
+    ) == "https://example.com/app"
+
+
+def test_extract_target_url_plain() -> None:
+    assert burp_main._extract_target_url("http://10.0.0.1:8080") == "http://10.0.0.1:8080"
+
+
+def test_extract_target_url_fallback() -> None:
+    assert burp_main._extract_target_url("just a plain string") == "just a plain string"
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = burp_main._handle_info({})
+    assert result["name"] == "burpgpt"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        burp_main, "_handle_ask",
+        lambda p: {"answer": "scan done", "findings": []},
+    )
+    monkeypatch.setattr(
+        burp_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "https://t.local", "model": ""},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    burp_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "scan done"
+    assert response["id"] == "test-id"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        burp_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    burp_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+def test_main_handles_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(burp_main.sys, "stdin", io.StringIO("not-json\n"))
+
+    burp_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+
+
+def test_main_skips_empty_lines(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(burp_main.sys, "stdin", io.StringIO("\n\n   \n"))
+
+    burp_main.main()
+
+    assert capsys.readouterr().out.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# BurpGPTDriverClient — with mocked transport
+# ---------------------------------------------------------------------------
+
+
+def test_driver_client_ask_returns_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "2 issues found", "findings": []}
+
+    from rune_bench.drivers.burpgpt import BurpGPTDriverClient
+
+    client = BurpGPTDriverClient(transport=mock_transport)
+    result = client.ask("https://target.local", "llama3.1:8b", "http://ollama:11434")
+
+    assert result == "2 issues found"
+    mock_transport.call.assert_called_once()
+    call_args = mock_transport.call.call_args
+    assert call_args[0][0] == "ask"
+    assert call_args[0][1]["question"] == "https://target.local"
+
+
+def test_driver_client_raises_on_missing_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"findings": []}
+
+    from rune_bench.drivers.burpgpt import BurpGPTDriverClient
+
+    client = BurpGPTDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="did not include an answer"):
+        client.ask("q", "m")
+
+
+def test_driver_client_raises_on_empty_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": ""}
+
+    from rune_bench.drivers.burpgpt import BurpGPTDriverClient
+
+    client = BurpGPTDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="empty answer"):
+        client.ask("q", "m")

--- a/tests/test_pentestgpt_driver.py
+++ b/tests/test_pentestgpt_driver.py
@@ -1,0 +1,275 @@
+"""Tests for rune_bench.drivers.pentestgpt — driver client and subprocess entry point.
+
+All HTTP calls to Ollama are mocked so no external services are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+import rune_bench.drivers.pentestgpt.__main__ as pt_main
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+def _mock_urlopen(responses: dict):
+    """Return a context-manager factory that returns canned JSON responses keyed by URL substring."""
+
+    class FakeResponse:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def read(self) -> bytes:
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def _urlopen(req, *args, **kwargs):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for key, payload in responses.items():
+            if key in url:
+                return FakeResponse(json.dumps(payload).encode())
+        raise RuntimeError(f"Unmocked URL: {url}")
+
+    return _urlopen
+
+
+_CHAT_RESPONSE = {
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": "Step 1: Run nmap -sV target.local to enumerate services.",
+            }
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — Ollama chat call
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_calls_ollama_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = _mock_urlopen({"/v1/chat/completions": _CHAT_RESPONSE})
+    monkeypatch.setattr(pt_main.urllib.request, "urlopen", mock)
+
+    result = pt_main._handle_ask({
+        "question": "Pentest target.local",
+        "model": "llama3.1:8b",
+        "ollama_url": "http://ollama:11434",
+    })
+
+    assert result["answer"] == "Step 1: Run nmap -sV target.local to enumerate services."
+
+
+def test_handle_ask_sends_correct_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    class FakeResponse:
+        def read(self):
+            return json.dumps(_CHAT_RESPONSE).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def capture_urlopen(req, *args, **kwargs):
+        captured["url"] = req.full_url
+        captured["data"] = json.loads(req.data.decode())
+        return FakeResponse()
+
+    monkeypatch.setattr(pt_main.urllib.request, "urlopen", capture_urlopen)
+
+    pt_main._handle_ask({
+        "question": "scan 10.0.0.1",
+        "model": "mistral:7b",
+        "ollama_url": "http://localhost:11434",
+    })
+
+    assert "/v1/chat/completions" in captured["url"]
+    assert captured["data"]["model"] == "mistral:7b"
+    messages = captured["data"]["messages"]
+    assert messages[0]["role"] == "system"
+    assert "PentestGPT" in messages[0]["content"]
+    assert messages[1]["role"] == "user"
+    assert messages[1]["content"] == "scan 10.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — missing required params
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_raises_without_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(RuntimeError, match="model name is required"):
+        pt_main._handle_ask({"question": "q", "model": ""})
+
+
+def test_handle_ask_raises_without_ollama_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(RuntimeError, match="ollama_url is required"):
+        pt_main._handle_ask({"question": "q", "model": "m"})
+
+
+# ---------------------------------------------------------------------------
+# _handle_ask — empty response
+# ---------------------------------------------------------------------------
+
+
+def test_handle_ask_raises_on_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = _mock_urlopen({
+        "/v1/chat/completions": {"choices": [{"message": {"content": ""}}]}
+    })
+    monkeypatch.setattr(pt_main.urllib.request, "urlopen", mock)
+
+    with pytest.raises(RuntimeError, match="empty response"):
+        pt_main._handle_ask({
+            "question": "q",
+            "model": "m",
+            "ollama_url": "http://ollama:11434",
+        })
+
+
+def test_handle_ask_raises_on_no_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock = _mock_urlopen({"/v1/chat/completions": {"choices": []}})
+    monkeypatch.setattr(pt_main.urllib.request, "urlopen", mock)
+
+    with pytest.raises(RuntimeError, match="no choices"):
+        pt_main._handle_ask({
+            "question": "q",
+            "model": "m",
+            "ollama_url": "http://ollama:11434",
+        })
+
+
+# ---------------------------------------------------------------------------
+# _handle_info
+# ---------------------------------------------------------------------------
+
+
+def test_handle_info_returns_driver_metadata() -> None:
+    result = pt_main._handle_info({})
+    assert result["name"] == "pentestgpt"
+    assert "ask" in result["actions"]
+    assert "info" in result["actions"]
+
+
+# ---------------------------------------------------------------------------
+# main() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_processes_ask_request(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(pt_main, "_handle_ask", lambda p: {"answer": "pentest done"})
+    monkeypatch.setattr(
+        pt_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({
+            "action": "ask",
+            "params": {"question": "q", "model": "m", "ollama_url": "http://o:11434"},
+            "id": "test-id",
+        }) + "\n"),
+    )
+
+    pt_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "ok"
+    assert response["result"]["answer"] == "pentest done"
+    assert response["id"] == "test-id"
+
+
+def test_main_returns_error_for_unknown_action(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        pt_main.sys,
+        "stdin",
+        io.StringIO(json.dumps({"action": "unknown", "params": {}, "id": "u1"}) + "\n"),
+    )
+
+    pt_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+    assert "unknown" in response["error"].lower()
+
+
+def test_main_handles_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(pt_main.sys, "stdin", io.StringIO("not-json\n"))
+
+    pt_main.main()
+
+    response = json.loads(capsys.readouterr().out.strip())
+    assert response["status"] == "error"
+
+
+def test_main_skips_empty_lines(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr(pt_main.sys, "stdin", io.StringIO("\n\n   \n"))
+
+    pt_main.main()
+
+    assert capsys.readouterr().out.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# PentestGPTDriverClient — with mocked transport
+# ---------------------------------------------------------------------------
+
+
+def test_driver_client_ask_returns_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": "step 1: nmap scan"}
+
+    from rune_bench.drivers.pentestgpt import PentestGPTDriverClient
+
+    client = PentestGPTDriverClient(transport=mock_transport)
+    result = client.ask("pentest target", "llama3.1:8b", "http://ollama:11434")
+
+    assert result == "step 1: nmap scan"
+    mock_transport.call.assert_called_once()
+    call_args = mock_transport.call.call_args
+    assert call_args[0][0] == "ask"
+    assert call_args[0][1]["question"] == "pentest target"
+    assert call_args[0][1]["ollama_url"] == "http://ollama:11434"
+
+
+def test_driver_client_raises_on_missing_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {}
+
+    from rune_bench.drivers.pentestgpt import PentestGPTDriverClient
+
+    client = PentestGPTDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="did not include an answer"):
+        client.ask("q", "m", "http://o:11434")
+
+
+def test_driver_client_raises_on_empty_answer() -> None:
+    mock_transport = MagicMock()
+    mock_transport.call.return_value = {"answer": ""}
+
+    from rune_bench.drivers.pentestgpt import PentestGPTDriverClient
+
+    client = PentestGPTDriverClient(transport=mock_transport)
+    with pytest.raises(RuntimeError, match="empty answer"):
+        client.ask("q", "m")


### PR DESCRIPTION
## Summary
- **PentestGPT driver** (#69): Wraps Ollama's OpenAI-compatible chat API (`/v1/chat/completions`) with a pentest-focused system prompt for step-by-step penetration testing guidance. No kubeconfig required.
- **BurpGPT driver** (#72): Talks to the Burp Suite Pro REST API to launch scans (`POST /v0.1/scan`), poll for completion, and return formatted vulnerability findings. No kubeconfig required.
- Both drivers follow the Holmes wire protocol (JSON over stdio), include `DriverClient` classes, updated agent stubs that delegate to the drivers, and full test suites (32 tests, all passing).

Closes #69, closes #72

## Test plan
- [x] `pytest tests/test_pentestgpt_driver.py` — 14 tests (Ollama chat mock, missing params, empty response, wire protocol, driver client)
- [x] `pytest tests/test_burpgpt_driver.py` — 18 tests (scan+poll cycle, URL extraction, no findings, Burp not running, scan timeout, scan failed, wire protocol, driver client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)