### PR TITLE
fix(deps): Level 1 CVE Remediation (vastai-sdk)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -285,7 +285,7 @@ jobs:
           python -m venv .venv-vastai
           .venv-vastai/bin/pip install --upgrade pip --quiet
           .venv-vastai/bin/pip install "${WHEEL}[vastai]" --quiet
-          .venv-vastai/bin/python -c "from vastai import VastAI; print('vastai extra import: OK')"
+          .venv-vastai/bin/python -c "from rune_bench.resources.vastai.sdk import VastAI; print('vastai extra import: OK')"
           .venv-vastai/bin/python -m rune --help
 
   # ─── Docker / container gates ────────────────────────────────────────────────

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -85,7 +85,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest pytest-cov pytest-xdist
+          pip install --prefer-binary -r requirements.txt pytest pytest-cov pytest-xdist respx
       - name: Coverage
         run: .venv/bin/python -m pytest --cov --cov-report=term-missing:skip-covered --cov-fail-under=97
       - name: Comment coverage on PR
@@ -141,7 +141,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest pytest-xdist
+          pip install --prefer-binary -r requirements.txt pytest pytest-xdist respx
       - run: .venv/bin/python -m pytest -p no:cov -o addopts='' tests/ -m "not regression" -v --tb=short
 
   linting-python:
@@ -193,7 +193,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest
+          pip install --prefer-binary -r requirements.txt pytest respx
       - run: .venv/bin/python -m pytest -p no:cov -o addopts='' -m regression tests/ -v --tb=short
 
   integration-ollama:
@@ -218,7 +218,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest
+          pip install --prefer-binary -r requirements.txt pytest respx
       - uses: actions/cache@v5
         id: cache-ollama-models
         with:
@@ -346,7 +346,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
-          pip install --prefer-binary -r requirements.txt pytest
+          pip install --prefer-binary -r requirements.txt pytest respx
       - run: .venv/bin/python -m pytest -p no:cov -o addopts='' tests/test_cli_http_mode.py tests/test_api_server.py -v --tb=short
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 # Application source — preserve subdirectory names so python -m rune resolves correctly
 COPY rune ./rune
 COPY rune_bench ./rune_bench
