### PR TITLE
build: resolve SAST & typing exclusions for ML4 compliance (#125)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -508,7 +508,7 @@ jobs:
           rc=0
 
           pip install bandit
-          bandit -c pyproject.toml -r . -ll -f json -o bandit-results.json || rc=1
+          bandit -c pyproject.toml -r rune rune_bench tests -ll -f json -o bandit-results.json || rc=1
 
           python3 - <<'PY'
           import json

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -508,7 +508,7 @@ jobs:
           rc=0
 
           pip install bandit
-          bandit -r rune rune_bench -ll -f json -o bandit-results.json || rc=1
+          bandit -c pyproject.toml -r . -ll -f json -o bandit-results.json || rc=1
 
           python3 - <<'PY'
           import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,17 @@ include = ["rune*", "rune_bench*"]
 [tool.mypy]
 python_version = "3.11"
 
+# Reason: vastai SDK does not provide type hints
 [[tool.mypy.overrides]]
-module = ["vastai", "holmes", "holmes.*", "yaml"]
+module = "vastai"
+ignore_missing_imports = true
+
+# Reason: holmesgpt package does not provide type hints
+[[tool.mypy.overrides]]
+module = ["holmes", "holmes.*"]
 ignore_missing_imports = true
 
 [tool.bandit]
 # IEC 62443 4-1 ML4 SI-1: static application security testing
-targets = ["rune", "rune_bench"]
-exclude_dirs = ["tests"]
+targets = ["rune", "rune_bench", "tests"]
 skips = ["B101"]   # assert statements used only in test/debug guards

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 typer>=0.9
 rich>=13.7
 vastai-sdk>=0.6.0
+types-PyYAML>=6.0.12

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from rune_bench.agents.config import AgentConfig, resolve_agent_config
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -109,11 +109,11 @@ def test_agent_result_structured():
     r = AgentResult(
         answer="report",
         result_type="report",
-        artifacts=[{"path": "/tmp/out.pdf"}],
+        artifacts=[{"path": "/tmp/out.pdf"}],  # nosec  # test artifact paths
         metadata={"pages": 3},
     )
     assert r.result_type == "report"
-    assert r.artifacts == [{"path": "/tmp/out.pdf"}]
+    assert r.artifacts == [{"path": "/tmp/out.pdf"}]  # nosec  # test artifact paths
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -83,7 +83,7 @@ def test_request_adds_auth_tenant_and_idempotency_headers(monkeypatch):
 
     monkeypatch.setattr("rune_bench.common.http_client.urlopen", fake_urlopen)
 
-    client = RuneApiClient("http://api:8080", api_token="secret", tenant_id="tenant-a")
+    client = RuneApiClient("http://api:8080", api_token="secret", tenant_id="tenant-a")  # nosec  # test credentials
     payload = client._request("POST", "/v1/jobs/benchmark", body={"x": 1}, idempotency_key="idem-1")
 
     assert payload == {"ok": True}

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -30,11 +30,11 @@ def test_agentic_request_from_cli_converts_kubeconfig_to_string():
         ollama_url="http://localhost:11434",
         ollama_warmup=True,
         ollama_warmup_timeout=90,
-        kubeconfig=Path("/tmp/kubeconfig"),
+        kubeconfig=Path("/tmp/kubeconfig"),  # nosec  # test artifact paths
     )
 
     payload = request.to_dict()
-    assert payload["kubeconfig"] == "/tmp/kubeconfig"
+    assert payload["kubeconfig"] == "/tmp/kubeconfig"  # nosec  # test artifact paths
 
 
 def test_agentic_request_from_cli_kubeconfig_optional():

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -45,7 +45,7 @@ def rune_api_server(tmp_path):
 
 def test_healthz_is_public(rune_api_server):
     base_url, _state = rune_api_server
-    with urlopen(f"{base_url}/healthz") as response:
+    with urlopen(f"{base_url}/healthz") as response:  # nosec  # test request mock/local execution
         payload = json.loads(response.read().decode("utf-8"))
 
     assert payload == {"status": "ok"}
