### PR TITLE
docs: clarify compliance wording and point to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 The core RUNE engine for AI model benchmarking and provisioning.
 
 ## 📖 Documentation
-All documentation is consolidated in **[rune-docs](https://github.com/lpasquali/rune-docs)**.
+All documentation is consolidated in the **[RUNE Documentation Site](https://lpasquali.github.io/rune-docs/)**.
 
 ## 🛡️ Compliance
-- **ML4**: This repository aligns with **IEC 62443-4-1 ML4** secure development requirements.
-- **SLSA**: Build provenance follows **SLSA Level 3**.
+- **ML4**: This repository is designed to align with **IEC 62443-4-1 ML4** secure development requirements in preparation for future certification.
+- **SLSA**: Build provenance is designed to follow **SLSA Level 3** guidelines.
 
 ## 📜 License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Clarifies compliance wording to specify preparation for certification and points to GitHub Pages site.

Closes #121
Epic: #121

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [ ] Tested in **docker-compose mode**
- [ ] Tested in **kind (Kubernetes) mode**
- [ ] Tested in **standalone CLI mode**
- [ ] **Breaking change audit**: API versions, persistent data, cross-component contracts
- [ ] **Dependency CVE audit** (if deps changed): `pip-audit` / `govulncheck` / `grype` — no new CVEs

## Level 2 Checklist

- [ ] Full test suite passes
- [ ] Coverage not degraded (at or above floor)
- [ ] No unintended CI side effects

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Wording updated.

## Test Plan Evidence

- [x] Syntax checked.

## Breaking Changes

None.

## Notes for Reviewer

None.