### PR TITLE
chore(release): bump version to 0.0.0a4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rune-bench"
-version = "0.0.0a3"
+version = "0.0.0a4"
 description = "RUNE — Reliability Use-case Numeric Evaluator"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Bumps version to 0.0.0a4 to trigger a clean release of artifacts after CI fixes.

Closes #166
Epic: #121

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [ ] Tested in **docker-compose mode**
- [ ] Tested in **kind (Kubernetes) mode**
- [ ] Tested in **standalone CLI mode**
- [ ] **Breaking change audit**: API versions, persistent data, cross-component contracts
- [ ] **Dependency CVE audit** (if deps changed): `pip-audit` / `govulncheck` / `grype` — no new CVEs

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Level 3 Checklist

- [ ] `mkdocs build --strict` passes
- [ ] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Version bumped to `0.0.0a4`

## Test Plan Evidence

- [x] Version bump passes CI checks

## Breaking Changes

None.

## Notes for Reviewer

None.
