### PR TITLE
fix: add SPDX-License-Identifier headers to all Python files

### DIFF
--- a/devops_agent.py
+++ b/devops_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import time
 from openai import OpenAI

--- a/rune.py
+++ b/rune.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 """Backward-compatible CLI shim.
 

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 """rune.py — CLI entry point for RUNE.
 

--- a/rune/__main__.py
+++ b/rune/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from rune import app

--- a/rune/api.py
+++ b/rune/api.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import os

--- a/rune_bench/__init__.py
+++ b/rune_bench/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 rune_bench — modular benchmarking toolkit for RUNE.
 

--- a/rune_bench/agents/__init__.py
+++ b/rune_bench/agents/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Multi-domain agent registry, configuration, and execution APIs."""
 
 from .base import AgentResult, AgentRunner

--- a/rune_bench/agents/art/__init__.py
+++ b/rune_bench/agents/art/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Art/Creative agentic runners (Midjourney, ComfyUI, Krea AI)."""

--- a/rune_bench/agents/art/comfyui.py
+++ b/rune_bench/agents/art/comfyui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # WARNING: ComfyUI is GPL-3.0. This driver MUST integrate via REST API only (DriverTransport).
 # Do NOT import any ComfyUI Python modules directly -- doing so triggers GPL-3.0 copyleft obligations.
 """ComfyUI agentic runner stub.

--- a/rune_bench/agents/art/krea.py
+++ b/rune_bench/agents/art/krea.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Krea AI agentic runner stub.
 
 Scope:      Art/Creative  |  Rank 3  |  Rating 4.0

--- a/rune_bench/agents/art/midjourney.py
+++ b/rune_bench/agents/art/midjourney.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Midjourney agentic runner stub.
 
 Scope:      Art/Creative  |  Rank 1  |  Rating 5.0

--- a/rune_bench/agents/base.py
+++ b/rune_bench/agents/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Protocol definition for agentic runner implementations."""
 
 from dataclasses import dataclass, field

--- a/rune_bench/agents/config.py
+++ b/rune_bench/agents/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Agent configuration resolution framework."""
 
 import os

--- a/rune_bench/agents/cybersec/__init__.py
+++ b/rune_bench/agents/cybersec/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Cybersecurity agentic runners (PentestGPT, Radiant, Mindgard, BurpGPT, XBOW)."""

--- a/rune_bench/agents/cybersec/burpgpt.py
+++ b/rune_bench/agents/cybersec/burpgpt.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """BurpGPT agentic runner -- delegates to the burpgpt driver.
 
 Scope:      Cybersec  |  Rank 4  |  Rating 3.5

--- a/rune_bench/agents/cybersec/mindgard.py
+++ b/rune_bench/agents/cybersec/mindgard.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Mindgard agentic runner — delegates to the Mindgard driver for AI red-teaming.
 
 Scope:      Cybersec  |  Rank 3  |  Rating 4.0

--- a/rune_bench/agents/cybersec/pentestgpt.py
+++ b/rune_bench/agents/cybersec/pentestgpt.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """PentestGPT agentic runner -- delegates to the pentestgpt driver.
 
 Scope:      Cybersec  |  Rank 1  |  Rating 4.5

--- a/rune_bench/agents/cybersec/radiant.py
+++ b/rune_bench/agents/cybersec/radiant.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Radiant Security agentic runner stub.
 
 Scope:      Cybersec  |  Rank 2  |  Rating 4.5

--- a/rune_bench/agents/cybersec/xbow.py
+++ b/rune_bench/agents/cybersec/xbow.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """XBOW agentic runner stub.
 
 Scope:      Cybersec  |  Rank 5  |  Rating 3.5

--- a/rune_bench/agents/experimental/cognitive_agent.py
+++ b/rune_bench/agents/experimental/cognitive_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Experimental Unified Cognitive Agent Runner.
 
 Integrates MemoryProvider, SafetyInterceptor, MCP Tool Routing,

--- a/rune_bench/agents/experimental/memory_provider.py
+++ b/rune_bench/agents/experimental/memory_provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Experimental Multi-Tier Memory Provider for autonomous agents.
 
 Supports episodic (short-term session logs), semantic (long-term domain knowledge),

--- a/rune_bench/agents/experimental/reflection_agent.py
+++ b/rune_bench/agents/experimental/reflection_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Experimental Reflection Agent Runner.
 
 Implements a basic self-reflection loop for cognitive agents.

--- a/rune_bench/agents/experimental/safety_interceptor.py
+++ b/rune_bench/agents/experimental/safety_interceptor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Experimental Safety Interceptor (Observer Agent).
 
 Acts as middleware to evaluate tool execution requests against safety policies

--- a/rune_bench/agents/legal/__init__.py
+++ b/rune_bench/agents/legal/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Legal agentic runners (Harvey AI, Spellbook)."""

