### PR TITLE
refactor: generalize AgentRunner.ask() signature with backend_type

### DIFF
--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -38,6 +38,8 @@ from rune_bench.common import (
 )
 from rune_bench.debug import set_debug
 from rune_bench.metrics import InMemoryCollector, set_collector, clear_collector
+from rune_bench.backends import get_backend
+from rune_bench.backends.base import ModelCapabilities
 from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
 from rune_bench.agents.registry import get_agent
 from rune_bench.workflows import (
@@ -218,11 +220,14 @@ def _confirm_instance_creation() -> bool:
     return ack == "yes"
 
 
-def _fetch_model_capabilities(backend_url: str, model: str) -> OllamaModelCapabilities | None:
-    """Try to fetch model capabilities from Ollama; return None on any failure."""
+def _fetch_model_capabilities(
+    backend_url: str, model: str, backend_type: str = "ollama",
+) -> ModelCapabilities | None:
+    """Try to fetch model capabilities from the backend; return None on any failure."""
     try:
-        normalized = OllamaModelManager.create(backend_url).normalize_model_name(model)
-        return OllamaClient(backend_url).get_model_capabilities(normalized)
+        backend = get_backend(backend_type, backend_url)
+        normalized = backend.normalize_model_name(model)
+        return backend.get_model_capabilities(normalized)
     except RuntimeError:
         return None
 

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -40,7 +40,6 @@ from rune_bench.debug import set_debug
 from rune_bench.metrics import InMemoryCollector, set_collector, clear_collector
 from rune_bench.backends import get_backend
 from rune_bench.backends.base import ModelCapabilities
-from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
 from rune_bench.agents.registry import get_agent
 from rune_bench.workflows import (
     ExistingOllamaServer,
@@ -243,7 +242,7 @@ def _vastai_sdk() -> "VastAI":
     return VastAI(api_key=api_key, raw=True)
 
 
-def _apply_model_limits(capabilities: OllamaModelCapabilities) -> None:
+def _apply_model_limits(capabilities: ModelCapabilities) -> None:
     """Pre-set LiteLLM override env vars so the agent skips the redundant re-fetch."""
     import os
 
@@ -255,7 +254,7 @@ def _apply_model_limits(capabilities: OllamaModelCapabilities) -> None:
             os.environ[env_name] = str(value)
 
 
-def _print_existing_ollama(server: ExistingOllamaServer, capabilities: OllamaModelCapabilities | None = None) -> None:
+def _print_existing_ollama(server: ExistingOllamaServer, capabilities: ModelCapabilities | None = None) -> None:
     table = Table(title="Existing Ollama Server", show_header=True, header_style="bold magenta")
     table.add_column("Property", style="dim")
     table.add_column("Value")
@@ -270,7 +269,7 @@ def _print_existing_ollama(server: ExistingOllamaServer, capabilities: OllamaMod
     console.print(table)
 
 
-def _print_vastai_result(result: VastAIProvisioningResult, capabilities: OllamaModelCapabilities | None = None) -> None:
+def _print_vastai_result(result: VastAIProvisioningResult, capabilities: ModelCapabilities | None = None) -> None:
     console.print(f"[green]Best offer:[/green] id={result.offer_id}, gpu_total_ram={result.total_vram_mb} MB")
     console.print(f"[green]Selected model:[/green] {result.model_name} (~{result.model_vram_mb} MB VRAM)")
     console.print(f"[green]Required disk:[/green] {result.required_disk_gb} GB")

--- a/rune_bench/agents/base.py
+++ b/rune_bench/agents/base.py
@@ -11,7 +11,7 @@ class AgentConfig:
     base_url: str | None = None
     kubeconfig: str | None = None
     model: str | None = None
-    ollama_url: str | None = None
+    backend_url: str | None = None
     extra: dict[str, str] = field(default_factory=dict)
 
 
@@ -38,6 +38,12 @@ class AgentRunner(Protocol):
     The ``ask()`` method returns a plain string for backward compatibility.
     """
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(
+        self,
+        question: str,
+        model: str,
+        backend_url: str | None = None,
+        backend_type: str = "ollama",
+    ) -> str:
         """Run an investigation query and return the answer as a string."""
         ...

--- a/rune_bench/agents/config.py
+++ b/rune_bench/agents/config.py
@@ -28,7 +28,7 @@ def resolve_agent_config(agent_name: str, kwargs: dict[str, Any] | None = None) 
         base_url = os.environ.get("BURP_API_URL")
 
     model = kwargs.get("model") or os.environ.get(f"{prefix}MODEL")
-    ollama_url = kwargs.get("ollama_url") or os.environ.get(f"{prefix}OLLAMA_URL")
+    backend_url = kwargs.get("backend_url") or os.environ.get(f"{prefix}BACKEND_URL") or os.environ.get(f"{prefix}OLLAMA_URL")
     
     extra = {}
     if agent_name == "dagger":
@@ -43,6 +43,6 @@ def resolve_agent_config(agent_name: str, kwargs: dict[str, Any] | None = None) 
         base_url=base_url,
         kubeconfig=kubeconfig,
         model=model,
-        ollama_url=ollama_url,
+        backend_url=backend_url,
         extra=extra,
     )

--- a/rune_bench/agents/experimental/cognitive_agent.py
+++ b/rune_bench/agents/experimental/cognitive_agent.py
@@ -52,7 +52,7 @@ class CognitiveAgentRunner:
             return f"Reflection: Failed to achieve goal '{goal}'. Needs replanning."
         return f"Reflection: Successfully achieved goal '{goal}'."
 
-    def ask(self, question: str, model: str, ollama_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Run the full cognitive ReAct loop."""
         self.memory.append_episodic(action="Receive Objective", result=question)
         

--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -157,6 +157,7 @@ def run_agentic_agent(request: RunAgenticAgentRequest) -> dict:
         question=request.question,
         model=request.model,
         backend_url=request.backend_url,
+        backend_type=getattr(request, "backend_type", "ollama"),
     )
     return {"answer": answer}
 
@@ -193,6 +194,7 @@ def run_benchmark(request: RunBenchmarkRequest) -> dict:
             question=request.question,
             model=effective_model,
             backend_url=result.backend_url,
+            backend_type=getattr(request, "backend_type", "ollama"),
         )
     finally:
         provider.teardown(result)

--- a/rune_bench/drivers/burpgpt/__init__.py
+++ b/rune_bench/drivers/burpgpt/__init__.py
@@ -32,7 +32,7 @@ class BurpGPTDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("burpgpt")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a scan request to the burpgpt driver and return findings.
 
         Args:

--- a/rune_bench/drivers/consensus/__init__.py
+++ b/rune_bench/drivers/consensus/__init__.py
@@ -33,6 +33,7 @@ class ConsensusDriverClient:
         question: str,
         model: str = "",
         backend_url: str | None = None,
+        backend_type: str = "ollama",
         limit: int | None = None,
     ) -> str:
         """Dispatch a research question to the consensus driver and return the answer.

--- a/rune_bench/drivers/crewai/__init__.py
+++ b/rune_bench/drivers/crewai/__init__.py
@@ -27,7 +27,7 @@ class CrewAIDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("crewai")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a question to the CrewAI driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/dagger/__init__.py
+++ b/rune_bench/drivers/dagger/__init__.py
@@ -27,7 +27,7 @@ class DaggerDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("dagger")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a pipeline objective to the dagger driver and return the result.
 
         Args:

--- a/rune_bench/drivers/elicit/__init__.py
+++ b/rune_bench/drivers/elicit/__init__.py
@@ -27,7 +27,7 @@ class ElicitDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("elicit")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a research question to the elicit driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/glean/__init__.py
+++ b/rune_bench/drivers/glean/__init__.py
@@ -25,7 +25,7 @@ class GleanDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("glean")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a question to the Glean driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/harvey/__init__.py
+++ b/rune_bench/drivers/harvey/__init__.py
@@ -20,7 +20,7 @@ class HarveyDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("harvey")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the Harvey AI driver.
 
         Raises:

--- a/rune_bench/drivers/holmes/__init__.py
+++ b/rune_bench/drivers/holmes/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from rune_bench.backends.ollama import OllamaClient, OllamaModelManager
+from rune_bench.backends import get_backend
 from rune_bench.debug import debug_log
 from rune_bench.drivers import DriverTransport, make_driver_transport
 
@@ -34,17 +34,24 @@ class HolmesDriverClient:
         self._kubeconfig = kubeconfig
         self._transport: DriverTransport = transport or make_driver_transport("holmes")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(
+        self,
+        question: str,
+        model: str,
+        backend_url: str | None = None,
+        backend_type: str = "ollama",
+    ) -> str:
         """Dispatch a question to the holmes driver and return the answer.
 