@@ -56,22 +56,22 @@ def test_api_server_requires_auth(rune_api_server):
     request = Request(f"{base_url}/v1/catalog/vastai-models")
 
     with pytest.raises(HTTPError) as exc:
-        urlopen(request)
+        urlopen(request)  # nosec  # test request mock/local execution
 
     assert exc.value.code == 401
 
 
 def test_api_server_enforces_tenant_scoping_and_idempotency(rune_api_server):
     base_url, state = rune_api_server
-    client_a = RuneApiClient(base_url, api_token="token-a", tenant_id="tenant-a")
-    client_b = RuneApiClient(base_url, api_token="token-b", tenant_id="tenant-b")
+    client_a = RuneApiClient(base_url, api_token="token-a", tenant_id="tenant-a")  # nosec  # test credentials
+    client_b = RuneApiClient(base_url, api_token="token-b", tenant_id="tenant-b")  # nosec  # test credentials
     request_payload = {
         "question": "What is unhealthy?",
         "model": "llama3.1:8b",
         "ollama_url": None,
         "ollama_warmup": False,
         "ollama_warmup_timeout": 1,
-        "kubeconfig": "/tmp/config",
+        "kubeconfig": "/tmp/config",  # nosec  # test artifact paths
     }
 
     job_id_1 = client_a.submit_agentic_agent_job(request_payload, idempotency_key="idem-1")

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -12,7 +12,7 @@ Covers:
 
 from __future__ import annotations
 
-import subprocess
+import subprocess  # nosec  # tests require subprocess
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/test_comprehensive_error_paths.py
+++ b/tests/test_comprehensive_error_paths.py
@@ -50,7 +50,7 @@ def test_api_client_remaining_paths(monkeypatch):
     monkeypatch.setenv("RUNE_API_TOKEN", "env-token")
     monkeypatch.setenv("RUNE_API_TENANT", "env-tenant")
     client = RuneApiClient("api:8080")
-    assert client.api_token == "env-token"
+    assert client.api_token == "env-token"  # nosec  # test credentials
     assert client.tenant_id == "env-tenant"
 
     from urllib.error import HTTPError, URLError
@@ -152,24 +152,24 @@ def test_api_server_remaining_paths(monkeypatch, tmp_path):
     base = f"http://{host}:{port}"
     try:
         req = Request(f"{base}/v1/ollama/models?ollama_url=http://x", headers={"Authorization": "Bearer token", "X-Tenant-ID": "tenant"})
-        with urlopen(req) as response:
+        with urlopen(req) as response:  # nosec  # test request mock/local execution
             assert response.status == 200
 
         bad_auth = Request(f"{base}/v1/jobs/whatever", method="POST", data=b"{}", headers={"Authorization": "Bearer wrong", "X-Tenant-ID": "tenant", "Content-Type": "application/json"})
         with pytest.raises(Exception):
-            urlopen(bad_auth)
+            urlopen(bad_auth)  # nosec  # test request mock/local execution
 
         bad_kind = Request(f"{base}/v1/jobs/whatever", method="POST", data=b"{}", headers={"Authorization": "Bearer token", "X-Tenant-ID": "tenant", "Content-Type": "application/json"})
         with pytest.raises(Exception):
-            urlopen(bad_kind)
+            urlopen(bad_kind)  # nosec  # test request mock/local execution
 
         req = Request(f"{base}/v1/jobs/ollama-instance", method="POST", data=b'{"vastai": false, "template_hash": "t", "min_dph": 1, "max_dph": 2, "reliability": 0.9, "ollama_url": "http://x"}', headers={"Authorization": "Bearer token", "X-Tenant-ID": "tenant", "Content-Type": "application/json"})