--- a/rune_bench/agents/legal/harvey.py
+++ b/rune_bench/agents/legal/harvey.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Harvey AI agentic runner stub.
 
 Scope:      Legal  |  Rank 1  |  Rating 4.8

--- a/rune_bench/agents/legal/spellbook.py
+++ b/rune_bench/agents/legal/spellbook.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Spellbook agentic runner stub.
 
 Scope:      Legal  |  Rank 2  |  Rating 4.0

--- a/rune_bench/agents/ops/__init__.py
+++ b/rune_bench/agents/ops/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Ops/Misc agentic runners (MultiOn, Dagger, Sierra, SkillFortify, CrewAI)."""

--- a/rune_bench/agents/ops/crewai.py
+++ b/rune_bench/agents/ops/crewai.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CrewAI agentic runner — delegates to the CrewAI driver.
 
 Scope:      Ops/Misc  |  Rank 5  |  Rating 4.0

--- a/rune_bench/agents/ops/dagger.py
+++ b/rune_bench/agents/ops/dagger.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Dagger agentic runner stub.
 
 Scope:      Ops/Misc  |  Rank 2  |  Rating 4.5

--- a/rune_bench/agents/ops/multion.py
+++ b/rune_bench/agents/ops/multion.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MultiOn agentic runner stub.
 
 Scope:      Ops/Misc  |  Rank 1  |  Rating 4.5

--- a/rune_bench/agents/ops/sierra.py
+++ b/rune_bench/agents/ops/sierra.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Sierra agentic runner stub.
 
 Scope:      Ops/Misc  |  Rank 3  |  Rating 4.0

--- a/rune_bench/agents/ops/skillfortify.py
+++ b/rune_bench/agents/ops/skillfortify.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SkillFortify agentic runner stub.
 
 Scope:      Ops/Misc  |  Rank 4  |  Rating 3.0

--- a/rune_bench/agents/registry.py
+++ b/rune_bench/agents/registry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Dynamic agent registry with lazy import resolution.
 
 The registry supports two kinds of agents:

--- a/rune_bench/agents/research/__init__.py
+++ b/rune_bench/agents/research/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Research agentic runners (Perplexity, Glean, Elicit, LangGraph, Consensus)."""

--- a/rune_bench/agents/research/consensus.py
+++ b/rune_bench/agents/research/consensus.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Consensus agentic runner — evidence-based synthesis from academic papers.
 
 Scope:      Research  |  Rank 5  |  Rating 3.5

--- a/rune_bench/agents/research/elicit.py
+++ b/rune_bench/agents/research/elicit.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Elicit agentic runner — delegates to the Elicit driver for literature review.
 
 Scope:      Research  |  Rank 3  |  Rating 4.0

--- a/rune_bench/agents/research/glean.py
+++ b/rune_bench/agents/research/glean.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Glean agentic runner -- delegates to the Glean driver.
 
 Scope:      Research  |  Rank 2  |  Rating 4.8

--- a/rune_bench/agents/research/langgraph.py
+++ b/rune_bench/agents/research/langgraph.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LangGraph agentic runner — delegates to the LangGraph driver.
 
 Scope:      Research  |  Rank 4  |  Rating 4.0

--- a/rune_bench/agents/research/perplexity.py
+++ b/rune_bench/agents/research/perplexity.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Perplexity Pro agentic runner — delegates to the Perplexity driver.
 
 Scope:      Research  |  Rank 1  |  Rating 5.0

