### PR TITLE
[Legal] Block GPL-2.0 variants in security-licenses gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -607,6 +607,10 @@ jobs:
             'gpl v3',
             'gnu general public license v3',
             'gnu affero general public license',
+            'gplv2',
+            'gpl v2',
+            'gpl-2.0',
+            'gnu general public license v2',
           )
           allowed_package_exceptions = {
             # Temporary exceptions for transitive deps pulled by the Holmes stack.


### PR DESCRIPTION
fix(ci): Block GPL-2.0 variants in security-licenses gate

Closes #132

[x] **Level 2**

## Acceptance Criteria Evidence
- [x] Added GPL-2.0 variants to blocked licenses

## Audit Checks
- PASS: CI workflow files modified, cyber check passes

## Breaking Changes
- None