### PR TITLE
chore: bump version to 0.0.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rune-bench"
-version = "0.0.0a1"
+version = "0.0.0a2"
 description = "RUNE — Reliability Use-case Numeric Evaluator"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Bump version from 0.0.0a1 to 0.0.0a2 for release

## Test plan
- [ ] CI passes
- [ ] Tag v0.0.0a2 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)