-        with urlopen(req) as response:
+        with urlopen(req) as response:  # nosec  # test request mock/local execution
             payload = response.read().decode("utf-8")
             assert "job_id" in payload
 
         req = Request(f"{base}/v1/jobs/benchmark", method="POST", data=b'{"vastai": false, "template_hash": "t", "min_dph": 1, "max_dph": 2, "reliability": 0.9, "ollama_url": null, "question": "q", "model": "m", "ollama_warmup": false, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k", "vastai_stop_instance": false}', headers={"Authorization": "Bearer token", "X-Tenant-ID": "tenant", "Content-Type": "application/json", "Idempotency-Key": "id1"})
-        with urlopen(req) as response:
+        with urlopen(req) as response:  # nosec  # test request mock/local execution
             assert response.status == 202
     finally:
         server.shutdown()
@@ -179,12 +179,12 @@ def test_api_server_remaining_paths(monkeypatch, tmp_path):
     jobs = [store.get_job(job_id) for job_id, _ in [store.create_job(tenant_id="tenant", kind="agentic-agent", request_payload={})]]
     assert jobs[0] is not None
 
-    job_id, _ = store.create_job(tenant_id="tenant", kind="agentic-agent", request_payload={"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})
-    app._execute_job(job_id, "agentic-agent", {"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})
+    job_id, _ = store.create_job(tenant_id="tenant", kind="agentic-agent", request_payload={"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})  # nosec  # test artifact paths
+    app._execute_job(job_id, "agentic-agent", {"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})  # nosec  # test artifact paths
     assert store.get_job(job_id).status == "failed"
 
     assert app._dispatch("ollama-instance", {"vastai": False, "template_hash": "t", "min_dph": 1, "max_dph": 2, "reliability": 0.9, "ollama_url": "http://x"}) == {"mode": "existing"}
-    assert app._dispatch("benchmark", {"vastai": False, "template_hash": "t", "min_dph": 1, "max_dph": 2, "reliability": 0.9, "ollama_url": None, "question": "qq", "model": "m", "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k", "vastai_stop_instance": False}) == {"answer": "qq"}
+    assert app._dispatch("benchmark", {"vastai": False, "template_hash": "t", "min_dph": 1, "max_dph": 2, "reliability": 0.9, "ollama_url": None, "question": "qq", "model": "m", "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k", "vastai_stop_instance": False}) == {"answer": "qq"}  # nosec  # test artifact paths
 
     monkeypatch.setattr(api_server, "ThreadingHTTPServer", lambda *args, **kwargs: type("S", (), {"serve_forever": lambda self: None, "server_close": lambda self: None})())
     api_server.RuneApiApplication(store=store, security=api_server.ApiSecurityConfig(auth_disabled=True, tenant_tokens={})).serve("127.0.0.1", 0)
@@ -215,7 +215,7 @@ def test_api_server_error_paths(monkeypatch, tmp_path):
             headers={"X-API-Key": "token", "X-Tenant-ID": "tenant", "Content-Type": "application/json"},
         )
         with pytest.raises(Exception):
-            urlopen(req)
+            urlopen(req)  # nosec  # test request mock/local execution
 
         req = Request(
             f"{base}/v1/jobs/agentic-agent",
@@ -224,11 +224,11 @@ def test_api_server_error_paths(monkeypatch, tmp_path):
             headers={"X-API-Key": "token", "X-Tenant-ID": "tenant", "Content-Type": "application/json"},
         )
         with pytest.raises(Exception):
-            urlopen(req)
+            urlopen(req)  # nosec  # test request mock/local execution
 
         req = Request(f"{base}/v1/jobs/missing", headers={"X-API-Key": "token", "X-Tenant-ID": "tenant"})
         with pytest.raises(Exception):
-            urlopen(req)
+            urlopen(req)  # nosec  # test request mock/local execution
     finally:
         server.shutdown()
         thread.join(timeout=2)
@@ -243,9 +243,9 @@ def test_api_server_error_paths(monkeypatch, tmp_path):
     job_id, _ = real_store.create_job(
         tenant_id="default",
         kind="agentic-agent",
-        request_payload={"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"},
+        request_payload={"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"},  # nosec  # test artifact paths
     )
-    app._execute_job(job_id, "agentic-agent", {"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})
+    app._execute_job(job_id, "agentic-agent", {"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})  # nosec  # test artifact paths
     assert real_store.get_job(job_id).status == "succeeded"
 
 
@@ -443,26 +443,26 @@ def test_cost_estimate_backend_and_server_endpoints(monkeypatch, tmp_path):
             data=b'{"vastai": true, "min_dph": 2.0, "max_dph": 3.0, "estimated_duration_seconds": 3600}',
             headers={**auth_headers, "Content-Type": "application/json"},
         )
-        with urlopen(req) as resp:
+        with urlopen(req) as resp:  # nosec  # test request mock/local execution
             import json as _json
             payload = _json.loads(resp.read())
         assert payload["projected_cost_usd"] == 1.5
 
         # /v1/metrics/summary GET (lines 183-188)
         req = Request(f"{base}/v1/metrics/summary", headers=auth_headers)
-        with urlopen(req) as resp:
+        with urlopen(req) as resp:  # nosec  # test request mock/local execution
             payload = _json.loads(resp.read())
         assert "events" in payload
 
         # /v1/jobs/{id}/events GET — job not found (lines 193-197)
         req = Request(f"{base}/v1/jobs/nonexistent/events", headers=auth_headers)
         with pytest.raises(Exception):
-            urlopen(req)
+            urlopen(req)  # nosec  # test request mock/local execution
 
         # /v1/jobs/{id}/events GET — job exists (lines 198-200)
         job_id, _ = store.create_job(tenant_id="t", kind="agentic-agent", request_payload={"question": "q"})
         req = Request(f"{base}/v1/jobs/{job_id}/events", headers=auth_headers)
-        with urlopen(req) as resp:
+        with urlopen(req) as resp:  # nosec  # test request mock/local execution
             payload = _json.loads(resp.read())
         assert payload["job_id"] == job_id
         assert "events" in payload

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -142,7 +142,7 @@ def test_api_server_backend_type_guards():
         ollama_url="http://localhost:11434",
         ollama_warmup=False,
         ollama_warmup_timeout=1,
-        kubeconfig="/tmp/k",
+        kubeconfig="/tmp/k",  # nosec  # test artifact paths
     )
     benchmark = RunBenchmarkRequest(
         vastai=False,
@@ -155,7 +155,7 @@ def test_api_server_backend_type_guards():
         model="m",
         ollama_warmup=False,
         ollama_warmup_timeout=1,
-        kubeconfig="/tmp/k",
+        kubeconfig="/tmp/k",  # nosec  # test artifact paths
         vastai_stop_instance=False,
     )
     ollama = RunOllamaInstanceRequest(
@@ -182,7 +182,7 @@ def test_api_server_backend_success_paths(monkeypatch):
         ollama_url="http://localhost:11434",
         ollama_warmup=False,
         ollama_warmup_timeout=1,
-        kubeconfig="/tmp/k",
+        kubeconfig="/tmp/k",  # nosec  # test artifact paths
     )
     benchmark = RunBenchmarkRequest(
         vastai=False,
@@ -195,7 +195,7 @@ def test_api_server_backend_success_paths(monkeypatch):
         model="m",
         ollama_warmup=False,
         ollama_warmup_timeout=1,
-        kubeconfig="/tmp/k",
+        kubeconfig="/tmp/k",  # nosec  # test artifact paths
         vastai_stop_instance=False,
     )
     ollama = RunOllamaInstanceRequest(

--- a/tests/test_dagger_driver.py
+++ b/tests/test_dagger_driver.py
@@ -6,7 +6,7 @@ The dagger-io package is optional, so all tests mock it entirely.
 from __future__ import annotations
 
 import json
-import subprocess
+import subprocess  # nosec  # tests require subprocess
 import sys
 import types
 from unittest.mock import MagicMock, patch

--- a/tests/test_driver_coverage_extras.py
+++ b/tests/test_driver_coverage_extras.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 
 import io
 import json
-import os
-import sys
-import types
-from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -8,7 +8,7 @@ make_http_request are monkeypatched throughout.
 from __future__ import annotations
 
 import json
-import subprocess
+import subprocess  # nosec  # tests require subprocess
 
 import pytest
 
@@ -256,7 +256,7 @@ def test_http_transport_sends_auth_headers(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr("rune_bench.drivers.http.make_http_request", fake)
     monkeypatch.setattr("rune_bench.drivers.http.time.sleep", lambda *_: None)
 
-    transport = HttpTransport("http://driver:8080", api_token="secret", tenant="my-tenant")
+    transport = HttpTransport("http://driver:8080", api_token="secret", tenant="my-tenant")  # nosec  # test credentials
     transport.call("ask", {})
 
     assert len(captured_headers) >= 1

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -489,7 +489,7 @@ def test_api_backend_server_workflows_instance_remaining(monkeypatch, tmp_path):
     try:
         req = Request(f"http://{host}:{port}/v1/ollama/models?ollama_url=http://x")
         with pytest.raises(HTTPError) as exc:
-            urlopen(req)
+            urlopen(req)  # nosec  # test request mock/local execution
         assert exc.value.code == 400
     finally:
         server.shutdown()

--- a/tests/test_holmes_driver.py
+++ b/tests/test_holmes_driver.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import io
 import json
-import subprocess
+import subprocess  # nosec  # tests require subprocess
 
 import pytest
 
@@ -34,7 +34,7 @@ def test_handle_ask_calls_holmes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     result = holmes_main._handle_ask({
         "question": "What is wrong?",
         "model": "llama3.1:8b",
-        "kubeconfig_path": "/tmp/kubeconfig",
+        "kubeconfig_path": "/tmp/kubeconfig",  # nosec  # test artifact paths
         "ollama_url": "http://ollama:11434",
         "context_window": 131072,
         "max_output_tokens": 26214,
@@ -42,7 +42,7 @@ def test_handle_ask_calls_holmes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert result["answer"] == "the answer"
     assert "holmes.main" in captured["cmd"]
-    assert captured["env"]["KUBECONFIG"] == "/tmp/kubeconfig"
+    assert captured["env"]["KUBECONFIG"] == "/tmp/kubeconfig"  # nosec  # test artifact paths
     assert captured["env"]["OLLAMA_API_BASE"] == "http://ollama:11434"
     assert captured["env"]["OPENAI_API_BASE"] == "http://ollama:11434"
     assert captured["env"]["OVERRIDE_MAX_CONTENT_SIZE"] == "131072"
@@ -58,7 +58,7 @@ def test_handle_ask_works_without_optional_params(monkeypatch: pytest.MonkeyPatc
     result = holmes_main._handle_ask({
         "question": "q",
         "model": "m",
-        "kubeconfig_path": "/tmp/kc",
+        "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
     })
     assert result["answer"] == "answer"
 
@@ -70,7 +70,7 @@ def test_handle_ask_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> N
         lambda *a, **kw: subprocess.CompletedProcess([], 1, stdout="", stderr="holmes error"),
     )
     with pytest.raises(RuntimeError, match="holmes error"):
-        holmes_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})
+        holmes_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})  # nosec  # test artifact paths
 
 
 def test_handle_ask_uses_stdout_detail_on_stderr_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,7 +80,7 @@ def test_handle_ask_uses_stdout_detail_on_stderr_empty(monkeypatch: pytest.Monke
         lambda *a, **kw: subprocess.CompletedProcess([], 1, stdout="stdout error", stderr=""),
     )
     with pytest.raises(RuntimeError, match="stdout error"):
-        holmes_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})
+        holmes_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})  # nosec  # test artifact paths
 
 
 def test_handle_ask_does_not_override_existing_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -96,7 +96,7 @@ def test_handle_ask_does_not_override_existing_env_vars(monkeypatch: pytest.Monk
     holmes_main._handle_ask({
         "question": "q",
         "model": "m",
-        "kubeconfig_path": "/tmp/kc",
+        "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
         "context_window": 1234,
     })
     # setdefault should preserve the pre-existing env var
@@ -127,7 +127,7 @@ def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pyt
         "stdin",
         io.StringIO(json.dumps({
             "action": "ask",
-            "params": {"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"},
+            "params": {"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"},  # nosec  # test artifact paths
             "id": "test-id",
         }) + "\n"),
     )

--- a/tests/test_k8sgpt_driver.py
+++ b/tests/test_k8sgpt_driver.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import io
 import json
-import subprocess
+import subprocess  # nosec  # tests require subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -63,7 +63,7 @@ def test_handle_ask_calls_k8sgpt_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     result = k8sgpt_main._handle_ask({
         "question": "What is wrong?",
         "model": "llama3.1:8b",
-        "kubeconfig_path": "/tmp/kubeconfig",
+        "kubeconfig_path": "/tmp/kubeconfig",  # nosec  # test artifact paths
         "ollama_url": "http://ollama:11434",
     })
 
@@ -72,7 +72,7 @@ def test_handle_ask_calls_k8sgpt_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(result["findings"]) == 2
     assert "nginx-broken" in result["answer"]
     assert "k8sgpt" in captured["cmd"]
-    assert captured["env"]["KUBECONFIG"] == "/tmp/kubeconfig"
+    assert captured["env"]["KUBECONFIG"] == "/tmp/kubeconfig"  # nosec  # test artifact paths
     assert "--base-url" in captured["cmd"]
     assert "http://ollama:11434" in captured["cmd"]
 
@@ -90,7 +90,7 @@ def test_handle_ask_without_ollama_url(monkeypatch: pytest.MonkeyPatch) -> None:
     result = k8sgpt_main._handle_ask({
         "question": "q",
         "model": "m",
-        "kubeconfig_path": "/tmp/kc",
+        "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
     })
     assert result["answer"]
     assert "--base-url" not in captured["cmd"]
@@ -103,7 +103,7 @@ def test_handle_ask_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
         k8sgpt_main._handle_ask({
             "question": "q",
             "model": "m",
-            "kubeconfig_path": "/tmp/kc",
+            "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
         })
 
 
@@ -118,7 +118,7 @@ def test_handle_ask_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
     result = k8sgpt_main._handle_ask({
         "question": "q",
         "model": "m",
-        "kubeconfig_path": "/tmp/kc",
+        "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
     })
     assert result["answer"] == "No issues detected"
     assert result["findings"] == []
@@ -135,7 +135,7 @@ def test_handle_ask_empty_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
     result = k8sgpt_main._handle_ask({
         "question": "q",
         "model": "m",
-        "kubeconfig_path": "/tmp/kc",
+        "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
     })
     assert result["answer"] == "No issues detected"
 
@@ -149,7 +149,7 @@ def test_handle_ask_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     with pytest.raises(RuntimeError, match="k8sgpt error"):
-        k8sgpt_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})
+        k8sgpt_main._handle_ask({"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"})  # nosec  # test artifact paths
 
 
 def test_handle_ask_resource_kind_filter(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -165,7 +165,7 @@ def test_handle_ask_resource_kind_filter(monkeypatch: pytest.MonkeyPatch) -> Non
     k8sgpt_main._handle_ask({
         "question": "Pod",
         "model": "m",
-        "kubeconfig_path": "/tmp/kc",
+        "kubeconfig_path": "/tmp/kc",  # nosec  # test artifact paths
     })
     assert "--filter" in captured["cmd"]
     assert "Pod" in captured["cmd"]
@@ -216,7 +216,7 @@ def test_main_processes_ask_request(monkeypatch: pytest.MonkeyPatch, capsys: pyt
         "stdin",
         io.StringIO(json.dumps({
             "action": "ask",
-            "params": {"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"},
+            "params": {"question": "q", "model": "m", "kubeconfig_path": "/tmp/kc"},  # nosec  # test artifact paths
             "id": "test-id",
         }) + "\n"),
     )

--- a/tests/test_mindgard_driver.py
+++ b/tests/test_mindgard_driver.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import io
 import json
-import subprocess
+import subprocess  # nosec  # tests require subprocess
 
 import pytest
 

--- a/tests/test_rune_cli_integration.py
+++ b/tests/test_rune_cli_integration.py
@@ -49,12 +49,12 @@ def _result(**kwargs):
 
 def test_main_and_basic_helpers(monkeypatch):
     with pytest.raises(typer.BadParameter):
-        rune.main(backend="bad", api_base_url="http://x", api_token="", api_tenant="default", debug=False)
+        rune.main(backend="bad", api_base_url="http://x", api_token="", api_tenant="default", debug=False)  # nosec  # test credentials
 
-    rune.main(backend="http", api_base_url="http://api", api_token="tok", api_tenant="tenant-a", debug=False)
+    rune.main(backend="http", api_base_url="http://api", api_token="tok", api_tenant="tenant-a", debug=False)  # nosec  # test credentials
     client = rune._http_client()
     assert client.base_url == "http://api"
-    assert client.api_token == "tok"
+    assert client.api_token == "tok"  # nosec  # test credentials
     assert client.tenant_id == "tenant-a"
 
     called = []

--- a/tests/test_vastai_instance_manager.py
+++ b/tests/test_vastai_instance_manager.py
@@ -166,13 +166,13 @@ def test_api_security_from_env(monkeypatch):
 def test_api_server_misc_paths(misc_server):
     base_url, app = misc_server
 
-    with urlopen(f"{base_url}/v1/catalog/vastai-models") as response:
+    with urlopen(f"{base_url}/v1/catalog/vastai-models") as response:  # nosec  # test request mock/local execution
         payload = json.loads(response.read().decode("utf-8"))
     assert "models" in payload
 
     req = Request(f"{base_url}/v1/ollama/models")
     with pytest.raises(HTTPError) as exc:
-        urlopen(req)
+        urlopen(req)  # nosec  # test request mock/local execution
     assert exc.value.code == 400
 
     bad_req = Request(
@@ -182,16 +182,16 @@ def test_api_server_misc_paths(misc_server):
         method="POST",
     )
     with pytest.raises(HTTPError) as exc:
-        urlopen(bad_req)
+        urlopen(bad_req)  # nosec  # test request mock/local execution
     assert exc.value.code == 400
 
     unknown_req = Request(f"{base_url}/nope")
     with pytest.raises(HTTPError) as exc:
-        urlopen(unknown_req)
+        urlopen(unknown_req)  # nosec  # test request mock/local execution
     assert exc.value.code == 404
 
     job = app.store.create_job(tenant_id="default", kind="agentic-agent", request_payload={})[0]
-    with urlopen(f"{base_url}/v1/jobs/{job}") as response:
+    with urlopen(f"{base_url}/v1/jobs/{job}") as response:  # nosec  # test request mock/local execution
         payload = json.loads(response.read().decode("utf-8"))
     assert payload["job_id"] == job
 
@@ -221,12 +221,12 @@ def test_api_server_internal_dispatch_and_failures(tmp_path):
                 "model": "m",
                 "ollama_warmup": False,
                 "ollama_warmup_timeout": 1,
-                "kubeconfig": "/tmp/k",
+                "kubeconfig": "/tmp/k",  # nosec  # test artifact paths
                 "vastai_stop_instance": False,
             },
         )
 
-    app._execute_job("missing", "agentic-agent", {"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})
+    app._execute_job("missing", "agentic-agent", {"question": "q", "model": "m", "ollama_url": None, "ollama_warmup": False, "ollama_warmup_timeout": 1, "kubeconfig": "/tmp/k"})  # nosec  # test artifact paths
     assert store.get_job("missing") is None
 
 


### PR DESCRIPTION
- Removed blanket `exclude_dirs = ["tests"]` from Bandit configuration
- Added inline `# nosec` justifications for legitimate test-code SAST suppressions
- Removed blanket MyPy `ignore_missing_imports` for `yaml`, `vastai`, and `holmes`
- Added explicit type hints (types-PyYAML) and documented justifications for remaining untyped boundaries
