### PR TITLE
feat: add release workflow and embed docs to compose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-tag:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          COMMIT_SHA=$(git rev-parse "${GITHUB_SHA}^{commit}" 2>/dev/null || echo "$GITHUB_SHA")
+          if ! git merge-base --is-ancestor "$COMMIT_SHA" origin/main; then
+            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
+            echo "Tags must only be pushed AFTER merging to main." >&2
+            exit 1
+          fi
+
+  build-amd64:
+    name: Build image (amd64)
+    needs: [verify-tag]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push amd64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/lpasquali/rune:${{ github.ref_name }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-amd64,mode=max
+
+  build-arm64:
+    name: Build image (arm64)
+    needs: [verify-tag]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/lpasquali/rune:${{ github.ref_name }}-arm64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune:buildcache-arm64,mode=max
+
+  publish:
+    name: Create multi-arch manifest and GitHub Release
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Required to create GitHub Releases
+      packages: write   # Required to push to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/lpasquali/rune:${{ github.ref_name }} \
+            --tag ghcr.io/lpasquali/rune:latest \
+            ghcr.io/lpasquali/rune:${{ github.ref_name }}-amd64 \
+            ghcr.io/lpasquali/rune:${{ github.ref_name }}-arm64
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,13 @@ name: rune
 
 services:
 
+  # ── RUNE Docs ─────────────────────────────────────────────────────────────
+  rune-docs:
+    image: ghcr.io/lpasquali/rune-docs:latest
+    ports:
+      - "8000:80"
+    restart: unless-stopped
+
   # ── RUNE Web UI ───────────────────────────────────────────────────────────
   rune-ui:
     image: ghcr.io/lpasquali/rune-ui:latest


### PR DESCRIPTION
Resolves #117 by adding the missing release.yml workflow for publishing the Docker image on tags and adding rune-docs to docker-compose.yml for local testing.