### PR TITLE
test: enforce strict test coverage boundaries (#123)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,19 +2,44 @@
 source =
     rune
     rune_bench
+omit =
+    # Tier 2: vendor API required
+    rune_bench/agents/*/perplexity.py
+    rune_bench/drivers/perplexity/*
+    rune_bench/agents/*/elicit.py
+    rune_bench/drivers/elicit/*
+    rune_bench/agents/*/pagerduty.py
+    rune_bench/drivers/pagerduty/*
+    rune_bench/agents/*/metoro.py
+    rune_bench/drivers/metoro/*
+    rune_bench/agents/*/mindgard.py
+    rune_bench/drivers/mindgard/*
+    rune_bench/agents/*/glean.py
+    rune_bench/drivers/glean/*
+    rune_bench/agents/*/burpgpt.py
+    rune_bench/drivers/burpgpt/*
+    rune_bench/agents/*/midjourney.py
+    rune_bench/drivers/midjourney/*
+    rune_bench/agents/*/krea.py
+    rune_bench/drivers/krea/*
+    rune_bench/agents/*/multion.py
+    rune_bench/drivers/multion/*
+    # Tier 3: enterprise-only, no testable API
+    rune_bench/agents/*/harvey.py
+    rune_bench/drivers/harvey/*
+    rune_bench/agents/*/spellbook.py
+    rune_bench/drivers/spellbook/*
+    rune_bench/agents/*/radiant.py
+    rune_bench/drivers/radiant/*
+    rune_bench/agents/*/xbow.py
+    rune_bench/drivers/xbow/*
+    rune_bench/agents/*/sierra.py
+    rune_bench/drivers/sierra/*
+    rune_bench/agents/*/skillfortify.py
+    rune_bench/drivers/skillfortify/*
 
 [report]
 omit =
-    # Stub agents — intentionally unimplemented (raise NotImplementedError)
-    rune_bench/agents/art/*
-    rune_bench/agents/cybersec/*
-    rune_bench/agents/legal/*
-    rune_bench/agents/ops/*
-    rune_bench/agents/research/*
-    rune_bench/agents/sre/cleric.py
-    rune_bench/agents/sre/k8sgpt.py
-    rune_bench/agents/sre/metoro.py
-    rune_bench/agents/sre/pagerduty.py
     # Backend stubs — intentionally unimplemented (raise NotImplementedError)
     rune_bench/backends/openai.py
     rune_bench/backends/bedrock.py


### PR DESCRIPTION
- Replaced blanket wildcard test coverage exclusions with explicit per-agent omissions.
- Allowed only Tier 2 (vendor API required) and Tier 3 (enterprise-only, no testable API) agents in the omit list.
- Ensured Tier 1 OSS agents like PentestGPT, LangGraph, and CrewAI are measured for coverage per ML4 compliance.
