### PR TITLE
refactor: extract Ollama logic from workflows into backends/

### DIFF
--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -47,14 +47,21 @@ from rune_bench.workflows import (
     VastAIProvisioningResult,
     DEFAULT_SPEND_THRESHOLD,
     evaluate_spend_gate,
-    list_existing_ollama_models,
-    list_running_ollama_models,
-    provision_vastai_ollama,
+    list_backend_models,
+    list_running_backend_models,
+    provision_vastai_backend,
     run_preflight_cost_check,
     stop_vastai_instance,
-    warmup_existing_ollama_model,
-    use_existing_ollama_server,
+    warmup_backend_model,
+    use_existing_backend_server,
 )
+
+# Backward-compatible aliases for renamed workflow functions.
+use_existing_ollama_server = use_existing_backend_server
+list_existing_ollama_models = list_backend_models
+list_running_ollama_models = list_running_backend_models
+warmup_existing_ollama_model = warmup_backend_model
+provision_vastai_ollama = provision_vastai_backend
 
 app = typer.Typer(help="RUNE — Reliability Use-case Numeric Evaluator", add_completion=False)
 console = Console()
@@ -465,7 +472,7 @@ def _warmup_ollama_model(*, backend_url: str, model_name: str, timeout_seconds: 
     with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as progress:
         progress.add_task(f"Loading Ollama model {model_name} and waiting until it is ready...", total=None)
         try:
-            warmed_model = warmup_existing_ollama_model(
+            warmed_model = warmup_backend_model(
                 backend_url,
                 model_name,
                 timeout_seconds=timeout_seconds,
@@ -492,7 +499,7 @@ def _run_vastai_provisioning(
             p.update(task, description=f"Waiting for running status: {status}")
 
         try:
-            return provision_vastai_ollama(
+            return provision_vastai_backend(
                 sdk,
                 template_hash=template_hash,
                 min_dph=min_dph,
@@ -649,7 +656,7 @@ def run_llm_instance(
 
     if not vastai:
         try:
-            server = use_existing_ollama_server(backend_url, model_name="<user-selected>")
+            server = use_existing_backend_server(backend_url, model_name="<user-selected>")
         except RuntimeError as exc:
             _print_error_and_exit(str(exc))
         _print_existing_ollama(server)
@@ -729,9 +736,9 @@ def ollama_list_models(
         return
 
     try:
-        normalized_url = use_existing_ollama_server(backend_url, model_name="<n/a>").url
-        models = list_existing_ollama_models(normalized_url)
-        running_models = set(list_running_ollama_models(normalized_url))
+        normalized_url = use_existing_backend_server(backend_url, model_name="<n/a>").url
+        models = list_backend_models(normalized_url)
+        running_models = set(list_running_backend_models(normalized_url))
     except RuntimeError as exc:
         _print_error_and_exit(str(exc))
 
@@ -1031,7 +1038,7 @@ def run_benchmark(
             )
     else:
         try:
-            server = use_existing_ollama_server(backend_url, model_name=selected_model_name)
+            server = use_existing_backend_server(backend_url, model_name=selected_model_name)
         except RuntimeError as exc:
             _print_error_and_exit(str(exc))
         console.print("\n[bold cyan]PHASE 1: Using Existing Ollama Server[/bold cyan]")

--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -18,10 +18,10 @@ from rune_bench.metrics import span  # noqa: F401 (used by workflows layer)
 from rune_bench.resources.base import LLMResourceProvider
 from rune_bench.resources.existing_ollama_provider import ExistingOllamaProvider
 from rune_bench.workflows import (
-    list_existing_ollama_models,
-    list_running_ollama_models,
-    use_existing_ollama_server,
-    warmup_existing_ollama_model,
+    list_backend_models as list_backend_models_wf,
+    list_running_backend_models,
+    use_existing_backend_server,
+    warmup_backend_model,
 )
 
 try:
@@ -107,11 +107,11 @@ def list_vastai_models() -> list[dict]:
 
 
 def list_backend_models(backend_url: str) -> dict:
-    server = use_existing_ollama_server(backend_url, model_name="<n/a>")
+    server = use_existing_backend_server(backend_url, model_name="<n/a>")
     return {
         "backend_url": server.url,
-        "models": list_existing_ollama_models(server.url),
-        "running_models": list_running_ollama_models(server.url),
+        "models": list_backend_models_wf(server.url),
+        "running_models": list_running_backend_models(server.url),
     }
 
 
@@ -127,7 +127,7 @@ def run_llm_instance(request: RunLLMInstanceRequest) -> dict:
 
 def run_agentic_agent(request: RunAgenticAgentRequest) -> dict:
     if request.backend_url and request.backend_warmup:
-        warmup_existing_ollama_model(
+        warmup_backend_model(
             request.backend_url,
             request.model,
             timeout_seconds=request.backend_warmup_timeout,

--- a/rune_bench/backends/__init__.py
+++ b/rune_bench/backends/__init__.py
@@ -1,18 +1,82 @@
-"""LLM backend protocol and implementations.
+"""LLM backend protocol, registry, and factory.
 
 Backends define HOW to communicate with an LLM — handling auth, model
 capability discovery, and inference calls — independent of WHERE the LLM
 runs (resources/) or WHAT the agent does with it (agents/).
+
+The registry supports two kinds of backends:
+
+1. **Built-in backends** listed in :data:`_BUILTIN_BACKENDS` -- resolved via
+   :func:`importlib.import_module` the first time they are requested.
+2. **Custom backends** added at runtime via :func:`register_backend`.
+
+Custom registrations take precedence over built-in entries so that
+downstream integrations can override the default implementation of any
+backend without modifying this module.
 """
 
+from __future__ import annotations
+
+import importlib
+
 from .base import BackendCredentials, LLMBackend, ModelCapabilities
-from .ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
+from .ollama import OllamaBackend, OllamaClient, OllamaModelCapabilities, OllamaModelManager
+
+_BACKEND_REGISTRY: dict[str, type] = {}
+
+_BUILTIN_BACKENDS: dict[str, tuple[str, str]] = {
+    "ollama": ("rune_bench.backends.ollama", "OllamaBackend"),
+}
+
+
+def register_backend(name: str, cls: type) -> None:
+    """Register a custom backend class under *name*.
+
+    Custom registrations shadow built-in entries so callers can override
+    the default implementation at runtime.
+    """
+    _BACKEND_REGISTRY[name] = cls
+
+
+def get_backend(backend_type: str, base_url: str, **kwargs: object) -> LLMBackend:
+    """Resolve and instantiate an LLM backend by type.
+
+    Resolution order:
+    1. Custom registry (populated by :func:`register_backend`).
+    2. Built-in map (lazy ``importlib.import_module``).
+
+    Raises:
+        ValueError: if *backend_type* is not found in either source.
+    """
+    if backend_type in _BACKEND_REGISTRY:
+        return _BACKEND_REGISTRY[backend_type](base_url, **kwargs)  # type: ignore[return-value]
+
+    if backend_type in _BUILTIN_BACKENDS:
+        module_path, class_name = _BUILTIN_BACKENDS[backend_type]
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, class_name)
+        return cls(base_url, **kwargs)  # type: ignore[return-value]
+
+    available = sorted(set(list(_BACKEND_REGISTRY.keys()) + list(_BUILTIN_BACKENDS.keys())))
+    raise ValueError(
+        f"Unknown backend type {backend_type!r}. Available: {', '.join(available)}"
+    )
+
+
+def list_backends() -> list[str]:
+    """Return a sorted list of all known backend type names."""
+    return sorted(set(list(_BACKEND_REGISTRY.keys()) + list(_BUILTIN_BACKENDS.keys())))
+
 
 __all__ = [
     "BackendCredentials",
     "LLMBackend",
     "ModelCapabilities",
+    "OllamaBackend",
     "OllamaClient",
     "OllamaModelCapabilities",
     "OllamaModelManager",
+    "get_backend",
+    "list_backends",
+    "register_backend",
 ]

--- a/rune_bench/backends/base.py
+++ b/rune_bench/backends/base.py
@@ -1,7 +1,7 @@
 """Protocol and credential types for LLM backend implementations."""
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -27,6 +27,7 @@ class BackendCredentials:
     extra: dict[str, str] = field(default_factory=dict, hash=False, compare=False)
 
 
+@runtime_checkable
 class LLMBackend(Protocol):
     """Protocol for LLM backend clients.
 
@@ -34,6 +35,34 @@ class LLMBackend(Protocol):
     alongside the existing Ollama backend.
     """
 
+    @property
+    def base_url(self) -> str:
+        """Return the normalized backend endpoint URL."""
+        ...
+
     def get_model_capabilities(self, model: str) -> ModelCapabilities:
         """Return best-effort capability metadata for the given model."""
+        ...
+
+    def list_models(self) -> list[str]:
+        """Return model names available on this backend."""
+        ...
+
+    def list_running_models(self) -> list[str]:
+        """Return model names currently loaded/active on this backend."""
+        ...
+
+    def normalize_model_name(self, model_name: str) -> str:
+        """Normalize a provider-prefixed model name to the backend's native form."""
+        ...
+
+    def warmup(
+        self,
+        model_name: str,
+        *,
+        timeout_seconds: int = 120,
+        poll_interval_seconds: float = 2.0,
+        keep_alive: str = "30m",
+    ) -> str:
+        """Load a model and wait until it is ready. Return the resolved model name."""
         ...

--- a/rune_bench/backends/ollama.py
+++ b/rune_bench/backends/ollama.py
@@ -2,14 +2,20 @@
 
 Consolidates the low-level API client (OllamaClient) and the high-level
 model lifecycle manager (OllamaModelManager) into a single backend module.
+The :class:`OllamaBackend` facade exposes every Ollama-specific operation
+so that the workflow layer remains backend-agnostic.
 """
+
+from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from typing import Any
 
 from rune_bench.backends.base import ModelCapabilities
 from rune_bench.common import make_http_request, normalize_url
 from rune_bench.debug import debug_log
+from rune_bench.metrics import span
 
 # ---------------------------------------------------------------------------
 # Public type alias — keeps existing callsites using OllamaModelCapabilities
@@ -186,3 +192,89 @@ class OllamaModelManager:
             if normalized.startswith(prefix):
                 return normalized.removeprefix(prefix)
         return normalized
+
+
+class OllamaBackend:
+    """Facade over OllamaClient + OllamaModelManager implementing LLMBackend.
+
+    Provides every Ollama-specific operation that the workflow layer needs,
+    keeping ``workflows.py`` free of Ollama implementation details.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self._manager = OllamaModelManager.create(base_url)
+
+    @property
+    def base_url(self) -> str:
+        """Return the normalized Ollama server URL."""
+        return self._manager.client.base_url
+
+    # -- URL helpers --------------------------------------------------------
+
+    @staticmethod
+    def normalize_url(url: str | None) -> str:
+        """Validate and normalize an Ollama base URL.
+
+        Adds ``http://`` when missing.  Raises ``RuntimeError`` when *url* is
+        ``None``.
+        """
+        if url is None:
+            raise RuntimeError("Missing Ollama URL")
+        client = OllamaClient(url)
+        return client.base_url
+
+    @staticmethod
+    def extract_service_url(details: Any) -> str | None:
+        """Return the Ollama endpoint from Vast.ai connection details.
+
+        Scans *details.service_urls* for port 11434 (Ollama default).
+        """
+        for svc in details.service_urls:
+            direct = str(svc.get("direct", ""))
+            proxy = str(svc.get("proxy", "")) if svc.get("proxy") else ""
+            if ":11434" in direct:
+                return direct
+            if ":11434" in proxy:
+                return proxy
+        return None
+
+    # -- Server / model operations -----------------------------------------
+
+    def get_model_capabilities(self, model: str) -> ModelCapabilities:
+        """Return best-effort capability metadata for the given model."""
+        return self._manager.client.get_model_capabilities(model)
+
+    def list_models(self) -> list[str]:
+        """Return model names available on this backend."""
+        return self._manager.list_available_models()
+
+    def list_running_models(self) -> list[str]:
+        """Return model names currently loaded/active on this backend."""
+        return self._manager.list_running_models()
+
+    def normalize_model_name(self, model_name: str) -> str:
+        """Normalize a provider-prefixed model name to the backend's native form."""
+        return self._manager.normalize_model_name(model_name)
+
+    def warmup(
+        self,
+        model_name: str,
+        *,
+        timeout_seconds: int = 120,
+        poll_interval_seconds: float = 2.0,
+        keep_alive: str = "30m",
+    ) -> str:
+        """Load a model and wait until it is ready. Return the resolved model name."""
+        api_model_name = self._manager.normalize_model_name(model_name)
+        debug_log(
+            f"OllamaBackend warmup: base_url={self.base_url} "
+            f"requested_model={model_name} api_model={api_model_name}"
+        )
+        with span("ollama.model.warmup", model=api_model_name):
+            return self._manager.warmup_model(
+                api_model_name,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                keep_alive=keep_alive,
+                unload_others=True,
+            )

--- a/rune_bench/resources/existing_ollama_provider.py
+++ b/rune_bench/resources/existing_ollama_provider.py
@@ -1,7 +1,7 @@
 """Existing Ollama server LLM resource provider."""
 
 from rune_bench.resources.base import ProvisioningResult
-from rune_bench.workflows import use_existing_ollama_server, warmup_existing_ollama_model
+from rune_bench.workflows import use_existing_backend_server, warmup_backend_model
 
 
 class ExistingOllamaProvider:
@@ -25,12 +25,12 @@ class ExistingOllamaProvider:
         self._warmup_timeout = warmup_timeout
 
     def provision(self) -> ProvisioningResult:
-        server = use_existing_ollama_server(
+        server = use_existing_backend_server(
             self._backend_url,
             model_name=self._model or "<user-selected>",
         )
         if self._warmup and self._model:
-            warmup_existing_ollama_model(
+            warmup_backend_model(
                 server.url,
                 self._model,
                 timeout_seconds=self._warmup_timeout,

--- a/rune_bench/resources/vastai/provider.py
+++ b/rune_bench/resources/vastai/provider.py
@@ -8,7 +8,7 @@ from rune_bench.resources.base import ProvisioningResult
 class VastAIProvider:
     """LLMResourceProvider backed by Vast.ai GPU instances.
 
-    Wraps :func:`rune_bench.workflows.provision_vastai_ollama` and
+    Wraps :func:`rune_bench.workflows.provision_vastai_backend` and
     :func:`rune_bench.workflows.stop_vastai_instance`.
     """
 
@@ -30,8 +30,8 @@ class VastAIProvider:
         self._stop_on_teardown = stop_on_teardown
 
     def provision(self) -> ProvisioningResult:
-        from rune_bench.workflows import provision_vastai_ollama
-        result = provision_vastai_ollama(
+        from rune_bench.workflows import provision_vastai_backend
+        result = provision_vastai_backend(
             self._sdk,
             template_hash=self._template_hash,
             min_dph=self._min_dph,

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -1,6 +1,8 @@
 """Application workflows used by the RUNE CLI.
 
 This module keeps orchestration/business logic out of the CLI layer.
+Generic dispatchers delegate to backend-specific implementations in
+``rune_bench/backends/``.
 """
 
 from __future__ import annotations
@@ -16,8 +18,8 @@ if TYPE_CHECKING:
 
 from .common import ModelSelector
 from .debug import debug_log
-from .metrics import span
-from rune_bench.backends.ollama import OllamaClient, OllamaModelManager
+from .metrics import span  # noqa: F401
+from rune_bench.backends.ollama import OllamaBackend
 
 try:
     from rune_bench.resources.vastai import ConnectionDetails, InstanceManager, OfferFinder, TeardownResult, TemplateLoader
@@ -82,42 +84,44 @@ class VastAIProvisioningResult:
     pull_warning: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# Generic backend dispatchers
+# ---------------------------------------------------------------------------
+
 def normalize_backend_url(backend_url: str | None) -> str:
-    """Validate and normalize an Ollama base URL.
+    """Validate and normalize a backend base URL.
 
-    Adds ``http://`` when missing. This is a convenience wrapper that delegates
-    to OllamaClient's normalization logic.
+    Delegates to :meth:`OllamaBackend.normalize_url`.
     """
-    if backend_url is None:
-        raise RuntimeError("Missing Ollama URL")
-    client = OllamaClient(backend_url)
-    return client.base_url
+    return OllamaBackend.normalize_url(backend_url)
 
 
-def use_existing_ollama_server(backend_url: str | None, model_name: str) -> ExistingOllamaServer:
-    """Resolve an existing Ollama server target."""
+def use_existing_backend_server(backend_url: str | None, model_name: str) -> ExistingOllamaServer:
+    """Resolve an existing backend server target."""
     return ExistingOllamaServer(url=normalize_backend_url(backend_url), model_name=model_name)
 
 
-def list_existing_ollama_models(backend_url: str | None) -> list[str]:
-    """Return available model names from an existing Ollama server."""
-    manager = OllamaModelManager.create(normalize_backend_url(backend_url))
-    return manager.list_available_models()
+def list_backend_models(backend_url: str | None) -> list[str]:
+    """Return available model names from an existing backend server."""
+    url = normalize_backend_url(backend_url)
+    backend = OllamaBackend(url)
+    return backend.list_models()
 
 
-def list_running_ollama_models(backend_url: str | None) -> list[str]:
-    """Return model names currently loaded in memory on an existing Ollama server."""
-    manager = OllamaModelManager.create(normalize_backend_url(backend_url))
-    return manager.list_running_models()
+def list_running_backend_models(backend_url: str | None) -> list[str]:
+    """Return model names currently loaded in memory on an existing backend server."""
+    url = normalize_backend_url(backend_url)
+    backend = OllamaBackend(url)
+    return backend.list_running_models()
 
 
-def normalize_ollama_model_for_api(model_name: str) -> str:
-    """Convert provider-prefixed model identifiers into plain Ollama model names."""
-    manager = OllamaModelManager.create("http://localhost:11434")  # URL not used for normalization
-    return manager.normalize_model_name(model_name)
+def normalize_backend_model_for_api(model_name: str) -> str:
+    """Convert provider-prefixed model identifiers into plain backend model names."""
+    backend = OllamaBackend("http://localhost:11434")  # URL not used for normalization
+    return backend.normalize_model_name(model_name)
 
 
-def warmup_existing_ollama_model(
+def warmup_backend_model(
     backend_url: str | None,
     model_name: str,
     *,
@@ -125,26 +129,32 @@ def warmup_existing_ollama_model(
     poll_interval_seconds: float = 2.0,
     keep_alive: str = "30m",
 ) -> str:
-    """Load a model into an existing Ollama server and wait until it is running."""
-    normalized_url = normalize_backend_url(backend_url)
-    manager = OllamaModelManager.create(normalized_url)
-    api_model_name = manager.normalize_model_name(model_name)
-    debug_log(
-        f"Workflow warmup: backend_url={normalized_url} requested_model={model_name} api_model={api_model_name}"
+    """Load a model into an existing backend server and wait until it is running."""
+    url = normalize_backend_url(backend_url)
+    backend = OllamaBackend(url)
+    return backend.warmup(
+        model_name,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        keep_alive=keep_alive,
     )
 
-    with span("ollama.model.warmup", model=api_model_name):
-        return manager.warmup_model(
-            api_model_name,
-            timeout_seconds=timeout_seconds,
-            poll_interval_seconds=poll_interval_seconds,
-            keep_alive=keep_alive,
-            unload_others=True,
-        )
+
+# -- Backward-compatible aliases -------------------------------------------
+# These preserve import compatibility for any callsite still using the old
+# Ollama-specific names.  They will be removed in a future release.
+use_existing_ollama_server = use_existing_backend_server
+list_existing_ollama_models = list_backend_models
+list_running_ollama_models = list_running_backend_models
+normalize_ollama_model_for_api = normalize_backend_model_for_api
+warmup_existing_ollama_model = warmup_backend_model
 
 
+# ---------------------------------------------------------------------------
+# Vast.ai provisioning workflow
+# ---------------------------------------------------------------------------
 
-def provision_vastai_ollama(
+def provision_vastai_backend(
     sdk: VastAI,
     *,
     template_hash: str,
@@ -154,7 +164,7 @@ def provision_vastai_ollama(
     confirm_create: Callable[[], bool],
     on_poll: Callable[[str], None] | None = None,
 ) -> VastAIProvisioningResult:
-    """Run the full Vast.ai + Ollama provisioning workflow.
+    """Run the full Vast.ai + backend provisioning workflow.
 
     Reuses an already-running matching instance when possible; otherwise provisions a new one.
     Ensures the selected model is present and warmed up before returning.
@@ -211,8 +221,8 @@ def provision_vastai_ollama(
         offer_id = offer.offer_id
 
     details = InstanceManager.build_connection_details(contract_id, instance_info)
-    backend_url = _extract_ollama_service_url(details)
-    debug_log(f"Workflow detected Ollama URL: {backend_url or '<missing>'}")
+    backend_url = OllamaBackend.extract_service_url(details)
+    debug_log(f"Workflow detected backend URL: {backend_url or '<missing>'}")
 
     pull_warning = None
     try:
@@ -221,11 +231,11 @@ def provision_vastai_ollama(
                 "Could not determine Ollama URL from instance service mappings (port 11434 missing)."
             )
 
-        available = set(list_existing_ollama_models(backend_url))
-        running = set(list_running_ollama_models(backend_url))
-        api_model = normalize_ollama_model_for_api(selected_model.name)
+        available = set(list_backend_models(backend_url))
+        running = set(list_running_backend_models(backend_url))
+        api_model = normalize_backend_model_for_api(selected_model.name)
         debug_log(
-            f"Workflow Ollama state: available={sorted(available)} running={sorted(running)} selected={api_model}"
+            f"Workflow backend state: available={sorted(available)} running={sorted(running)} selected={api_model}"
         )
 
         if api_model not in running:
@@ -233,7 +243,7 @@ def provision_vastai_ollama(
                 with span("vastai.model.pull", model=selected_model.name):
                     manager.pull_model(contract_id, selected_model.name, backend_url=backend_url)
 
-            warmup_existing_ollama_model(
+            warmup_backend_model(
                 backend_url,
                 selected_model.name,
                 timeout_seconds=120,
@@ -254,6 +264,10 @@ def provision_vastai_ollama(
         reused_existing_instance=reused_existing_instance,
         pull_warning=pull_warning,
     )
+
+
+# Backward-compatible alias
+provision_vastai_ollama = provision_vastai_backend
 
 
 def stop_vastai_instance(sdk: VastAI, contract_id: int | str) -> TeardownResult:
@@ -298,12 +312,7 @@ def run_preflight_cost_check(
     response = asyncio.run(estimator.estimate(cost_req))
     return response.to_dict()
 
+
 def _extract_ollama_service_url(details: ConnectionDetails) -> str | None:
-    for svc in details.service_urls:
-        direct = str(svc.get("direct", ""))
-        proxy = str(svc.get("proxy", "")) if svc.get("proxy") else ""
-        if ":11434" in direct:
-            return direct
-        if ":11434" in proxy:
-            return proxy
-    return None
+    """Backward-compatible alias for :meth:`OllamaBackend.extract_service_url`."""
+    return OllamaBackend.extract_service_url(details)

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -1,0 +1,244 @@
+"""Tests for the LLM backend factory, registry, and OllamaBackend wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rune_bench.backends import get_backend, list_backends, register_backend
+from rune_bench.backends import _BACKEND_REGISTRY
+from rune_bench.backends.base import LLMBackend, ModelCapabilities
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _MockBackend:
+    """Minimal backend that satisfies the LLMBackend protocol for testing."""
+
+    def __init__(self, base_url: str, **kwargs: object) -> None:
+        self._base_url = base_url
+        self._kwargs = kwargs
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def get_model_capabilities(self, model: str) -> ModelCapabilities:
+        return ModelCapabilities(model_name=model)
+
+    def list_models(self) -> list[str]:
+        return ["mock-model"]
+
+    def list_running_models(self) -> list[str]:
+        return []
+
+    def normalize_model_name(self, model_name: str) -> str:
+        return model_name
+
+    def warmup(
+        self,
+        model_name: str,
+        *,
+        timeout_seconds: int = 120,
+        poll_interval_seconds: float = 2.0,
+        keep_alive: str = "30m",
+    ) -> str:
+        return model_name
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Ensure a pristine custom registry for each test."""
+    saved = dict(_BACKEND_REGISTRY)
+    _BACKEND_REGISTRY.clear()
+    yield
+    _BACKEND_REGISTRY.clear()
+    _BACKEND_REGISTRY.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Factory: get_backend
+# ---------------------------------------------------------------------------
+
+class TestGetBackend:
+    """Tests for the get_backend() factory function."""
+
+    def test_builtin_ollama_returns_ollama_backend(self):
+        """get_backend('ollama', ...) returns an OllamaBackend instance."""
+        with patch("rune_bench.backends.ollama.OllamaClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.base_url = "http://localhost:11434"
+            mock_client_cls.return_value = mock_client
+
+            backend = get_backend("ollama", "http://localhost:11434")
+
+        from rune_bench.backends.ollama import OllamaBackend
+        assert isinstance(backend, OllamaBackend)
+
+    def test_unknown_backend_raises_value_error(self):
+        """get_backend() raises ValueError for unregistered backend types."""
+        with pytest.raises(ValueError, match="Unknown backend type 'nonexistent'"):
+            get_backend("nonexistent", "http://localhost:1234")
+
+    def test_unknown_backend_error_lists_available(self):
+        """The ValueError message includes available backend names."""
+        with pytest.raises(ValueError, match="ollama"):
+            get_backend("nonexistent", "http://localhost:1234")
+
+    def test_custom_registry_returns_custom_backend(self):
+        """register_backend() makes the backend available via get_backend()."""
+        register_backend("mock", _MockBackend)
+        backend = get_backend("mock", "http://example.com:8080")
+        assert isinstance(backend, _MockBackend)
+        assert backend.base_url == "http://example.com:8080"
+
+    def test_custom_registry_shadows_builtin(self):
+        """Custom registration takes precedence over built-in entries."""
+        register_backend("ollama", _MockBackend)
+        backend = get_backend("ollama", "http://localhost:11434")
+        assert isinstance(backend, _MockBackend)
+
+    def test_kwargs_forwarded_to_custom_backend(self):
+        """Extra kwargs are forwarded to the backend constructor."""
+        register_backend("mock", _MockBackend)
+        backend = get_backend("mock", "http://example.com", extra_param="value")
+        assert isinstance(backend, _MockBackend)
+        assert backend._kwargs == {"extra_param": "value"}
+
+
+# ---------------------------------------------------------------------------
+# Registry: register_backend / list_backends
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    """Tests for register_backend() and list_backends()."""
+
+    def test_list_backends_default(self):
+        """list_backends() includes built-in backends."""
+        backends = list_backends()
+        assert "ollama" in backends
+
+    def test_list_backends_includes_custom(self):
+        """list_backends() includes custom registrations."""
+        register_backend("custom-test", _MockBackend)
+        backends = list_backends()
+        assert "custom-test" in backends
+        assert "ollama" in backends
+
+    def test_list_backends_sorted(self):
+        """list_backends() returns a sorted list."""
+        register_backend("zzz-backend", _MockBackend)
+        register_backend("aaa-backend", _MockBackend)
+        backends = list_backends()
+        assert backends == sorted(backends)
+
+    def test_register_backend_overwrites(self):
+        """Registering the same name twice keeps the latest."""
+        register_backend("dup", _MockBackend)
+        register_backend("dup", _MockBackend)
+        assert _BACKEND_REGISTRY["dup"] is _MockBackend
+
+
+# ---------------------------------------------------------------------------
+# OllamaBackend protocol conformance
+# ---------------------------------------------------------------------------
+
+class TestOllamaBackendProtocol:
+    """Verify OllamaBackend satisfies the LLMBackend protocol."""
+
+    def test_isinstance_check(self):
+        """OllamaBackend passes isinstance(obj, LLMBackend) at runtime."""
+        with patch("rune_bench.backends.ollama.OllamaClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.base_url = "http://localhost:11434"
+            mock_client_cls.return_value = mock_client
+
+            from rune_bench.backends.ollama import OllamaBackend
+            backend = OllamaBackend("http://localhost:11434")
+            assert isinstance(backend, LLMBackend)
+
+    def test_has_all_protocol_methods(self):
+        """OllamaBackend defines every method in the LLMBackend protocol."""
+        from rune_bench.backends.ollama import OllamaBackend
+        required_methods = [
+            "base_url",
+            "get_model_capabilities",
+            "list_models",
+            "list_running_models",
+            "normalize_model_name",
+            "warmup",
+        ]
+        for method in required_methods:
+            assert hasattr(OllamaBackend, method), f"Missing {method}"
+
+
+# ---------------------------------------------------------------------------
+# OllamaBackend method delegation
+# ---------------------------------------------------------------------------
+
+class TestOllamaBackendDelegation:
+    """Verify OllamaBackend delegates to OllamaModelManager correctly."""
+
+    @pytest.fixture()
+    def backend(self):
+        """Create an OllamaBackend with mocked HTTP layer."""
+        with patch("rune_bench.backends.ollama.OllamaClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.base_url = "http://localhost:11434"
+            mock_client_cls.return_value = mock_client
+            from rune_bench.backends.ollama import OllamaBackend
+            backend = OllamaBackend("http://localhost:11434")
+            backend._mock_client = mock_client
+            yield backend
+
+    def test_base_url_property(self, backend):
+        assert backend.base_url == "http://localhost:11434"
+
+    def test_get_model_capabilities(self, backend):
+        caps = ModelCapabilities(model_name="test-model", context_window=4096)
+        backend._mock_client.get_model_capabilities.return_value = caps
+        result = backend.get_model_capabilities("test-model")
+        assert result == caps
+        backend._mock_client.get_model_capabilities.assert_called_once_with("test-model")
+
+    def test_list_models(self, backend):
+        backend._mock_client.get_available_models.return_value = ["model-a", "model-b"]
+        result = backend.list_models()
+        assert result == ["model-a", "model-b"]
+
+    def test_list_running_models(self, backend):
+        backend._mock_client.get_running_models.return_value = {"model-a"}
+        result = backend.list_running_models()
+        assert result == ["model-a"]
+
+    def test_normalize_model_name(self, backend):
+        assert backend.normalize_model_name("ollama/tinyllama") == "tinyllama"
+        assert backend.normalize_model_name("ollama_chat/tinyllama") == "tinyllama"
+        assert backend.normalize_model_name("tinyllama") == "tinyllama"
+
+    def test_warmup_delegates_to_manager(self, backend):
+        backend._mock_client.get_running_models.return_value = set()
+        backend._mock_client.load_model.return_value = None
+        # After load, model appears in running
+        backend._mock_client.get_running_models.side_effect = [
+            set(),         # _unload_conflicting_models
+            {"tinyllama"},  # poll check
+        ]
+        result = backend.warmup("tinyllama", timeout_seconds=5, poll_interval_seconds=0.1)
+        assert result == "tinyllama"
+
+
+# ---------------------------------------------------------------------------
+# MockBackend protocol conformance
+# ---------------------------------------------------------------------------
+
+class TestMockBackendProtocol:
+    """Verify _MockBackend satisfies the LLMBackend protocol."""
+
+    def test_mock_isinstance_check(self):
+        """_MockBackend passes isinstance(obj, LLMBackend) at runtime."""
+        backend = _MockBackend("http://example.com")
+        assert isinstance(backend, LLMBackend)

--- a/tests/test_comprehensive_error_paths.py
+++ b/tests/test_comprehensive_error_paths.py
@@ -341,7 +341,7 @@ def test_offer_template_backend_instance_and_workflow_remaining(monkeypatch, tmp
     sdk.show_volumes.side_effect = Exception("nope")
     assert InstanceManager(sdk)._list_volumes_optional() is None
 
-    monkeypatch.setattr(workflows, "OllamaClient", lambda _url: (_ for _ in ()).throw(RuntimeError("bad")))
+    monkeypatch.setattr("rune_bench.backends.ollama.OllamaClient", lambda _url: (_ for _ in ()).throw(RuntimeError("bad")))
     with pytest.raises(RuntimeError, match="bad"):
         workflows.normalize_backend_url("x")
 
@@ -379,11 +379,11 @@ def test_offer_template_backend_instance_and_workflow_remaining(monkeypatch, tmp
 
     monkeypatch.setattr(workflows, "InstanceManager", CreatedManager)
     monkeypatch.setattr(workflows.ModelSelector, "select", lambda self, _vram: type("M", (), {"name": "m", "vram_mb": 1, "required_disk_gb": 2})())
-    monkeypatch.setattr(workflows, "list_existing_ollama_models", lambda _url: [])
-    monkeypatch.setattr(workflows, "list_running_ollama_models", lambda _url: [])
-    monkeypatch.setattr(workflows, "normalize_ollama_model_for_api", lambda model: model)
-    monkeypatch.setattr(workflows, "warmup_existing_ollama_model", lambda *_args, **_kwargs: "m")
-    res = workflows.provision_vastai_ollama(MagicMock(), template_hash="t", min_dph=1, max_dph=2, reliability=0.9, confirm_create=lambda: True)
+    monkeypatch.setattr(workflows, "list_backend_models", lambda _url: [])
+    monkeypatch.setattr(workflows, "list_running_backend_models", lambda _url: [])
+    monkeypatch.setattr(workflows, "normalize_backend_model_for_api", lambda model: model)
+    monkeypatch.setattr(workflows, "warmup_backend_model", lambda *_args, **_kwargs: "m")
+    res = workflows.provision_vastai_backend(MagicMock(), template_hash="t", min_dph=1, max_dph=2, reliability=0.9, confirm_create=lambda: True)
     assert res.pull_warning is not None
 
 
@@ -396,7 +396,7 @@ def test_api_backend_and_workflow_last_edges(monkeypatch, tmp_path):
 
     fake_client = MagicMock()
     fake_client.get_available_models.return_value = ["x"]
-    manager = api_backend.use_existing_ollama_server
+    manager = api_backend.use_existing_backend_server
     assert callable(manager)
 
 

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -245,12 +245,9 @@ def test_api_server_backend_success_paths(monkeypatch):
 
 def test_workflow_normalize_backend_url_success(monkeypatch):
     from rune_bench import workflows
+    from rune_bench.backends.ollama import OllamaBackend
 
-    class DummyClient:
-        def __init__(self, _url: str):
-            self.base_url = "http://normalized:11434"
-
-    monkeypatch.setattr(workflows, "OllamaClient", DummyClient)
+    monkeypatch.setattr(OllamaBackend, "normalize_url", staticmethod(lambda _url: "http://normalized:11434"))
     assert workflows.normalize_backend_url("localhost:11434") == "http://normalized:11434"
 
 
@@ -295,7 +292,7 @@ def test_vastai_provider_provision_and_teardown(monkeypatch):
     fake_provision_result.contract_id = 42
 
     import rune_bench.workflows as workflows_mod
-    monkeypatch.setattr(workflows_mod, "provision_vastai_ollama", lambda *_a, **_k: fake_provision_result)
+    monkeypatch.setattr(workflows_mod, "provision_vastai_backend", lambda *_a, **_k: fake_provision_result)
 
     stop_calls = []
     monkeypatch.setattr(workflows_mod, "stop_vastai_instance", lambda sdk, cid: stop_calls.append(cid))

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -124,7 +124,7 @@ def test_rune_remaining_branches(monkeypatch, tmp_path):
         kwargs["on_poll"]("running")
         return result
 
-    monkeypatch.setattr(rune, "provision_vastai_ollama", fake_provision)
+    monkeypatch.setattr(rune, "provision_vastai_backend", fake_provision)
     monkeypatch.setattr(rune, "_vastai_sdk", lambda: MagicMock())
     rune._run_vastai_provisioning(template_hash="t", min_dph=1, max_dph=2, reliability=0.9)
 
@@ -136,7 +136,7 @@ def test_rune_remaining_branches(monkeypatch, tmp_path):
 
     # run-benchmark local existing server failure branch
     monkeypatch.setattr(rune, "BACKEND_MODE", "local")
-    monkeypatch.setattr(rune, "use_existing_ollama_server", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("bad-existing")))
+    monkeypatch.setattr(rune, "use_existing_backend_server", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("bad-existing")))
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text("apiVersion: v1\n")
     with pytest.raises(rune.typer.Exit):
@@ -451,8 +451,8 @@ def test_api_backend_server_workflows_instance_remaining(monkeypatch, tmp_path):
     from rune_bench.resources.existing_ollama_provider import ExistingOllamaProvider
 
     warmups = []
-    monkeypatch.setattr(_ep, "use_existing_ollama_server", lambda *_a, **_k: type("S", (), {"url": "http://existing"})())
-    monkeypatch.setattr(_ep, "warmup_existing_ollama_model", lambda *_a, **_k: warmups.append(True) or "m")
+    monkeypatch.setattr(_ep, "use_existing_backend_server", lambda *_a, **_k: type("S", (), {"url": "http://existing"})())
+    monkeypatch.setattr(_ep, "warmup_backend_model", lambda *_a, **_k: warmups.append(True) or "m")
     monkeypatch.setattr(
         api_backend,
         "_make_resource_provider_for_benchmark",
@@ -528,9 +528,9 @@ def test_api_backend_server_workflows_instance_remaining(monkeypatch, tmp_path):
     monkeypatch.setattr(workflows.OfferFinder, "find_best", lambda self, **_k: type("O", (), {"offer_id": 1, "total_vram_mb": 100})())
     monkeypatch.setattr(workflows.ModelSelector, "select", lambda self, _v: type("M", (), {"name": "m", "vram_mb": 1, "required_disk_gb": 1})())
     monkeypatch.setattr(workflows.TemplateLoader, "load", lambda self, _h: type("T", (), {"env": "E=1", "image": "img"})())
-    monkeypatch.setattr(workflows, "list_existing_ollama_models", lambda _u: ["m"])
-    monkeypatch.setattr(workflows, "list_running_ollama_models", lambda _u: ["m"])
-    monkeypatch.setattr(workflows, "normalize_ollama_model_for_api", lambda m: m)
+    monkeypatch.setattr(workflows, "list_backend_models", lambda _u: ["m"])
+    monkeypatch.setattr(workflows, "list_running_backend_models", lambda _u: ["m"])
+    monkeypatch.setattr(workflows, "normalize_backend_model_for_api", lambda m: m)
     res = workflows.provision_vastai_ollama(
         sdk=object(),
         template_hash="t",

--- a/tests/test_ollama_model_manager.py
+++ b/tests/test_ollama_model_manager.py
@@ -150,13 +150,13 @@ class _SelectedModel:
 
 
 def test_workflow_normalizers_and_stop(monkeypatch):
-    monkeypatch.setattr(workflows, "OllamaClient", lambda url: type("C", (), {"base_url": f"normalized:{url}"})())
+    monkeypatch.setattr("rune_bench.backends.ollama.OllamaClient", lambda url: type("C", (), {"base_url": f"normalized:{url}"})())
     assert workflows.normalize_backend_url("x") == "normalized:x"
 
-    fake_manager = MagicMock()
-    fake_manager.normalize_model_name.return_value = "plain-model"
-    monkeypatch.setattr(workflows.OllamaModelManager, "create", lambda *_: fake_manager)
-    assert workflows.normalize_ollama_model_for_api("ollama/model") == "plain-model"
+    fake_backend = MagicMock()
+    fake_backend.normalize_model_name.return_value = "plain-model"
+    monkeypatch.setattr(workflows, "OllamaBackend", lambda _url: fake_backend)
+    assert workflows.normalize_backend_model_for_api("ollama/model") == "plain-model"
 
     fake_instance_manager = MagicMock()
     fake_instance_manager.destroy_instance_and_related_storage.return_value = "done"
@@ -164,7 +164,7 @@ def test_workflow_normalizers_and_stop(monkeypatch):
     assert workflows.stop_vastai_instance(MagicMock(), 7) == "done"
 
 
-def test_provision_vastai_ollama_reuses_running_instance(monkeypatch):
+def test_provision_vastai_backend_reuses_running_instance(monkeypatch):
     sdk = MagicMock()
     fake_manager = MagicMock()
     reusable = {"id": 9, "gpu_total_ram": 32000, "ask_contract_id": 44}
@@ -200,12 +200,12 @@ def test_provision_vastai_ollama_reuses_running_instance(monkeypatch):
 
     monkeypatch.setattr(workflows, "InstanceManager", FakeInstanceManager)
     monkeypatch.setattr(workflows.ModelSelector, "select", lambda self, _vram: _SelectedModel("foo:1", 32000, 50))
-    monkeypatch.setattr(workflows, "list_existing_ollama_models", lambda _url: ["foo:1"])
-    monkeypatch.setattr(workflows, "list_running_ollama_models", lambda _url: ["foo:1"])
-    monkeypatch.setattr(workflows, "warmup_existing_ollama_model", lambda *_args, **_kwargs: "foo:1")
-    monkeypatch.setattr(workflows, "normalize_ollama_model_for_api", lambda model: model)
+    monkeypatch.setattr(workflows, "list_backend_models", lambda _url: ["foo:1"])
+    monkeypatch.setattr(workflows, "list_running_backend_models", lambda _url: ["foo:1"])
+    monkeypatch.setattr(workflows, "warmup_backend_model", lambda *_args, **_kwargs: "foo:1")
+    monkeypatch.setattr(workflows, "normalize_backend_model_for_api", lambda model: model)
 
-    result = workflows.provision_vastai_ollama(
+    result = workflows.provision_vastai_backend(
         sdk,
         template_hash="tpl",
         min_dph=1,
@@ -220,7 +220,7 @@ def test_provision_vastai_ollama_reuses_running_instance(monkeypatch):
     fake_manager.pull_model.assert_not_called()
 
 
-def test_provision_vastai_ollama_creates_new_instance_and_warms(monkeypatch):
+def test_provision_vastai_backend_creates_new_instance_and_warms(monkeypatch):
     sdk = MagicMock()
     fake_manager = MagicMock()
     fake_manager.find_reusable_running_instance.return_value = None
@@ -259,13 +259,13 @@ def test_provision_vastai_ollama_creates_new_instance_and_warms(monkeypatch):
     monkeypatch.setattr(workflows.OfferFinder, "find_best", lambda self, **_: type("Offer", (), {"offer_id": 5, "total_vram_mb": 24000})())
     monkeypatch.setattr(workflows.ModelSelector, "select", lambda self, _vram: _SelectedModel("foo:1", 20000, 60))
     monkeypatch.setattr(workflows.TemplateLoader, "load", lambda self, _hash: type("Tpl", (), {"env": "ENV=1", "image": "img"})())
-    monkeypatch.setattr(workflows, "list_existing_ollama_models", lambda _url: [])
-    monkeypatch.setattr(workflows, "list_running_ollama_models", lambda _url: [])
+    monkeypatch.setattr(workflows, "list_backend_models", lambda _url: [])
+    monkeypatch.setattr(workflows, "list_running_backend_models", lambda _url: [])
     warmed = []
-    monkeypatch.setattr(workflows, "warmup_existing_ollama_model", lambda *_args, **_kwargs: warmed.append(True) or "foo:1")
-    monkeypatch.setattr(workflows, "normalize_ollama_model_for_api", lambda model: model)
+    monkeypatch.setattr(workflows, "warmup_backend_model", lambda *_args, **_kwargs: warmed.append(True) or "foo:1")
+    monkeypatch.setattr(workflows, "normalize_backend_model_for_api", lambda model: model)
 
-    result = workflows.provision_vastai_ollama(
+    result = workflows.provision_vastai_backend(
         sdk,
         template_hash="tpl",
         min_dph=1,
@@ -280,7 +280,7 @@ def test_provision_vastai_ollama_creates_new_instance_and_warms(monkeypatch):
     fake_manager.pull_model.assert_called_once_with(12, "foo:1", backend_url="http://x:11434")
 
 
-def test_provision_vastai_ollama_abort_and_pull_warning(monkeypatch):
+def test_provision_vastai_backend_abort_and_pull_warning(monkeypatch):
     sdk = MagicMock()
     fake_manager = MagicMock()
     fake_manager.find_reusable_running_instance.return_value = None
@@ -318,7 +318,7 @@ def test_provision_vastai_ollama_abort_and_pull_warning(monkeypatch):
     monkeypatch.setattr(workflows.TemplateLoader, "load", lambda self, _hash: type("Tpl", (), {"env": "ENV=1", "image": "img"})())
 
     with pytest.raises(workflows.UserAbortedError):
-        workflows.provision_vastai_ollama(
+        workflows.provision_vastai_backend(
             sdk,
             template_hash="tpl",
             min_dph=1,
@@ -330,7 +330,7 @@ def test_provision_vastai_ollama_abort_and_pull_warning(monkeypatch):
     fake_manager.create.return_value = 12
     fake_manager.wait_until_running.return_value = {"id": 12}
 
-    result = workflows.provision_vastai_ollama(
+    result = workflows.provision_vastai_backend(
         sdk,
         template_hash="tpl",
         min_dph=1,
@@ -345,9 +345,9 @@ def test_api_backend_functions(monkeypatch, tmp_path):
     monkeypatch.setattr(api_backend, "ModelSelector", lambda: type("S", (), {"list_models": lambda self: [_SelectedModel("m1", 1, 2)]})())
     assert api_backend.list_vastai_models() == [{"name": "m1", "vram_mb": 1, "required_disk_gb": 2}]
 
-    monkeypatch.setattr(api_backend, "use_existing_ollama_server", lambda url, model_name: type("Srv", (), {"url": f"norm:{url}"})())
-    monkeypatch.setattr(api_backend, "list_existing_ollama_models", lambda _url: ["a"])
-    monkeypatch.setattr(api_backend, "list_running_ollama_models", lambda _url: ["a"])
+    monkeypatch.setattr(api_backend, "use_existing_backend_server", lambda url, model_name: type("Srv", (), {"url": f"norm:{url}"})())
+    monkeypatch.setattr(api_backend, "list_backend_models_wf", lambda _url: ["a"])
+    monkeypatch.setattr(api_backend, "list_running_backend_models", lambda _url: ["a"])
     payload = api_backend.list_backend_models("raw")
     assert payload["backend_url"] == "norm:raw"
 
@@ -378,7 +378,7 @@ def test_api_backend_functions(monkeypatch, tmp_path):
     kubeconfig = tmp_path / "config"
     kubeconfig.write_text("apiVersion: v1\n")
     warmed = []
-    monkeypatch.setattr(api_backend, "warmup_existing_ollama_model", lambda *_args, **_kwargs: warmed.append(True) or "m")
+    monkeypatch.setattr(api_backend, "warmup_backend_model", lambda *_args, **_kwargs: warmed.append(True) or "m")
     monkeypatch.setattr(api_backend, "_make_agent_runner", lambda *_args, **_kwargs: type("R", (), {"ask": lambda self, **_: "answer"})())
     areq = api_backend.RunAgenticAgentRequest(question="q", model="m", backend_url="http://x", backend_warmup=True, backend_warmup_timeout=1, kubeconfig=str(kubeconfig))
     assert api_backend.run_agentic_agent(areq) == {"answer": "answer"}

--- a/tests/test_rune_cli_integration.py
+++ b/tests/test_rune_cli_integration.py
@@ -87,11 +87,11 @@ def test_fetch_and_warmup_helpers(monkeypatch):
 
     test_console = Console(record=True)
     monkeypatch.setattr(rune, "console", test_console)
-    monkeypatch.setattr(rune, "warmup_existing_ollama_model", lambda *_args, **_kwargs: "m")
+    monkeypatch.setattr(rune, "warmup_backend_model", lambda *_args, **_kwargs: "m")
     rune._warmup_ollama_model(backend_url="http://x", model_name="m", timeout_seconds=1)
     assert "Ollama model ready" in test_console.export_text()
 
-    monkeypatch.setattr(rune, "warmup_existing_ollama_model", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
+    monkeypatch.setattr(rune, "warmup_backend_model", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
     with pytest.raises(typer.Exit):
         rune._warmup_ollama_model(backend_url="http://x", model_name="m", timeout_seconds=1)
 
@@ -100,15 +100,15 @@ def test_run_vastai_provisioning_helper(monkeypatch):
     test_console = Console(record=True)
     monkeypatch.setattr(rune, "console", test_console)
     monkeypatch.setattr(rune, "_vastai_sdk", lambda: MagicMock())
-    monkeypatch.setattr(rune, "provision_vastai_ollama", lambda *_args, **_kwargs: _result())
+    monkeypatch.setattr(rune, "provision_vastai_backend", lambda *_args, **_kwargs: _result())
     assert rune._run_vastai_provisioning(template_hash="t", min_dph=1, max_dph=2, reliability=0.9).contract_id == 7
 
-    monkeypatch.setattr(rune, "provision_vastai_ollama", lambda *_args, **_kwargs: (_ for _ in ()).throw(rune.UserAbortedError("stop")))
+    monkeypatch.setattr(rune, "provision_vastai_backend", lambda *_args, **_kwargs: (_ for _ in ()).throw(rune.UserAbortedError("stop")))
     with pytest.raises(typer.Exit) as exc:
         rune._run_vastai_provisioning(template_hash="t", min_dph=1, max_dph=2, reliability=0.9)
     assert exc.value.exit_code == 0
 
-    monkeypatch.setattr(rune, "provision_vastai_ollama", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
+    monkeypatch.setattr(rune, "provision_vastai_backend", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
     with pytest.raises(typer.Exit):
         rune._run_vastai_provisioning(template_hash="t", min_dph=1, max_dph=2, reliability=0.9)
 
@@ -130,11 +130,11 @@ def test_run_llm_instance_paths(monkeypatch):
     test_console = Console(record=True, width=200)
     monkeypatch.setattr(rune, "console", test_console)
     monkeypatch.setattr(rune, "BACKEND_MODE", "local")
-    monkeypatch.setattr(rune, "use_existing_ollama_server", lambda *_args, **_kwargs: ExistingOllamaServer(url="http://x", model_name="m"))
+    monkeypatch.setattr(rune, "use_existing_backend_server", lambda *_args, **_kwargs: ExistingOllamaServer(url="http://x", model_name="m"))
     rune.run_llm_instance(vastai=False, template_hash="t", min_dph=1, max_dph=2, reliability=0.9, backend_url="u", debug=False, idempotency_key=None)
     assert "Existing Ollama Server" in test_console.export_text()
 
-    monkeypatch.setattr(rune, "use_existing_ollama_server", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
+    monkeypatch.setattr(rune, "use_existing_backend_server", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
     with pytest.raises(typer.Exit):
         rune.run_llm_instance(vastai=False, template_hash="t", min_dph=1, max_dph=2, reliability=0.9, backend_url="u", debug=False, idempotency_key=None)
 
@@ -178,12 +178,12 @@ def test_list_commands(monkeypatch):
         rune.ollama_list_models(debug=False, backend_url="http://x")
 
     monkeypatch.setattr(rune, "BACKEND_MODE", "local")
-    monkeypatch.setattr(rune, "use_existing_ollama_server", lambda *_args, **_kwargs: ExistingOllamaServer(url="http://x", model_name="m"))
-    monkeypatch.setattr(rune, "list_existing_ollama_models", lambda _url: ["m"])
-    monkeypatch.setattr(rune, "list_running_ollama_models", lambda _url: ["m"])
+    monkeypatch.setattr(rune, "use_existing_backend_server", lambda *_args, **_kwargs: ExistingOllamaServer(url="http://x", model_name="m"))
+    monkeypatch.setattr(rune, "list_backend_models", lambda _url: ["m"])
+    monkeypatch.setattr(rune, "list_running_backend_models", lambda _url: ["m"])
     rune.ollama_list_models(debug=False, backend_url="http://x")
 
-    monkeypatch.setattr(rune, "list_existing_ollama_models", lambda _url: (_ for _ in ()).throw(RuntimeError("bad")))
+    monkeypatch.setattr(rune, "list_backend_models", lambda _url: (_ for _ in ()).throw(RuntimeError("bad")))
     with pytest.raises(typer.Exit):
         rune.ollama_list_models(debug=False, backend_url="http://x")
 
@@ -240,11 +240,11 @@ def test_run_benchmark_paths(monkeypatch, tmp_path):
         rune.run_benchmark(debug=False, vastai=False, template_hash="t", min_dph=1, max_dph=2, reliability=0.9, backend_url=None, question="q", model="m", backend_warmup=False, backend_warmup_timeout=1, kubeconfig=kubeconfig, vastai_stop_instance=True, idempotency_key=None)
 
     monkeypatch.setattr(rune, "BACKEND_MODE", "local")
-    monkeypatch.setattr(rune, "use_existing_ollama_server", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad-server")))
+    monkeypatch.setattr(rune, "use_existing_backend_server", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad-server")))
     with pytest.raises(typer.Exit):
         rune.run_benchmark(debug=False, vastai=False, template_hash="t", min_dph=1, max_dph=2, reliability=0.9, backend_url="http://x", question="q", model="m", backend_warmup=True, backend_warmup_timeout=1, kubeconfig=kubeconfig, vastai_stop_instance=True, idempotency_key=None)
 
-    monkeypatch.setattr(rune, "use_existing_ollama_server", lambda *_args, **_kwargs: ExistingOllamaServer(url="http://x", model_name="m"))
+    monkeypatch.setattr(rune, "use_existing_backend_server", lambda *_args, **_kwargs: ExistingOllamaServer(url="http://x", model_name="m"))
     monkeypatch.setattr(rune, "_fetch_model_capabilities", lambda *_args, **_kwargs: OllamaModelCapabilities("m", 100, 20))
     monkeypatch.setattr(rune, "_warmup_ollama_model", lambda **_kwargs: None)
     monkeypatch.setattr(rune, "get_agent", lambda *_a, **_kw: type("R", (), {"ask": lambda self, **_: "bench-local"})())

--- a/tests/test_workflows_non_vastai.py
+++ b/tests/test_workflows_non_vastai.py
@@ -3,38 +3,44 @@ from unittest.mock import MagicMock
 import rune_bench.workflows as workflows
 
 
-def test_use_existing_ollama_server(monkeypatch):
+def test_use_existing_backend_server(monkeypatch):
     monkeypatch.setattr(workflows, "normalize_backend_url", lambda _: "http://localhost:11434")
-    server = workflows.use_existing_ollama_server("localhost:11434", "model:1")
+    server = workflows.use_existing_backend_server("localhost:11434", "model:1")
     assert server.url == "http://localhost:11434"
     assert server.model_name == "model:1"
 
 
-def test_list_existing_models(monkeypatch):
-    fake_manager = MagicMock()
-    fake_manager.list_available_models.return_value = ["a", "b"]
-    monkeypatch.setattr(workflows.OllamaModelManager, "create", lambda *_: fake_manager)
-    assert workflows.list_existing_ollama_models("http://localhost:11434") == ["a", "b"]
+def test_list_backend_models(monkeypatch):
+    fake_backend = MagicMock()
+    fake_backend.list_models.return_value = ["a", "b"]
+    monkeypatch.setattr(workflows, "normalize_backend_url", lambda u: u)
+    monkeypatch.setattr(workflows, "OllamaBackend", lambda _url: fake_backend)
+    assert workflows.list_backend_models("http://localhost:11434") == ["a", "b"]
 
 
-def test_list_running_models(monkeypatch):
-    fake_manager = MagicMock()
-    fake_manager.list_running_models.return_value = ["a"]
-    monkeypatch.setattr(workflows.OllamaModelManager, "create", lambda *_: fake_manager)
-    assert workflows.list_running_ollama_models("http://localhost:11434") == ["a"]
+def test_list_running_backend_models(monkeypatch):
+    fake_backend = MagicMock()
+    fake_backend.list_running_models.return_value = ["a"]
+    monkeypatch.setattr(workflows, "normalize_backend_url", lambda u: u)
+    monkeypatch.setattr(workflows, "OllamaBackend", lambda _url: fake_backend)
+    assert workflows.list_running_backend_models("http://localhost:11434") == ["a"]
 
 
-def test_warmup_existing_model_normalizes_before_warmup(monkeypatch):
-    fake_manager = MagicMock()
-    fake_manager.normalize_model_name.return_value = "foo:1"
-    fake_manager.warmup_model.return_value = "foo:1"
-    monkeypatch.setattr(workflows.OllamaModelManager, "create", lambda *_: fake_manager)
+def test_warmup_backend_model_normalizes_before_warmup(monkeypatch):
+    fake_backend = MagicMock()
+    fake_backend.warmup.return_value = "foo:1"
+    monkeypatch.setattr(workflows, "normalize_backend_url", lambda u: u)
+    monkeypatch.setattr(workflows, "OllamaBackend", lambda _url: fake_backend)
 
-    out = workflows.warmup_existing_ollama_model("http://localhost:11434", "ollama_chat/foo:1")
+    out = workflows.warmup_backend_model("http://localhost:11434", "ollama_chat/foo:1")
 
     assert out == "foo:1"
-    fake_manager.normalize_model_name.assert_called_once_with("ollama_chat/foo:1")
-    fake_manager.warmup_model.assert_called_once()
+    fake_backend.warmup.assert_called_once_with(
+        "ollama_chat/foo:1",
+        timeout_seconds=120,
+        poll_interval_seconds=2.0,
+        keep_alive="30m",
+    )
 
 
 def test_extract_ollama_service_url_prefers_direct_then_proxy():
@@ -62,3 +68,12 @@ def test_extract_ollama_service_url_prefers_direct_then_proxy():
         ],
     )
     assert workflows._extract_ollama_service_url(details2) == "https://proxy:11434/x"
+
+
+# Backward-compatible aliases still work
+def test_backward_compatible_aliases():
+    assert workflows.use_existing_ollama_server is workflows.use_existing_backend_server
+    assert workflows.list_existing_ollama_models is workflows.list_backend_models
+    assert workflows.list_running_ollama_models is workflows.list_running_backend_models
+    assert workflows.warmup_existing_ollama_model is workflows.warmup_backend_model
+    assert workflows.provision_vastai_ollama is workflows.provision_vastai_backend


### PR DESCRIPTION
## Summary

- Move all Ollama-specific function implementations from `workflows.py` into `OllamaBackend` facade class in `backends/ollama.py`
- Replace workflow functions with backend-agnostic dispatchers that delegate to `OllamaBackend`
- Add backward-compatible aliases so existing import paths continue to work
- Expand `LLMBackend` protocol with full method signatures (`list_models`, `warmup`, etc.)
- Add backend factory/registry (`get_backend()`, `register_backend()`, `list_backends()`)

Closes #168

## Acceptance Criteria Evidence

- [x] No Ollama-specific function implementations remain in `rune_bench/workflows.py` -- only backward-compatible aliases and generic dispatchers
- [x] `OllamaBackend` class exists in `rune_bench/backends/ollama.py` wrapping `OllamaClient` + `OllamaModelManager`
- [x] Generic dispatchers (`warmup_backend_model`, `list_backend_models`, `list_running_backend_models`, `use_existing_backend_server`) exist in `workflows.py` and delegate to `OllamaBackend`
- [x] `provision_vastai_ollama` renamed to `provision_vastai_backend` (alias preserved)
- [x] All test files pass with no failures (excluding pre-existing `test_vastai_sdk.py` fixture issue)
- [x] Coverage remains at pre-existing level (96.25% -- gap is from VastAI import branches and sdk.py, unchanged by this PR)
- [x] `rune/__init__.py` imports updated -- no broken CLI commands
- [x] `rune_bench/api_backend.py` imports updated -- API server starts without errors
- [x] `python -c "from rune_bench.backends.ollama import OllamaBackend"` succeeds
- [x] `python -m ruff check .` passes (excluding pre-existing `test_vastai_sdk.py`)
- [x] `python -m mypy rune_bench/` passes with 0 issues

## Audit Checks

No triggers fired -- no dependencies added/bumped, no API endpoints changed, no CI workflows modified, no Dockerfiles changed.

## Breaking Changes

Function signatures change but this is pre-alpha. Backward-compatible aliases are provided for all renamed functions:
- `use_existing_ollama_server` -> `use_existing_backend_server`
- `list_existing_ollama_models` -> `list_backend_models`
- `list_running_ollama_models` -> `list_running_backend_models`
- `warmup_existing_ollama_model` -> `warmup_backend_model`
- `provision_vastai_ollama` -> `provision_vastai_backend`
- `normalize_ollama_model_for_api` -> `normalize_backend_model_for_api`

## DoD Level

- [x] **Level 1** -- This changes runtime behavior (function locations, import paths, workflow signatures).

Note: Coverage at 96.25% is pre-existing (VastAI import branches, sdk.py at 22%). This PR does not reduce coverage -- all new code in `backends/ollama.py`, `backends/__init__.py`, and `backends/base.py` has 100% coverage.

## Test plan

- [x] `pytest tests/ -x -q` -- all tests pass
- [x] `ruff check .` -- clean
- [x] `mypy rune_bench/` -- 0 issues
- [x] `grep -n "ollama" rune_bench/workflows.py` -- only import and aliases, no implementations
- [x] Backward-compatible aliases verified in `test_backward_compatible_aliases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)