### PR TITLE
[Legal] Add NOTICE file (Apache-2.0 Section 4(d))

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+RUNE
+Copyright 2025-2026 The Rune Authors
+
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by third parties.
+
+---
+
+Typer (https://github.com/tiangolo/typer)
+  License: MIT
+  Copyright (c) Sebastián Ramírez
+
+Rich (https://github.com/Textualize/rich)
+  License: MIT
+  Copyright (c) Will McGugan
+
+PyYAML (https://github.com/yaml/pyyaml)
+  License: MIT
+  Copyright (c) Kirill Simonov


### PR DESCRIPTION
## Summary

- Adds NOTICE file with copyright attribution and third-party dependency notices (Typer, Rich, PyYAML) as required by Apache License 2.0 Section 4(d)

Closes #133

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- `ls NOTICE` confirms file exists at repo root
- `head -5 NOTICE` confirms canonical format with `Copyright 2025-2026 The Rune Authors`
- Third-party dependencies (Typer, Rich, PyYAML) attributed with license and copyright

## Audit Checks

No triggers fired. This change adds a legal metadata file only.

## Breaking Changes

None.