--- a/rune_bench/agents/sre/__init__.py
+++ b/rune_bench/agents/sre/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SRE agentic runners (HolmesGPT, K8sGPT, PagerDuty AI, Metoro, Cleric)."""
 
 from .holmes import HolmesRunner

--- a/rune_bench/agents/sre/cleric.py
+++ b/rune_bench/agents/sre/cleric.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Cleric agentic runner stub.
 
 Scope:      SRE  |  Rank 5  |  Rating 3.5

--- a/rune_bench/agents/sre/holmes.py
+++ b/rune_bench/agents/sre/holmes.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HolmesGPT agent for RUNE — thin re-export kept for backward compatibility.
 
 The implementation has moved to :mod:`rune_bench.drivers.holmes`.

--- a/rune_bench/agents/sre/k8sgpt.py
+++ b/rune_bench/agents/sre/k8sgpt.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """K8sGPT agentic runner — delegates to the K8sGPT driver.
 
 Scope:      SRE  |  Rank 1  |  Rating 5.0

--- a/rune_bench/agents/sre/metoro.py
+++ b/rune_bench/agents/sre/metoro.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Metoro agentic runner -- delegates to the Metoro driver.
 
 Scope:      SRE  |  Rank 4  |  Rating 4.0

--- a/rune_bench/agents/sre/pagerduty.py
+++ b/rune_bench/agents/sre/pagerduty.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """PagerDuty AI agentic runner — delegates to the pagerduty driver.
 
 Scope:      SRE  |  Rank 3  |  Rating 4.5

--- a/rune_bench/agents/stubs.py
+++ b/rune_bench/agents/stubs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Enterprise stub utilities for agents that require external configuration.
 
 Agents that are registered in the built-in map but depend on commercial

--- a/rune_bench/api_backend.py
+++ b/rune_bench/api_backend.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Local execution backend behind the RUNE HTTP API."""
 
 from __future__ import annotations

--- a/rune_bench/api_client.py
+++ b/rune_bench/api_client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HTTP client for RUNE API backend mode."""
 
 import os

--- a/rune_bench/api_contracts.py
+++ b/rune_bench/api_contracts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Stable contracts for CLI/API compatibility.
 
 These dataclasses are transport-agnostic and define the operation payloads

--- a/rune_bench/api_server.py
+++ b/rune_bench/api_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HTTP server for RUNE API mode."""
 
 from __future__ import annotations

--- a/rune_bench/attestation/__init__.py
+++ b/rune_bench/attestation/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """TPM 2.0 remote attestation scaffold for benchmark job scheduling targets."""
 
 from .factory import get_driver

--- a/rune_bench/attestation/factory.py
+++ b/rune_bench/attestation/factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Factory for attestation drivers.
 
 Resolves the driver name from the supplied *config* dict, falling back to

--- a/rune_bench/attestation/interface.py
+++ b/rune_bench/attestation/interface.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Attestation driver interface for TPM 2.0 PCR verification."""
 
 from __future__ import annotations

--- a/rune_bench/attestation/noop.py
+++ b/rune_bench/attestation/noop.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """NoOp attestation driver for local/dev environments.
 
 Always passes — use only when hardware TPM is unavailable or unnecessary.

--- a/rune_bench/attestation/tpm2.py
+++ b/rune_bench/attestation/tpm2.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """TPM 2.0 attestation driver using the tpm2-tools CLI.
 
 Invokes ``tpm2_quote`` to obtain a PCR quote from the local TPM chip and,

--- a/rune_bench/backends/__init__.py
+++ b/rune_bench/backends/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LLM backend protocol, registry, and factory.
 
 Backends define HOW to communicate with an LLM — handling auth, model

--- a/rune_bench/backends/base.py
+++ b/rune_bench/backends/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Protocol and credential types for LLM backend implementations."""
 
 from dataclasses import dataclass, field

--- a/rune_bench/backends/bedrock.py
+++ b/rune_bench/backends/bedrock.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """AWS Bedrock LLM backend stub.
 
 Scope:      SaaS API

--- a/rune_bench/backends/ollama.py
+++ b/rune_bench/backends/ollama.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Ollama LLM backend — HTTP client and high-level model manager.
 
 Consolidates the low-level API client (OllamaClient) and the high-level

--- a/rune_bench/backends/openai.py
+++ b/rune_bench/backends/openai.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """OpenAI API LLM backend stub.
 
 Scope:      SaaS API

