### PR TITLE
Resolve SAST & typing exclusions (ML4 compliance)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "ruff",
     "mypy",
     "bandit",
+    "types-PyYAML>=6.0.12",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Adds `types-PyYAML>=6.0.12` to dev dependencies in pyproject.toml
- Resolves the last MyPy `import-untyped` error for the `yaml` module
- All Bandit exclusions now use per-line `# nosec` with justification (no blanket test/ exclusion)

Closes #125

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- mypy: `Success: no issues found in 120 source files`
- bandit: runs against tests/ with no blanket exclusion
- pip-audit: types-PyYAML introduces no new CVEs
- pytest: all tests pass

## Audit Checks

cyber check:supply-chain — PASS (pyproject.toml dev dependency added, no runtime impact)

## Breaking Changes

None.