-        Fetches Ollama model capability limits (context window, max output tokens)
-        when *backend_url* is provided and passes them to the driver so it can set
-        the appropriate environment overrides before calling HolmesGPT.
+        Fetches LLM backend model capability limits (context window, max output
+        tokens) when *backend_url* is provided and passes them to the driver so
+        it can set the appropriate environment overrides before calling HolmesGPT.
 
         Args:
             question: Natural-language question about the Kubernetes cluster.
-            model: Ollama model identifier (e.g. ``"llama3.1:8b"``).
-            backend_url: Base URL of the Ollama server (optional).
+            model: LLM model identifier (e.g. ``"llama3.1:8b"``).
+            backend_url: Base URL of the LLM backend server (optional).
+            backend_type: Backend type (e.g. ``"ollama"``, ``"k8s-inference"``).
 
         Returns:
             HolmesGPT's textual answer.
@@ -57,7 +64,9 @@ class HolmesDriverClient:
         }
         if backend_url:
             params["backend_url"] = backend_url
-            params.update(self._fetch_model_limits(model=resolved_model, backend_url=backend_url))
+            params.update(self._fetch_model_limits(
+                model=resolved_model, backend_url=backend_url, backend_type=backend_type,
+            ))
 
         debug_log(
             f"HolmesDriverClient.ask: question={question!r} model={resolved_model!r} "
@@ -78,11 +87,14 @@ class HolmesDriverClient:
 
         return answer_text
 
-    def _fetch_model_limits(self, *, model: str, backend_url: str) -> dict:
+    def _fetch_model_limits(
+        self, *, model: str, backend_url: str, backend_type: str = "ollama",
+    ) -> dict:
         """Return context_window / max_output_tokens for *model*, or ``{}`` on error."""
         try:
-            normalized = OllamaModelManager.create(backend_url).normalize_model_name(model)
-            caps = OllamaClient(backend_url).get_model_capabilities(normalized)
+            backend = get_backend(backend_type, backend_url)
+            normalized = backend.normalize_model_name(model)
+            caps = backend.get_model_capabilities(normalized)
         except Exception as exc:  # noqa: BLE001
             debug_log(f"Could not fetch model limits for {model!r}: {exc}")
             return {}

--- a/rune_bench/drivers/k8sgpt/__init__.py
+++ b/rune_bench/drivers/k8sgpt/__init__.py
@@ -33,7 +33,7 @@ class K8sGPTDriverClient:
         self._kubeconfig = kubeconfig
         self._transport: DriverTransport = transport or make_driver_transport("k8sgpt")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch an analysis request to the k8sgpt driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/krea/__init__.py
+++ b/rune_bench/drivers/krea/__init__.py
@@ -21,7 +21,7 @@ class KreaDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("krea")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the Krea AI driver.
 
         Raises:

--- a/rune_bench/drivers/langgraph/__init__.py
+++ b/rune_bench/drivers/langgraph/__init__.py
@@ -27,7 +27,7 @@ class LangGraphDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("langgraph")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a question to the LangGraph driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/metoro/__init__.py
+++ b/rune_bench/drivers/metoro/__init__.py
@@ -32,7 +32,7 @@ class MetoroDriverClient:
         self._kubeconfig = kubeconfig
         self._transport: DriverTransport = transport or make_driver_transport("metoro")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a question to the Metoro driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/midjourney/__init__.py
+++ b/rune_bench/drivers/midjourney/__init__.py
@@ -23,7 +23,7 @@ class MidjourneyDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("midjourney")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the Midjourney driver.
 
         Raises:

--- a/rune_bench/drivers/mindgard/__init__.py
+++ b/rune_bench/drivers/mindgard/__init__.py
@@ -32,7 +32,7 @@ class MindgardDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("mindgard")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a red-team assessment to the mindgard driver and return findings.
 
         Args:

--- a/rune_bench/drivers/pagerduty/__init__.py
+++ b/rune_bench/drivers/pagerduty/__init__.py
@@ -34,7 +34,7 @@ class PagerDutyDriverClient:
         self._kubeconfig = kubeconfig
         self._transport: DriverTransport = transport or make_driver_transport("pagerduty")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a triage question to the pagerduty driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/pentestgpt/__init__.py
+++ b/rune_bench/drivers/pentestgpt/__init__.py
@@ -29,7 +29,7 @@ class PentestGPTDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("pentestgpt")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a pentest question to the pentestgpt driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/perplexity/__init__.py
+++ b/rune_bench/drivers/perplexity/__init__.py
@@ -27,7 +27,7 @@ class PerplexityDriverClient:
     ) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("perplexity")
 