--- a/rune_bench/catalog/__init__.py
+++ b/rune_bench/catalog/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """RUNE benchmark catalog — scopes, agents, questions, and chain definitions.
 
 Quick start::

--- a/rune_bench/catalog/loader.py
+++ b/rune_bench/catalog/loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Catalog loader for RUNE — supports CSV (default) and YAML (extended).
 
 Loading priority

--- a/rune_bench/catalog/models.py
+++ b/rune_bench/catalog/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Catalog data model for RUNE benchmark scopes, agents, and chain definitions.
 
 All types are plain dataclasses (no third-party dependencies) so they are

--- a/rune_bench/common/__init__.py
+++ b/rune_bench/common/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Common utilities and shared data structures."""
 
 from .config import INIT_TEMPLATE, get_loaded_config_files, load_config, peek_profile_from_argv

--- a/rune_bench/common/config.py
+++ b/rune_bench/common/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """YAML configuration loader with profile support.
 
 Precedence (highest to lowest):

--- a/rune_bench/common/costs.py
+++ b/rune_bench/common/costs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Cost estimation logic for cloud and local environments."""
 
 from typing import Optional

--- a/rune_bench/common/http_client.py
+++ b/rune_bench/common/http_client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared HTTP client utilities for URL normalization and request handling."""
 
 from __future__ import annotations

--- a/rune_bench/common/models.py
+++ b/rune_bench/common/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Block 2+3 — Model Selection and Disk Sizing.
 
 Selects the largest LLM model that fits in the available VRAM and

--- a/rune_bench/debug.py
+++ b/rune_bench/debug.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared debug logging helpers for RUNE."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/__init__.py
+++ b/rune_bench/drivers/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Driver transport package — factory and public re-exports.
 
 Usage::

--- a/rune_bench/drivers/base.py
+++ b/rune_bench/drivers/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Driver transport protocol — the base contract for all driver transports.
 
 A ``DriverTransport`` is anything that can send an action + params to an

--- a/rune_bench/drivers/burpgpt/__init__.py
+++ b/rune_bench/drivers/burpgpt/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """BurpGPT driver client -- delegates web vulnerability scanning to the burpgpt driver process.
 
 The driver process (``rune_bench.drivers.burpgpt.__main__``) talks to the

