### PR TITLE
refactor: generalize ProvisioningResult and resource providers

### DIFF
--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -16,7 +16,7 @@ from rune_bench.api_contracts import (
 from rune_bench.common import ModelSelector
 from rune_bench.metrics import span  # noqa: F401 (used by workflows layer)
 from rune_bench.resources.base import LLMResourceProvider
-from rune_bench.resources.existing_ollama_provider import ExistingOllamaProvider
+from rune_bench.resources.existing_backend_provider import ExistingBackendProvider
 from rune_bench.workflows import (
     list_backend_models as list_backend_models_wf,
     list_running_backend_models,
@@ -53,11 +53,12 @@ def _make_resource_provider_for_benchmark(request: RunBenchmarkRequest) -> LLMRe
             reliability=request.reliability,
             stop_on_teardown=request.vastai_stop_instance,
         )
-    return ExistingOllamaProvider(
+    return ExistingBackendProvider(
         request.backend_url,
         model=request.model,
         warmup=request.backend_warmup,
         warmup_timeout=request.backend_warmup_timeout,
+        backend_type=getattr(request, "backend_type", "ollama"),
     )
 
 
@@ -73,7 +74,10 @@ def _make_resource_provider_for_ollama_instance(request: RunLLMInstanceRequest) 
             reliability=request.reliability,
             stop_on_teardown=False,
         )
-    return ExistingOllamaProvider(request.backend_url)
+    return ExistingBackendProvider(
+        request.backend_url,
+        backend_type=getattr(request, "backend_type", "ollama"),
+    )
 
 
 def _make_agent_runner(agent_name: str | Path = "holmes", *, kubeconfig: Path | None = None) -> Any:

--- a/rune_bench/resources/__init__.py
+++ b/rune_bench/resources/__init__.py
@@ -1,11 +1,13 @@
 """LLM resource provisioning interfaces and implementations."""
 
 from .base import LLMResourceProvider, ProvisioningResult
+from .existing_backend_provider import ExistingBackendProvider
 from .existing_ollama_provider import ExistingOllamaProvider
 
 __all__ = [
     "LLMResourceProvider",
     "ProvisioningResult",
+    "ExistingBackendProvider",
     "ExistingOllamaProvider",
 ]
 

--- a/rune_bench/resources/base.py
+++ b/rune_bench/resources/base.py
@@ -15,6 +15,7 @@ class ProvisioningResult:
 
     backend_url: str | None
     model: str | None = None
+    backend_type: str = "ollama"
     provider_handle: Any = field(default=None, hash=False, compare=False)
 
 

--- a/rune_bench/resources/existing_backend_provider.py
+++ b/rune_bench/resources/existing_backend_provider.py
@@ -1,0 +1,47 @@
+"""Existing LLM backend server resource provider."""
+
+from rune_bench.resources.base import ProvisioningResult
+from rune_bench.workflows import use_existing_backend_server, warmup_backend_model
+
+
+class ExistingBackendProvider:
+    """LLMResourceProvider for a pre-existing LLM backend server.
+
+    Optionally warms up the specified model during :meth:`provision`.
+    :meth:`teardown` is a no-op — the external server is left running.
+    """
+
+    def __init__(
+        self,
+        backend_url: str | None,
+        *,
+        model: str | None = None,
+        warmup: bool = False,
+        warmup_timeout: int = 120,
+        backend_type: str = "ollama",
+    ) -> None:
+        self._backend_url = backend_url
+        self._model = model
+        self._warmup = warmup
+        self._warmup_timeout = warmup_timeout
+        self._backend_type = backend_type
+
+    def provision(self) -> ProvisioningResult:
+        server = use_existing_backend_server(
+            self._backend_url,
+            model_name=self._model or "<user-selected>",
+        )
+        if self._warmup and self._model:
+            warmup_backend_model(
+                server.url,
+                self._model,
+                timeout_seconds=self._warmup_timeout,
+            )
+        return ProvisioningResult(
+            backend_url=server.url,
+            model=self._model,
+            backend_type=self._backend_type,
+        )
+
+    def teardown(self, result: ProvisioningResult) -> None:
+        pass

--- a/rune_bench/resources/existing_ollama_provider.py
+++ b/rune_bench/resources/existing_ollama_provider.py
@@ -1,41 +1,5 @@
-"""Existing Ollama server LLM resource provider."""
+"""Backward-compatible alias — use ExistingBackendProvider instead."""
 
-from rune_bench.resources.base import ProvisioningResult
-from rune_bench.workflows import use_existing_backend_server, warmup_backend_model
+from rune_bench.resources.existing_backend_provider import ExistingBackendProvider
 
-
-class ExistingOllamaProvider:
-    """LLMResourceProvider for a pre-existing Ollama server.
-
-    Optionally warms up the specified model during :meth:`provision`.
-    :meth:`teardown` is a no-op — the external server is left running.
-    """
-
-    def __init__(
-        self,
-        backend_url: str | None,
-        *,
-        model: str | None = None,
-        warmup: bool = False,
-        warmup_timeout: int = 120,
-    ) -> None:
-        self._backend_url = backend_url
-        self._model = model
-        self._warmup = warmup
-        self._warmup_timeout = warmup_timeout
-
-    def provision(self) -> ProvisioningResult:
-        server = use_existing_backend_server(
-            self._backend_url,
-            model_name=self._model or "<user-selected>",
-        )
-        if self._warmup and self._model:
-            warmup_backend_model(
-                server.url,
-                self._model,
-                timeout_seconds=self._warmup_timeout,
-            )
-        return ProvisioningResult(backend_url=server.url, model=self._model)
-
-    def teardown(self, result: ProvisioningResult) -> None:
-        pass
+ExistingOllamaProvider = ExistingBackendProvider

--- a/rune_bench/resources/vastai/instance.py
+++ b/rune_bench/resources/vastai/instance.py
@@ -12,7 +12,7 @@ from rune_bench.resources.vastai.sdk import VastAI
 
 from rune_bench.common import SelectedModel
 from rune_bench.debug import debug_log
-from rune_bench.backends.ollama import OllamaClient
+from rune_bench.backends import get_backend
 
 from .template import Template
 
@@ -234,31 +234,38 @@ class InstanceManager:
             raise RuntimeError(f"Failed to destroy Vast.ai instance {cid}: {exc}") from exc
 
     # ------------------------------------------------------------------ #
-    # Block 8 — Pull model via Ollama                                     #
+    # Block 8 — Pull model via backend                                     #
     # ------------------------------------------------------------------ #
 
-    def pull_model(self, contract_id: int | str, model_name: str, backend_url: str | None = None) -> None:
-        """Load a model into Ollama on the remote instance via Ollama API.
+    def pull_model(
+        self,
+        contract_id: int | str,
+        model_name: str,
+        backend_url: str | None = None,
+        backend_type: str = "ollama",
+    ) -> None:
+        """Load a model into the LLM backend on the remote instance.
 
         Args:
             contract_id: The Vast.ai contract/instance id (for error context).
             model_name: The model name to load (e.g., "mistral:latest").
-            backend_url: Ollama API URL (e.g., "http://ip:11434").
+            backend_url: LLM backend API URL (e.g., "http://ip:11434").
+            backend_type: Backend type (e.g., "ollama").
 
         Raises:
-            RuntimeError: if no Ollama URL is provided or API load fails.
+            RuntimeError: if no backend URL is provided or model load fails.
         """
         if not backend_url:
             raise RuntimeError(
-                f"Cannot pull model for contract {contract_id}: missing Ollama URL"
+                f"Cannot pull model for contract {contract_id}: missing backend URL"
             )
 
         try:
             debug_log(
-                f"Vast.ai Ollama model load: contract_id={contract_id} backend_url={backend_url} model={model_name}"
+                f"Vast.ai model load: contract_id={contract_id} backend_url={backend_url} model={model_name}"
             )
-            client = OllamaClient(backend_url)
-            client.load_model(model_name)
+            backend = get_backend(backend_type, backend_url)
+            backend.warmup(model_name, timeout_seconds=300)
         except RuntimeError as exc:
             raise RuntimeError(
                 f"Model pull via Ollama API failed for contract {contract_id}: {exc}"

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -450,9 +450,9 @@ def test_api_backend_server_workflows_instance_remaining(monkeypatch, tmp_path):
     assert stopped == [True]
 
     # api_backend benchmark warmup branch — patch at provider module level to verify
-    # ExistingOllamaProvider.provision() calls warmup when warmup=True
-    import rune_bench.resources.existing_ollama_provider as _ep
-    from rune_bench.resources.existing_ollama_provider import ExistingOllamaProvider
+    # ExistingBackendProvider.provision() calls warmup when warmup=True
+    import rune_bench.resources.existing_backend_provider as _ep
+    from rune_bench.resources.existing_backend_provider import ExistingBackendProvider
 
     warmups = []
     monkeypatch.setattr(_ep, "use_existing_backend_server", lambda *_a, **_k: type("S", (), {"url": "http://existing"})())
@@ -460,7 +460,7 @@ def test_api_backend_server_workflows_instance_remaining(monkeypatch, tmp_path):
     monkeypatch.setattr(
         api_backend,
         "_make_resource_provider_for_benchmark",
-        lambda req: ExistingOllamaProvider(req.backend_url, model=req.model, warmup=req.backend_warmup, warmup_timeout=req.backend_warmup_timeout),
+        lambda req: ExistingBackendProvider(req.backend_url, model=req.model, warmup=req.backend_warmup, warmup_timeout=req.backend_warmup_timeout),
     )
     api_backend.run_benchmark(
         api_backend.RunBenchmarkRequest(

--- a/tests/test_vastai_mocked.py
+++ b/tests/test_vastai_mocked.py
@@ -84,23 +84,21 @@ def test_instance_manager_reuse_selects_best_running_candidate():
 
 
 def test_instance_manager_pull_model_requires_backend_url():
-    with pytest.raises(RuntimeError, match="missing Ollama URL"):
+    with pytest.raises(RuntimeError, match="missing backend URL"):
         InstanceManager(MagicMock()).pull_model(contract_id=123, model_name="foo:1", backend_url=None)
 
 
-def test_instance_manager_pull_model_wraps_ollama_errors(monkeypatch):
+def test_instance_manager_pull_model_wraps_backend_errors(monkeypatch):
     manager = InstanceManager(MagicMock())
 
-    class _FailingClient:
-        def __init__(self, _url):
-            pass
+    def _failing_get_backend(*_args, **_kw):
+        backend = MagicMock()
+        backend.warmup.side_effect = RuntimeError("boom")
+        return backend
 
-        def load_model(self, _name):
-            raise RuntimeError("boom")
+    monkeypatch.setattr("rune_bench.resources.vastai.instance.get_backend", _failing_get_backend)
 
-    monkeypatch.setattr("rune_bench.resources.vastai.instance.OllamaClient", _FailingClient)
-
-    with pytest.raises(RuntimeError, match="Model pull via Ollama API failed"):
+    with pytest.raises(RuntimeError, match="Model pull.*failed"):
         manager.pull_model(contract_id=999, model_name="foo:1", backend_url="http://fake:11434")
 
 


### PR DESCRIPTION
## Summary
- Add `backend_type: str = "ollama"` field to `ProvisioningResult` dataclass
- Create `ExistingBackendProvider` as backend-generic replacement for `ExistingOllamaProvider`
- `ExistingOllamaProvider` becomes a one-line backward-compat alias
- Replace `OllamaClient` in Vast.ai `InstanceManager.pull_model()` with `get_backend().warmup()`
- Thread `backend_type` through `api_backend.py` factory functions

Closes #171

## DoD Level

- [x] **Level 1** — Full Validation (provisioning contracts and runtime behavior changed)
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] `ProvisioningResult` has `backend_type: str = "ollama"` field
- [x] `ExistingBackendProvider` class exists in `existing_backend_provider.py`
- [x] `ExistingOllamaProvider` alias remains functional
- [x] `rune_bench/resources/vastai/instance.py` has zero imports from `rune_bench.backends.ollama`
- [x] `api_backend.py` factory functions pass `backend_type` from request to provider
- [x] All tests pass
- [x] Coverage: 97.82% (above 97% floor)

## Audit Checks

No triggers fired — no dependencies added/bumped, no API endpoints changed, no CI workflows modified.

## Breaking Changes

- `ExistingOllamaProvider` is now an alias for `ExistingBackendProvider` (pre-alpha, no backward compat required)
- Vast.ai `pull_model()` error message changed from "missing Ollama URL" to "missing backend URL"

## Test plan

- [x] `pytest tests/ -q` — all tests pass
- [x] `pytest --cov-fail-under=97` — 97.82% coverage
- [x] `ruff check` — clean (no new violations)
- [x] `grep -rn "OllamaClient" rune_bench/resources/` — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)