-RUN mkdir -p /app/.kube && chown -R rune:rune /app
+RUN mkdir -p /app/.kube /app/.rune-api && chown -R rune:rune /app
 
 ENV PATH="/opt/venv/bin:$PATH" \
     RUNE_BACKEND=local \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     volumes:
       - seaweedfs-data:/data
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:9333/cluster/status"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:9333/cluster/status"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ dev = [
     "mypy",
     "bandit",
     "types-PyYAML>=6.0.12",
+    "respx>=0.22.0",
+    "httpx>=0.27.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ holmes = [
     "supabase>=2.5,<2.8",
 ]
 vastai = [
-    "vastai-sdk>=0.6.0",
+    "httpx>=0.27.0",
 ]
 catalog = [
     "pyyaml>=6.0",
@@ -50,7 +50,7 @@ catalog = [
 all = [
     "holmesgpt>=0.23.0",
     "supabase>=2.5,<2.8",
-    "vastai-sdk>=0.6.0",
+    "httpx>=0.27.0",
     "pyyaml>=6.0",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rune-bench"
-version = "0.0.0a2"
+version = "0.0.0a3"
 description = "RUNE — Reliability Use-case Numeric Evaluator"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 typer>=0.9
 rich>=13.7
-vastai-sdk>=0.6.0
+httpx>=0.27.0
 types-PyYAML>=6.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 typer>=0.9
 rich>=13.7
 httpx>=0.27.0
+pyyaml>=6.0
 types-PyYAML>=6.0.12

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -18,7 +18,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 try:
-    from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+    from rune_bench.resources.vastai.sdk import VastAI
 except ImportError:
     VastAI = None  # type: ignore[assignment,misc]
 

--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -25,7 +25,7 @@ from rune_bench.workflows import (
 )
 
 try:
-    from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+    from rune_bench.resources.vastai.sdk import VastAI
 except ImportError:
     VastAI = None  # type: ignore[assignment,misc]
 

--- a/rune_bench/resources/vastai/instance.py
+++ b/rune_bench/resources/vastai/instance.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable
 
-from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+from rune_bench.resources.vastai.sdk import VastAI
 
 from rune_bench.common import SelectedModel
 from rune_bench.debug import debug_log

--- a/rune_bench/resources/vastai/offer.py
+++ b/rune_bench/resources/vastai/offer.py
@@ -6,7 +6,7 @@ reliability constraints, ordered by descending VRAM / DL perf.
 
 from dataclasses import dataclass
 
-from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+from rune_bench.resources.vastai.sdk import VastAI
 
 from rune_bench.debug import debug_log
 
@@ -37,11 +37,11 @@ class OfferFinder:
         Raises:
             RuntimeError: if the API call fails or no offers are found.
         """
-        query = (
-            f"reliability > {reliability} "
-            f"verified=True "
-            f"dph>={min_dph} dph<={max_dph}"
-        )
+        query = {
+            "reliability": {"gt": str(reliability)},
+            "verified": {"eq": "True"},
+            "dph": {"gte": str(min_dph), "lte": str(max_dph)}
+        }
         try:
             debug_log(
                 f"Vast.ai API call: search_offers query={query!r} order={self.DEFAULT_ORDER!r} disable_bundling=True"

--- a/rune_bench/resources/vastai/provider.py
+++ b/rune_bench/resources/vastai/provider.py
@@ -1,6 +1,6 @@
 """Vast.ai LLM resource provider."""
 
-from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+from rune_bench.resources.vastai.sdk import VastAI
 
 from rune_bench.resources.base import ProvisioningResult
 

--- a/rune_bench/resources/vastai/sdk.py
+++ b/rune_bench/resources/vastai/sdk.py
@@ -1,0 +1,93 @@
+"""Lightweight Vast.ai API client to replace vastai-sdk and avoid CVEs."""
+
+import json
+import urllib.parse
+from typing import Any
+
+import httpx
+
+
+
+class VastAI:
+    """Minimal wrapper around the Vast.ai REST API."""
+
+    def __init__(self, api_key: str, raw: bool = True) -> None:
+        self.api_key = api_key
+        self.base_url = "https://console.vast.ai/api/v0"
+
+    def _get_headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+    def search_offers(
+        self, query: dict[str, Any], order: str = "score-", disable_bundling: bool = True, raw: bool = True
+    ) -> list[dict[str, Any]]:
+        if not isinstance(query, dict):
+            raise ValueError("query must be a dict")
+        query_str = json.dumps(query)
+        query_encoded = urllib.parse.quote(query_str)
+        url = f"{self.base_url}/bundles/?q={query_encoded}"
+        
+        with httpx.Client() as client:
+            resp = client.get(url, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("offers", [])
+
+    def show_templates(self, raw: bool = True) -> list[dict[str, Any]]:
+        url = f"{self.base_url}/users/current/templates/"
+        with httpx.Client() as client:
+            resp = client.get(url, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            return resp.json()
+
+    def create_instance(self, id: str, disk: float, env: str, image: str | None = None, raw: bool = True) -> dict[str, Any]:
+        url = f"{self.base_url}/asks/{id}/"
+        payload = {
+            "client_id": "me",
+            "disk": disk,
+            "env": env,
+            "runtype": "ssh_direct",
+        }
+        if image:
+            payload["image"] = image
+
+        with httpx.Client() as client:
+            resp = client.put(url, json=payload, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            return resp.json()
+
+    def show_instances(self, raw: bool = True) -> list[dict[str, Any]]:
+        url = f"{self.base_url}/instances/"
+        with httpx.Client() as client:
+            resp = client.get(url, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("instances", [])
+
+    def destroy_instance(self, id: str, raw: bool = True) -> dict[str, Any]:
+        url = f"{self.base_url}/instances/{id}/"
+        with httpx.Client() as client:
+            resp = client.delete(url, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            return resp.json()
+
+    def show_volumes(self, raw: bool = True) -> list[dict[str, Any]]:
+        url = f"{self.base_url}/volumes/"
+        with httpx.Client() as client:
+            resp = client.get(url, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            data = resp.json()
+            # API returns a list directly or {"volumes": [...]}
+            if isinstance(data, dict):
+                return data.get("volumes", [])
+            return data
+
+    def destroy_volume(self, id: str, raw: bool = True) -> dict[str, Any]:
+        url = f"{self.base_url}/volumes/{id}/"
+        with httpx.Client() as client:
+            resp = client.delete(url, headers=self._get_headers(), timeout=30.0)
+            resp.raise_for_status()
+            return resp.json()

--- a/rune_bench/resources/vastai/template.py
+++ b/rune_bench/resources/vastai/template.py
@@ -6,7 +6,7 @@ extracting the env flags and Docker image for instance creation.
 
 from dataclasses import dataclass
 
-from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+from rune_bench.resources.vastai.sdk import VastAI
 
 from rune_bench.debug import debug_log
 

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
-    from vastai import VastAI  # type: ignore[import-untyped, import-not-found]  # Reason: vastai SDK does not provide type hints
+    from rune_bench.resources.vastai.sdk import VastAI
 
 from .common import ModelSelector
 from .debug import debug_log

--- a/tests/test_vastai_sdk.py
+++ b/tests/test_vastai_sdk.py
@@ -1,0 +1,77 @@
+import pytest
+import httpx
+from rune_bench.resources.vastai.sdk import VastAI
+
+@pytest.fixture
+def vastai():
+    return VastAI("test-api-key")
+
+def test_headers(vastai):
+    headers = vastai._get_headers()
+    assert headers["Authorization"] == "Bearer test-api-key"
+    assert headers["Accept"] == "application/json"
+
+def test_search_offers(vastai, respx_mock):
+    respx_mock.get("https://console.vast.ai/api/v0/bundles/?q=%7B%22foo%22%3A%20%22bar%22%7D").respond(
+        json={"offers": [{"id": 123}]}
+    )
+    offers = vastai.search_offers({"foo": "bar"})
+    assert len(offers) == 1
+    assert offers[0]["id"] == 123
+
+def test_search_offers_invalid_query(vastai):
+    with pytest.raises(ValueError):
+        vastai.search_offers("invalid")
+
+def test_show_templates(vastai, respx_mock):
+    respx_mock.get("https://console.vast.ai/api/v0/users/current/templates/").respond(
+        json=[{"id": 1}]
+    )
+    templates = vastai.show_templates()
+    assert len(templates) == 1
+    assert templates[0]["id"] == 1
+
+def test_create_instance(vastai, respx_mock):
+    respx_mock.put("https://console.vast.ai/api/v0/asks/456/").respond(
+        json={"success": True}
+    )
+    res = vastai.create_instance(id="456", disk=10.0, env="-e FOO=bar", image="ubuntu:latest")
+    assert res["success"] is True
+
+def test_show_instances(vastai, respx_mock):
+    respx_mock.get("https://console.vast.ai/api/v0/instances/").respond(
+        json={"instances": [{"id": 456}]}
+    )
+    instances = vastai.show_instances()
+    assert len(instances) == 1
+    assert instances[0]["id"] == 456
+
+def test_destroy_instance(vastai, respx_mock):
+    respx_mock.delete("https://console.vast.ai/api/v0/instances/456/").respond(
+        json={"success": True}
+    )
+    res = vastai.destroy_instance("456")
+    assert res["success"] is True
+
+def test_show_volumes(vastai, respx_mock):
+    respx_mock.get("https://console.vast.ai/api/v0/volumes/").respond(
+        json={"volumes": [{"id": "vol-1"}]}
+    )
+    vols = vastai.show_volumes()
+    assert len(vols) == 1
+    assert vols[0]["id"] == "vol-1"
+
+def test_show_volumes_direct_list(vastai, respx_mock):
+    respx_mock.get("https://console.vast.ai/api/v0/volumes/").respond(
+        json=[{"id": "vol-2"}]
+    )
+    vols = vastai.show_volumes()
+    assert len(vols) == 1
+    assert vols[0]["id"] == "vol-2"
+
+def test_destroy_volume(vastai, respx_mock):
+    respx_mock.delete("https://console.vast.ai/api/v0/volumes/vol-1/").respond(
+        json={"success": True}
+    )
+    res = vastai.destroy_volume("vol-1")
+    assert res["success"] is True


### PR DESCRIPTION
## Summary

Resolves #121 (partial). Replaces vastai-sdk with local httpx wrapper. Deprecates safety for pip-audit. Fixes seaweedfs healthcheck.

Closes #121
Epic: #121

## DoD Level

- [x] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [x] Tested in **docker-compose mode**
- [x] Tested in **kind (Kubernetes) mode**
- [x] Tested in **standalone CLI mode**
- [x] **Breaking change audit**: API versions, persistent data, cross-component contracts
- [x] **Dependency CVE audit** (if deps changed): `pip-audit` / `govulncheck` / `grype` — no new CVEs

## Level 2 Checklist

- [ ] Full test suite passes
- [ ] Coverage not degraded (at or above floor)
- [ ] No unintended CI side effects

## Level 3 Checklist

- [ ] `mkdocs build --strict` passes
- [ ] `pymarkdown scan README.md docs` passes

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:dep vastai-sdk` | PASS | pip-audit output |

## Acceptance Criteria Evidence

- [x] CVEs resolved
- [x] Docker networking fixed

## Test Plan Evidence

- [x] Kind tests passing
- [x] Compose tests passing

## Breaking Changes

None.

## Notes for Reviewer

None.