--- a/rune_bench/drivers/burpgpt/__main__.py
+++ b/rune_bench/drivers/burpgpt/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """BurpGPT driver entry point -- receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/consensus/__init__.py
+++ b/rune_bench/drivers/consensus/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Consensus driver client — delegates research queries to the consensus driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/consensus/__main__.py
+++ b/rune_bench/drivers/consensus/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Consensus driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/crewai/__init__.py
+++ b/rune_bench/drivers/crewai/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CrewAI driver client — delegates ops queries to the crewai driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/crewai/__main__.py
+++ b/rune_bench/drivers/crewai/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CrewAI driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/dagger/__init__.py
+++ b/rune_bench/drivers/dagger/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Dagger driver client — delegates CI/CD pipeline queries to the dagger driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/dagger/__main__.py
+++ b/rune_bench/drivers/dagger/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Dagger driver entry point -- receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/dagger/pipelines/__init__.py
+++ b/rune_bench/drivers/dagger/pipelines/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Pipeline templates for the Dagger driver.
 # Each .sh file in this directory is a named pipeline that can be invoked
 # via the ``pipeline`` parameter of the ``ask`` action.

--- a/rune_bench/drivers/elicit/__init__.py
+++ b/rune_bench/drivers/elicit/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Elicit driver client — delegates literature-review queries to the elicit driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/elicit/__main__.py
+++ b/rune_bench/drivers/elicit/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Elicit driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/glean/__init__.py
+++ b/rune_bench/drivers/glean/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Glean driver client -- delegates enterprise search queries to the glean driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/glean/__main__.py
+++ b/rune_bench/drivers/glean/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Glean driver entry point -- receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/harvey/__init__.py
+++ b/rune_bench/drivers/harvey/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Harvey AI driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/harvey/__main__.py
+++ b/rune_bench/drivers/harvey/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Harvey AI driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/holmes/__init__.py
+++ b/rune_bench/drivers/holmes/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Holmes driver client — delegates HolmesGPT queries to the holmes driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/holmes/__main__.py
+++ b/rune_bench/drivers/holmes/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Holmes driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/http.py
+++ b/rune_bench/drivers/http.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HttpTransport — drives a remote driver server via the rune job-poll protocol.
 
 The server must implement:

--- a/rune_bench/drivers/k8sgpt/__init__.py
+++ b/rune_bench/drivers/k8sgpt/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """K8sGPT driver client — delegates k8sgpt analysis queries to the k8sgpt driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/k8sgpt/__main__.py
+++ b/rune_bench/drivers/k8sgpt/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """K8sGPT driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/krea/__init__.py
+++ b/rune_bench/drivers/krea/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Krea AI driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/krea/__main__.py
+++ b/rune_bench/drivers/krea/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Krea AI driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/langgraph/__init__.py
+++ b/rune_bench/drivers/langgraph/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LangGraph driver client — delegates research queries to the langgraph driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/langgraph/__main__.py
+++ b/rune_bench/drivers/langgraph/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LangGraph driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/mcp_poc.py
+++ b/rune_bench/drivers/mcp_poc.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Experimental Model Context Protocol (MCP) Integration PoC.
 
 This module demonstrates how RUNE can act as an MCP Server exposing tools

--- a/rune_bench/drivers/metoro/__init__.py
+++ b/rune_bench/drivers/metoro/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Metoro driver client -- delegates eBPF observability queries to the metoro driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/metoro/__main__.py
+++ b/rune_bench/drivers/metoro/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Metoro driver entry point -- receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/midjourney/__init__.py
+++ b/rune_bench/drivers/midjourney/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Midjourney driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/midjourney/__main__.py
+++ b/rune_bench/drivers/midjourney/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Midjourney driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/mindgard/__init__.py
+++ b/rune_bench/drivers/mindgard/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Mindgard driver client — delegates AI red-teaming to the mindgard driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/mindgard/__main__.py
+++ b/rune_bench/drivers/mindgard/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Mindgard driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/pagerduty/__init__.py
+++ b/rune_bench/drivers/pagerduty/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """PagerDuty driver client -- delegates incident triage queries to the pagerduty driver process.
 
 This is a hybrid agent: PagerDuty REST API for data retrieval plus Ollama for

--- a/rune_bench/drivers/pagerduty/__main__.py
+++ b/rune_bench/drivers/pagerduty/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """PagerDuty driver entry point -- receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/pentestgpt/__init__.py
+++ b/rune_bench/drivers/pentestgpt/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """PentestGPT driver client -- delegates pentest queries to the pentestgpt driver process.
 
 The driver process (``rune_bench.drivers.pentestgpt.__main__``) calls the

--- a/rune_bench/drivers/pentestgpt/__main__.py
+++ b/rune_bench/drivers/pentestgpt/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """PentestGPT driver entry point -- receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/perplexity/__init__.py
+++ b/rune_bench/drivers/perplexity/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Perplexity driver client — delegates research queries to the perplexity driver process.
 
 The driver process is launched via :func:`~rune_bench.drivers.make_driver_transport`

--- a/rune_bench/drivers/perplexity/__main__.py
+++ b/rune_bench/drivers/perplexity/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Perplexity driver entry point — receives JSON actions on stdin, writes results to stdout.
 
 Run as::

--- a/rune_bench/drivers/radiant/__init__.py
+++ b/rune_bench/drivers/radiant/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Radiant Security driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/radiant/__main__.py
+++ b/rune_bench/drivers/radiant/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Radiant Security driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/sierra/__init__.py
+++ b/rune_bench/drivers/sierra/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Sierra driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/sierra/__main__.py
+++ b/rune_bench/drivers/sierra/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Sierra driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/skillfortify/__init__.py
+++ b/rune_bench/drivers/skillfortify/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SkillFortify driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/skillfortify/__main__.py
+++ b/rune_bench/drivers/skillfortify/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SkillFortify driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/spellbook/__init__.py
+++ b/rune_bench/drivers/spellbook/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Spellbook driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/spellbook/__main__.py
+++ b/rune_bench/drivers/spellbook/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Spellbook driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/stdio.py
+++ b/rune_bench/drivers/stdio.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """StdioTransport — drives an external process via newline-delimited JSON on stdio.
 
 Wire protocol (v1):

