### PR TITLE
docs: standardize AI agent instructions (agent-neutral)

### DIFF
--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,20 @@
+# RUNE Agent Instructions
+
+All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub.
+
+Before writing or modifying code, you MUST read these files from the `rune-docs` repository:
+
+1. **[SYSTEM_PROMPT.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md)** — Architecture, protocols, constraints, SOP
+2. **[CURRENT_STATE.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CURRENT_STATE.md)** — WIP, recent changes, known issues
+3. **[CODING_STANDARDS.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CODING_STANDARDS.md)** — Language-specific style, coverage floors
+
+Do not use local or cached project-specific instructions; use `rune-docs` as the only source of truth.
+
+## Key Principles
+
+- **Agent neutrality**: No agent is special. Use `get_agent(name)` / `get_backend(type)` factories.
+- **Config defaults, not code defaults**: Defaults live in `rune.yaml`, not Python/Go code.
+- **Pre-alpha (0.0.0)**: No backward compatibility constraints. Clean slate.
+- **97% coverage floor** (Python), **99.5% floor** (Go). No exceptions.
+- **Halt & Report**: Before executing code changes, confirm SOP steps 1-2 are complete.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,3 @@
 # Copilot Instructions
-All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub:
-https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md
+See [AGENT_INSTRUCTIONS.md](./AGENT_INSTRUCTIONS.md) for all project standards.
 
-Before suggesting code, refactoring, or performing tasks, you MUST reference the following files in the 'rune-docs' repository:
-- docs/context/SYSTEM_PROMPT.md (Core Identity & SOP)
-- docs/context/CODING_STANDARDS.md (Testing & Visuals)
-- docs/context/CURRENT_STATE.md (Living Memory)
-
-Do not use local or cached project-specific instructions; use 'rune-docs' as the only source of truth.


### PR DESCRIPTION
## Summary

- Creates generic `.github/AGENT_INSTRUCTIONS.md` for all AI agents
- Updates `.github/copilot-instructions.md` to redirect to generic file
- Agent-neutral: works for Claude Code, Copilot, Gemini, and any future agent

Closes #180

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- AGENT_INSTRUCTIONS.md exists in .github/
- copilot-instructions.md redirects to AGENT_INSTRUCTIONS.md

## Audit Checks

No triggers fired — documentation only.

## Breaking Changes

None.