### PR TITLE
ci: exempt Dependabot PRs from PR body compliance check

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -786,7 +786,7 @@ jobs:
 
   pr-body-check:
     name: RuneGate/Process/PR-Body-Compliance
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR body structure


### PR DESCRIPTION
## Summary

- Exempt Dependabot PRs from `RuneGate/Process/PR-Body-Compliance` check
- Dependabot auto-generated PR bodies don't include the DoD template, blocking all dependency update PRs

Closes #191

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- PR-Body-Compliance job skips when `github.actor == 'dependabot[bot]'`
- Non-Dependabot PRs still enforce the template

## Audit Checks

No triggers fired — CI workflow condition change only.

## Breaking Changes

None.