--- a/rune_bench/drivers/xbow/__init__.py
+++ b/rune_bench/drivers/xbow/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """XBOW driver client — enterprise stub pending API access."""
 
 from __future__ import annotations

--- a/rune_bench/drivers/xbow/__main__.py
+++ b/rune_bench/drivers/xbow/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """XBOW driver entry point — enterprise stub.
 
 Wire protocol (v1):

--- a/rune_bench/job_store.py
+++ b/rune_bench/job_store.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Persistent SQLite-backed job store for the RUNE API server."""
 
 from __future__ import annotations

--- a/rune_bench/metrics.py
+++ b/rune_bench/metrics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Workflow lifecycle metrics for RUNE.
 
 A lightweight, thread-safe metrics layer that counts and times workflow phases.

--- a/rune_bench/resources/__init__.py
+++ b/rune_bench/resources/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LLM resource provisioning interfaces and implementations."""
 
 from .base import LLMResourceProvider, ProvisioningResult

--- a/rune_bench/resources/base.py
+++ b/rune_bench/resources/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Protocol and data types for LLM resource provisioning."""
 
 from dataclasses import dataclass, field

--- a/rune_bench/resources/existing_backend_provider.py
+++ b/rune_bench/resources/existing_backend_provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Existing LLM backend server resource provider."""
 
 from rune_bench.resources.base import ProvisioningResult

--- a/rune_bench/resources/existing_ollama_provider.py
+++ b/rune_bench/resources/existing_ollama_provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Backward-compatible alias — use ExistingBackendProvider instead."""
 
 from rune_bench.resources.existing_backend_provider import ExistingBackendProvider

--- a/rune_bench/resources/vastai/__init__.py
+++ b/rune_bench/resources/vastai/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Vast.ai LLM resource provider and low-level instance lifecycle modules."""
 
 from .instance import ConnectionDetails, InstanceManager, TeardownResult

--- a/rune_bench/resources/vastai/instance.py
+++ b/rune_bench/resources/vastai/instance.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Block 6+7+8+9 — Instance lifecycle.
 
 Handles instance creation, polling until running, model pull via

--- a/rune_bench/resources/vastai/offer.py
+++ b/rune_bench/resources/vastai/offer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Block 1 — Search Offers.
 
 Finds the best available GPU offer on Vast.ai given price and

--- a/rune_bench/resources/vastai/provider.py
+++ b/rune_bench/resources/vastai/provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Vast.ai LLM resource provider."""
 
 from rune_bench.resources.vastai.sdk import VastAI