-    def ask(self, question: str, model: str = "sonar-pro", backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str = "sonar-pro", backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Dispatch a research question to the Perplexity driver and return the answer.
 
         Args:

--- a/rune_bench/drivers/radiant/__init__.py
+++ b/rune_bench/drivers/radiant/__init__.py
@@ -20,7 +20,7 @@ class RadiantDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("radiant")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the Radiant Security driver.
 
         Raises:

--- a/rune_bench/drivers/sierra/__init__.py
+++ b/rune_bench/drivers/sierra/__init__.py
@@ -19,7 +19,7 @@ class SierraDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("sierra")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the Sierra driver.
 
         Raises:

--- a/rune_bench/drivers/skillfortify/__init__.py
+++ b/rune_bench/drivers/skillfortify/__init__.py
@@ -19,7 +19,7 @@ class SkillfortifyDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("skillfortify")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the SkillFortify driver.
 
         Raises:

--- a/rune_bench/drivers/spellbook/__init__.py
+++ b/rune_bench/drivers/spellbook/__init__.py
@@ -21,7 +21,7 @@ class SpellbookDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("spellbook")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the Spellbook driver.
 
         Raises:

--- a/rune_bench/drivers/xbow/__init__.py
+++ b/rune_bench/drivers/xbow/__init__.py
@@ -19,7 +19,7 @@ class XbowDriverClient:
     def __init__(self, *, transport: DriverTransport | None = None) -> None:
         self._transport: DriverTransport = transport or make_driver_transport("xbow")
 
-    def ask(self, question: str, model: str, backend_url: str | None = None) -> str:
+    def ask(self, question: str, model: str, backend_url: str | None = None, backend_type: str = "ollama") -> str:
         """Send a question to the XBOW driver.
 
         Raises:

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -79,9 +79,9 @@ def test_resolve_glean_extra(monkeypatch):
     assert cfg.extra["instance"] == "glean-inst"
 
 def test_resolve_with_kwargs():
-    cfg = resolve_agent_config("test", {"kubeconfig": "kwarg-kube", "api_key": "kwarg-api", "base_url": "kwarg-url", "model": "kwarg-model", "ollama_url": "kwarg-ollama"})
+    cfg = resolve_agent_config("test", {"kubeconfig": "kwarg-kube", "api_key": "kwarg-api", "base_url": "kwarg-url", "model": "kwarg-model", "backend_url": "kwarg-backend"})
     assert cfg.kubeconfig == "kwarg-kube"
     assert cfg.api_key == "kwarg-api"
     assert cfg.base_url == "kwarg-url"
     assert cfg.model == "kwarg-model"
-    assert cfg.ollama_url == "kwarg-ollama"
+    assert cfg.backend_url == "kwarg-backend"

--- a/tests/test_comprehensive_error_paths.py
+++ b/tests/test_comprehensive_error_paths.py
@@ -38,10 +38,10 @@ def test_holmes_runner_remaining_paths(monkeypatch, tmp_path):
     runner2 = HolmesRunner(kubeconfig, transport=ok_transport)
     assert runner2.ask("q", "m") == "great"
 
-    # _fetch_model_limits returns {} when OllamaModelManager.create raises
-    bad_manager = MagicMock()
-    bad_manager.normalize_model_name.side_effect = RuntimeError("norm failed")
-    monkeypatch.setattr(holmes_driver_module.OllamaModelManager, "create", lambda *_: bad_manager)
+    # _fetch_model_limits returns {} when get_backend raises
+    bad_backend = MagicMock()
+    bad_backend.normalize_model_name.side_effect = RuntimeError("norm failed")
+    monkeypatch.setattr(holmes_driver_module, "get_backend", lambda *_args, **_kw: bad_backend)
     limits = runner2._fetch_model_limits(model="m", backend_url="http://x")
     assert limits == {}
 

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -18,7 +18,7 @@ from rune_bench.agents.sre.holmes import HolmesRunner
 from rune_bench.api_client import RuneApiClient
 from rune_bench.common import normalize_url
 from rune_bench.backends.base import ModelCapabilities
-from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
+from rune_bench.backends.ollama import OllamaClient, OllamaModelManager
 from rune_bench.resources.vastai import ConnectionDetails, InstanceManager, TeardownResult
 
 

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -17,6 +17,7 @@ import rune_bench.workflows as workflows
 from rune_bench.agents.sre.holmes import HolmesRunner
 from rune_bench.api_client import RuneApiClient
 from rune_bench.common import normalize_url
+from rune_bench.backends.base import ModelCapabilities
 from rune_bench.backends.ollama import OllamaClient, OllamaModelCapabilities, OllamaModelManager
 from rune_bench.resources.vastai import ConnectionDetails, InstanceManager, TeardownResult
 
@@ -350,14 +351,17 @@ def test_holmes_and_ollama_remaining_branches(monkeypatch, tmp_path):
     kubeconfig.write_text("apiVersion: v1\n")
     runner = HolmesRunner(kubeconfig)
 
-    # _fetch_model_limits success path via driver module monkeypatches
-    monkeypatch.setattr(holmes_driver_module.OllamaModelManager, "create", lambda *_: type("M", (), {"normalize_model_name": lambda self, m: "norm"})())
-    monkeypatch.setattr(holmes_driver_module, "OllamaClient", lambda *_: type("C", (), {"get_model_capabilities": lambda self, _m: OllamaModelCapabilities("norm", 10, 2)})())
+    # _fetch_model_limits success path via get_backend monkeypatch
+    fake_backend = type("B", (), {
+        "normalize_model_name": lambda self, m: "norm",
+        "get_model_capabilities": lambda self, _m: ModelCapabilities("norm", 10, 2),
+    })()
+    monkeypatch.setattr(holmes_driver_module, "get_backend", lambda *_args, **_kw: fake_backend)
     limits = runner._fetch_model_limits(model="m", backend_url="http://x")
     assert limits.get("context_window") == 10
 
     # _fetch_model_limits failure path
-    monkeypatch.setattr(holmes_driver_module, "OllamaClient", lambda *_: type("C", (), {"get_model_capabilities": lambda self, _m: (_ for _ in ()).throw(RuntimeError("bad"))})())
+    monkeypatch.setattr(holmes_driver_module, "get_backend", lambda *_args, **_kw: (_ for _ in ()).throw(RuntimeError("bad")))
     limits2 = runner._fetch_model_limits(model="m", backend_url="http://x")
     assert limits2 == {}
 

--- a/tests/test_holmes_runner.py
+++ b/tests/test_holmes_runner.py
@@ -12,7 +12,7 @@ import pytest
 
 import rune_bench.drivers.holmes as holmes_driver_module
 from rune_bench.agents.sre.holmes import HolmesRunner
-from rune_bench.backends.ollama import OllamaModelCapabilities
+from rune_bench.backends.base import ModelCapabilities
 from rune_bench.drivers.holmes import HolmesDriverClient
 
 
@@ -66,18 +66,15 @@ def test_ask_includes_backend_url_and_limits(monkeypatch: pytest.MonkeyPatch, tm
     mock_transport = MagicMock()
     mock_transport.call.return_value = {"answer": "ok"}
 
-    fake_manager = MagicMock()
-    fake_manager.normalize_model_name.return_value = "llama3.1:8b"
-
-    fake_client = MagicMock()
-    fake_client.get_model_capabilities.return_value = OllamaModelCapabilities(
+    fake_backend = MagicMock()
+    fake_backend.normalize_model_name.return_value = "llama3.1:8b"
+    fake_backend.get_model_capabilities.return_value = ModelCapabilities(
         model_name="llama3.1:8b",
         context_window=131072,
         max_output_tokens=26214,
     )
 
-    monkeypatch.setattr(holmes_driver_module.OllamaModelManager, "create", lambda *_: fake_manager)
-    monkeypatch.setattr(holmes_driver_module, "OllamaClient", lambda *_: fake_client)
+    monkeypatch.setattr(holmes_driver_module, "get_backend", lambda *_args, **_kw: fake_backend)
 
     runner = HolmesRunner(kubeconfig, transport=mock_transport)
     runner.ask("q", "llama3.1:8b", backend_url="http://ollama:11434")
@@ -109,10 +106,10 @@ def test_fetch_model_limits_handles_ollama_error(
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text("apiVersion: v1\n")
 
-    def broken_create(*_args: object) -> None:
+    def broken_get_backend(*_args: object, **_kw: object) -> None:
         raise RuntimeError("unreachable")
 
-    monkeypatch.setattr(holmes_driver_module.OllamaModelManager, "create", broken_create)
+    monkeypatch.setattr(holmes_driver_module, "get_backend", broken_get_backend)
 
     runner = HolmesRunner(kubeconfig, transport=MagicMock())
     limits = runner._fetch_model_limits(model="m", backend_url="http://ollama")
@@ -125,15 +122,13 @@ def test_fetch_model_limits_omits_none_values(
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text("apiVersion: v1\n")
 
-    fake_manager = MagicMock()
-    fake_manager.normalize_model_name.return_value = "m"
-    fake_client = MagicMock()
-    fake_client.get_model_capabilities.return_value = OllamaModelCapabilities(
+    fake_backend = MagicMock()
+    fake_backend.normalize_model_name.return_value = "m"
+    fake_backend.get_model_capabilities.return_value = ModelCapabilities(
         model_name="m", context_window=None, max_output_tokens=None
     )
 
-    monkeypatch.setattr(holmes_driver_module.OllamaModelManager, "create", lambda *_: fake_manager)
-    monkeypatch.setattr(holmes_driver_module, "OllamaClient", lambda *_: fake_client)
+    monkeypatch.setattr(holmes_driver_module, "get_backend", lambda *_args, **_kw: fake_backend)
 
     runner = HolmesRunner(kubeconfig, transport=MagicMock())
     limits = runner._fetch_model_limits(model="m", backend_url="http://ollama")

--- a/tests/test_rune_cli_integration.py
+++ b/tests/test_rune_cli_integration.py
@@ -73,16 +73,14 @@ def test_main_and_basic_helpers(monkeypatch):
 
 
 def test_fetch_and_warmup_helpers(monkeypatch):
-    fake_manager = MagicMock()
-    fake_manager.normalize_model_name.return_value = "norm"
-    fake_client = MagicMock()
-    fake_client.get_model_capabilities.return_value = OllamaModelCapabilities("norm", 100, 20)
-    monkeypatch.setattr(rune.OllamaModelManager, "create", lambda *_: fake_manager)
-    monkeypatch.setattr(rune, "OllamaClient", lambda *_: fake_client)
+    fake_backend = MagicMock()
+    fake_backend.normalize_model_name.return_value = "norm"
+    fake_backend.get_model_capabilities.return_value = OllamaModelCapabilities("norm", 100, 20)
+    monkeypatch.setattr(rune, "get_backend", lambda *_args, **_kw: fake_backend)
     caps = rune._fetch_model_capabilities("http://x", "m")
     assert caps.context_window == 100
 
-    fake_client.get_model_capabilities.side_effect = RuntimeError("nope")
+    fake_backend.get_model_capabilities.side_effect = RuntimeError("nope")
     assert rune._fetch_model_capabilities("http://x", "m") is None
 
     test_console = Console(record=True)


### PR DESCRIPTION
## Summary
- Add `backend_type: str = "ollama"` parameter to `AgentRunner` protocol and all 22 driver `ask()` methods
- Replace `OllamaClient`/`OllamaModelManager` coupling in Holmes driver with generic `get_backend()` factory
- Thread `backend_type` from API requests through to `runner.ask()` calls
- Rename `AgentConfig.ollama_url` → `backend_url` with env var fallback

Closes #170

### Files changed (32)
- `agents/base.py` — protocol signature + `AgentConfig` field rename
- `agents/config.py` — env var resolution updated
- `drivers/holmes/__init__.py` — `get_backend()` replaces Ollama imports
- `api_backend.py` — threads `backend_type`
- `rune/__init__.py` — CLI helper uses `get_backend()`
- All 22 driver `__init__.py` — mechanical `backend_type` param addition
- 5 test files — mock `get_backend` instead of `OllamaClient`

## DoD Level

- [x] **Level 1** — Full Validation (protocol signature change affects all 22 drivers and API backend)
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] `AgentRunner` protocol includes `backend_type: str = "ollama"` in `ask()` signature
- [x] `HolmesDriverClient._fetch_model_limits()` uses `get_backend()` instead of `OllamaClient`/`OllamaModelManager`
- [x] `rune_bench/drivers/holmes/__init__.py` has zero imports from `rune_bench.backends.ollama`
- [x] All 22 driver `ask()` methods include `backend_type` parameter (verified by grep)
- [x] `api_backend.py` threads `backend_type` from request to `runner.ask()`
- [x] All tests pass (pytest: all green)
- [x] Coverage: 97.82% (above 97% floor)

## Audit Checks

No triggers fired — no dependencies added/bumped, no API endpoints changed, no CI workflows modified.

## Breaking Changes

- `AgentConfig.ollama_url` renamed to `AgentConfig.backend_url`. Pre-alpha, no backward compat required.
- `resolve_agent_config()` now reads `RUNE_<AGENT>_BACKEND_URL` (falls back to `RUNE_<AGENT>_OLLAMA_URL`).

## Test plan

- [x] `pytest tests/ -x -q` — all tests pass
- [x] `grep -rn "OllamaClient\|OllamaModelManager" rune_bench/drivers/` — zero matches in Holmes driver
- [x] `pytest --cov=rune_bench --cov-fail-under=97` — 97.82% coverage
- [x] Protocol signature inspection confirms `backend_type` parameter present

🤖 Generated with [Claude Code](https://claude.com/claude-code)