--- a/rune_bench/resources/vastai/sdk.py
+++ b/rune_bench/resources/vastai/sdk.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Lightweight Vast.ai API client to replace vastai-sdk and avoid CVEs."""
 
 import json

--- a/rune_bench/resources/vastai/template.py
+++ b/rune_bench/resources/vastai/template.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Block 4 — Template Loading.
 
 Fetches Vast.ai templates and resolves a template by its hash,

--- a/rune_bench/workflows.py
+++ b/rune_bench/workflows.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Application workflows used by the RUNE CLI.
 
 This module keeps orchestration/business logic out of the CLI layer.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Pytest configuration: shared fixtures and test helpers."""
 
 import sys

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for agent configuration resolution."""
 
 from __future__ import annotations

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for agent registry and configuration validation."""
 
 import pytest

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from rune_bench.api_client import RuneApiClient

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from rune_bench.api_contracts import (

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import hashlib
 import json
 import threading

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for the rune_bench.attestation module.
 
 Covers:

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for the LLM backend factory, registry, and OllamaBackend wrapper."""
 
 from __future__ import annotations

--- a/tests/test_backend_stubs.py
+++ b/tests/test_backend_stubs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from rune_bench.backends.base import BackendCredentials
 from rune_bench.backends.openai import OpenAIBackend

--- a/tests/test_burpgpt_driver.py
+++ b/tests/test_burpgpt_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.burpgpt — driver client and subprocess entry point.
 
 All HTTP calls to Burp Suite REST API are mocked so no external services

--- a/tests/test_catalog_loader.py
+++ b/tests/test_catalog_loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.catalog — CSV loading, YAML overlay, and auto-detection."""
 
 from __future__ import annotations

--- a/tests/test_cli_http_mode.py
+++ b/tests/test_cli_http_mode.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer

--- a/tests/test_cognitive_agent.py
+++ b/tests/test_cognitive_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from rune_bench.drivers.mcp_poc import MCPToolServer, MCPClientDriver

--- a/tests/test_comprehensive_error_paths.py
+++ b/tests/test_comprehensive_error_paths.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import hashlib
 from unittest.mock import MagicMock
 from urllib.request import Request, urlopen

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.common.config — YAML configuration loader."""
 
 from __future__ import annotations

--- a/tests/test_consensus_driver.py
+++ b/tests/test_consensus_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.consensus — driver entry point and client.
 
 All HTTP calls (Semantic Scholar + Ollama) are monkeypatched so no network

--- a/tests/test_cost_estimation.py
+++ b/tests/test_cost_estimation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for cost estimation: api_backend.get_cost_estimate and common.costs.CostEstimator."""
 
 from __future__ import annotations

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 

--- a/tests/test_crewai_driver.py
+++ b/tests/test_crewai_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.crewai — driver client and __main__ entry point.
 
 CrewAI is an optional dependency.  All imports are mocked so the test suite

--- a/tests/test_dagger_driver.py
+++ b/tests/test_dagger_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.dagger — driver entry point and client.
 
 The dagger-io package is optional, so all tests mock it entirely.

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import rune_bench.debug as debug
 
 

--- a/tests/test_driver_clients.py
+++ b/tests/test_driver_clients.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for CrewAI and LangGraph driver clients (__init__.py coverage)."""
 
 from __future__ import annotations

--- a/tests/test_driver_coverage_extras.py
+++ b/tests/test_driver_coverage_extras.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 """Extra tests for driver coverage gaps."""
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for the driver transport infrastructure.
 
 Covers StdioTransport, HttpTransport, and the make_driver_transport() factory.

--- a/tests/test_edge_cases_micro_branches.py
+++ b/tests/test_edge_cases_micro_branches.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import runpy
 import sys
 import threading

--- a/tests/test_elicit_driver.py
+++ b/tests/test_elicit_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.elicit.__main__ — the driver entry point.
 
 The driver calls the Elicit REST API via urllib.request.  All HTTP calls are

--- a/tests/test_elicit_mindgard_clients.py
+++ b/tests/test_elicit_mindgard_clients.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for Elicit and Mindgard driver clients (__init__.py coverage)."""
 
 from __future__ import annotations

--- a/tests/test_enterprise_stubs.py
+++ b/tests/test_enterprise_stubs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for enterprise stub drivers.
 
 Each stub must:

--- a/tests/test_glean_driver.py
+++ b/tests/test_glean_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.glean.__main__ -- the Glean driver entry point.
 
 The driver calls the Glean REST API via urllib.request.  urllib.request.urlopen

--- a/tests/test_holmes_driver.py
+++ b/tests/test_holmes_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.holmes.__main__ — the driver entry point.
 
 The driver process calls ``python -m holmes.main ask`` as a subprocess.

--- a/tests/test_holmes_runner.py
+++ b/tests/test_holmes_runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for HolmesRunner / HolmesDriverClient.
 
 HolmesRunner is now a backward-compatible alias for HolmesDriverClient.

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from rune_bench.job_store import JobStore
 
 

--- a/tests/test_k8sgpt_driver.py
+++ b/tests/test_k8sgpt_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.k8sgpt — the driver entry point and client.
 
 The driver process calls ``k8sgpt analyze`` as a subprocess.

--- a/tests/test_langgraph_driver.py
+++ b/tests/test_langgraph_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.langgraph — driver client and __main__ entry point.
 
 LangGraph and langchain_ollama are optional dependencies.  All imports are

--- a/tests/test_mcp_poc.py
+++ b/tests/test_mcp_poc.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from rune_bench.drivers.mcp_poc import MCPToolServer, MCPClientDriver, route_dynamic_plan

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import pytest
 

--- a/tests/test_metoro_driver.py
+++ b/tests/test_metoro_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.metoro.__main__ -- the Metoro driver entry point.
 
 The driver calls the Metoro REST API via ``make_http_request()`` from

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for the rune_bench.metrics module."""
 
 from __future__ import annotations

--- a/tests/test_mindgard_driver.py
+++ b/tests/test_mindgard_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.mindgard.__main__ — the driver entry point.
 
 The driver calls the ``mindgard`` CLI as a subprocess.  subprocess.run and

--- a/tests/test_ollama_client_and_models.py
+++ b/tests/test_ollama_client_and_models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Live integration tests against a real Ollama instance with TinyLlama.
 
 These tests exercise ``OllamaClient`` and ``OllamaModelManager`` end-to-end

--- a/tests/test_ollama_model_manager.py
+++ b/tests/test_ollama_model_manager.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 

--- a/tests/test_pagerduty_driver.py
+++ b/tests/test_pagerduty_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.pagerduty — driver client and subprocess entry point.
 
 All HTTP calls to PagerDuty and Ollama are mocked so no external services

--- a/tests/test_pentestgpt_driver.py
+++ b/tests/test_pentestgpt_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.pentestgpt — driver client and subprocess entry point.
 
 All HTTP calls to Ollama are mocked so no external services are required.

--- a/tests/test_perplexity_driver.py
+++ b/tests/test_perplexity_driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune_bench.drivers.perplexity — driver entry point and client.
 
 The driver subprocess calls the Perplexity REST API via make_http_request.

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for preflight cost-check paths: CLI behaviour and api_client validation."""
 
 from __future__ import annotations

--- a/tests/test_reflection_agent.py
+++ b/tests/test_reflection_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 
 from rune_bench.agents.experimental.reflection_agent import ReflectionAgentRunner
 

--- a/tests/test_regression_suite.py
+++ b/tests/test_regression_suite.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from rune_bench.common.http_client import normalize_url

--- a/tests/test_rune_cli_integration.py
+++ b/tests/test_rune_cli_integration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_rune_display_and_limits.py
+++ b/tests/test_rune_display_and_limits.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 from rich.console import Console

--- a/tests/test_safety_interceptor.py
+++ b/tests/test_safety_interceptor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from rune_bench.agents.experimental.safety_interceptor import SafetyInterceptor, SafetyViolation

--- a/tests/test_tier1_agent_runners.py
+++ b/tests/test_tier1_agent_runners.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for Tier 1 agent runner modules that delegate to drivers.
 
 These modules are thin wrappers / re-exports; we verify they import cleanly

--- a/tests/test_vastai_instance_manager.py
+++ b/tests/test_vastai_instance_manager.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import hashlib
 import json
 import threading

--- a/tests/test_vastai_mocked.py
+++ b/tests/test_vastai_mocked.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_vastai_sdk.py
+++ b/tests/test_vastai_sdk.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from rune_bench.resources.vastai.sdk import VastAI
 

--- a/tests/test_workflows_non_vastai.py
+++ b/tests/test_workflows_non_vastai.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from unittest.mock import MagicMock
 
 import rune_bench.workflows as workflows

--- a/tests/uat/test_cost_estimation_uat.py
+++ b/tests/uat/test_cost_estimation_uat.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """UAT tests for cost estimation drivers.
 
 These tests validate the accuracy and plausibility of the cost estimation logic


### PR DESCRIPTION
## Summary
- Add `# SPDX-License-Identifier: Apache-2.0` to all Python source files
- Required for IEC 62443 ML4 legal compliance and REUSE specification

Closes #196

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure (header-only change, no runtime impact)
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] All .py files have SPDX header as first line
- [x] Tests pass with no regressions

## Audit Checks

No triggers fired — no dependencies, CI, or API changes.

## Breaking Changes

None.

## Test plan

- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)