### PR TITLE
feat(storage): add hand-rolled migrations framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,11 @@ Issues = "https://github.com/lpasquali/rune/issues"
 include = ["rune*", "rune_bench*"]
 
 [tool.setuptools.package-data]
-"rune_bench" = ["catalog/defaults/*.csv", "catalog/defaults/*.yaml"]
+"rune_bench" = [
+    "catalog/defaults/*.csv",
+    "catalog/defaults/*.yaml",
+    "storage/migrations/*.sql",
+]
 "*" = ["py.typed"]
 
 [tool.mypy]

--- a/rune_bench/storage/__init__.py
+++ b/rune_bench/storage/__init__.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 from urllib.parse import urlparse
 
 from rune_bench.storage.base import StoragePort
+from rune_bench.storage.migrator import Migrator
 from rune_bench.storage.sqlite import JobRecord, SQLiteStorageAdapter
 
 __all__ = [
     "JobRecord",
+    "Migrator",
     "SQLiteStorageAdapter",
     "StoragePort",
     "make_storage",

--- a/rune_bench/storage/migrations/0001_jobs.sql
+++ b/rune_bench/storage/migrations/0001_jobs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE jobs (
+    job_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    status TEXT NOT NULL,
+    request_json TEXT NOT NULL,
+    result_json TEXT,
+    error TEXT,
+    message TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);

--- a/rune_bench/storage/migrations/0002_idempotency_keys.sql
+++ b/rune_bench/storage/migrations/0002_idempotency_keys.sql
@@ -1,0 +1,8 @@
+CREATE TABLE idempotency_keys (
+    tenant_id TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (tenant_id, operation, idempotency_key)
+);

--- a/rune_bench/storage/migrations/0003_workflow_events.sql
+++ b/rune_bench/storage/migrations/0003_workflow_events.sql
@@ -1,0 +1,14 @@
+CREATE TABLE workflow_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT,
+    event TEXT NOT NULL,
+    status TEXT NOT NULL,
+    duration_ms REAL,
+    error_type TEXT,
+    labels_json TEXT,
+    recorded_at REAL NOT NULL
+);
+
+CREATE INDEX idx_workflow_events_job_id ON workflow_events(job_id);
+
+CREATE INDEX idx_workflow_events_event ON workflow_events(event);

--- a/rune_bench/storage/migrations/0004_chain_state.sql
+++ b/rune_bench/storage/migrations/0004_chain_state.sql
@@ -1,0 +1,6 @@
+CREATE TABLE chain_state (
+    job_id TEXT PRIMARY KEY,
+    state_json TEXT NOT NULL,
+    overall_status TEXT NOT NULL,
+    updated_at REAL NOT NULL
+);

--- a/rune_bench/storage/migrations/0005_audit_artifact.sql
+++ b/rune_bench/storage/migrations/0005_audit_artifact.sql
@@ -1,0 +1,12 @@
+CREATE TABLE audit_artifact (
+    artifact_id TEXT PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    content BLOB NOT NULL,
+    created_at REAL NOT NULL
+);
+
+CREATE INDEX idx_audit_artifact_job_id ON audit_artifact(job_id);

--- a/rune_bench/storage/migrator.py
+++ b/rune_bench/storage/migrator.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hand-rolled schema migrator for RUNE storage adapters.
+
+Applies versioned ``NNNN_*.sql`` files from
+``rune_bench/storage/migrations/`` in lexicographic order inside explicit
+``BEGIN ... COMMIT`` transactions and records every applied version in a
+``schema_version`` bookkeeping table so re-runs are no-ops.
+
+Why hand-rolled? alembic would pull SQLAlchemy (~80 transitive deps) for a
+project with a handful of tables; yoyo and dbmate add comparable weight for
+marginal benefit at this scale. ~50 LOC gives us everything we actually need
+(idempotent, transactional, ordered, auditable) without the footprint.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sqlite3
+import time
+
+_FILENAME_RE = re.compile(r"^(\d{4})_.*\.sql$")
+
+
+class Migrator:
+    """Apply pending SQL migrations to a SQLite connection.
+
+    The migrations directory contains ``NNNN_<slug>.sql`` files. Each file is
+    executed in a single transaction and, on success, the version is recorded
+    in ``schema_version(version, applied_at)``. Re-running against an
+    up-to-date database is a no-op.
+    """
+
+    def __init__(self, *, migrations_dir: pathlib.Path | None = None) -> None:
+        self._migrations_dir = (
+            migrations_dir
+            if migrations_dir is not None
+            else pathlib.Path(__file__).parent / "migrations"
+        )
+
+    def apply_pending(self, conn: sqlite3.Connection) -> list[int]:
+        """Apply every migration newer than the current ``schema_version``.
+
+        Returns the list of newly-applied version numbers (empty if the
+        database is already up to date). Each migration runs inside an
+        explicit ``BEGIN ... COMMIT``; a failure rolls back that migration
+        and re-raises :class:`RuntimeError` with the offending version and
+        filename so the underlying driver error is never swallowed.
+        """
+        self._ensure_bookkeeping_table(conn)
+        applied = self._already_applied(conn)
+        newly_applied: list[int] = []
+
+        for version, path in self._discover():
+            if version in applied:
+                continue
+            sql_text = path.read_text(encoding="utf-8")
+            # SQLite's ``executescript()`` issues an implicit COMMIT before
+            # running, which would break our explicit BEGIN…COMMIT envelope.
+            # Split on ';' and execute each non-empty statement individually
+            # so the whole migration lives inside one transaction and we can
+            # ROLLBACK cleanly on failure.
+            statements = [s.strip() for s in sql_text.split(";") if s.strip()]
+            conn.execute("BEGIN")
+            try:
+                for statement in statements:
+                    conn.execute(statement)
+                conn.execute(
+                    "INSERT INTO schema_version(version, applied_at) VALUES (?, ?)",
+                    (version, time.time()),
+                )
+                conn.commit()
+            except Exception as exc:
+                conn.rollback()
+                raise RuntimeError(
+                    f"migration {version} ({path.name}) failed: {exc}"
+                ) from exc
+            newly_applied.append(version)
+
+        return newly_applied
+
+    def _ensure_bookkeeping_table(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at REAL NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+    def _already_applied(self, conn: sqlite3.Connection) -> set[int]:
+        rows = conn.execute("SELECT version FROM schema_version").fetchall()
+        return {int(row[0]) for row in rows}
+
+    def _discover(self) -> list[tuple[int, pathlib.Path]]:
+        discovered: list[tuple[int, pathlib.Path]] = []
+        for path in sorted(self._migrations_dir.glob("[0-9][0-9][0-9][0-9]_*.sql")):
+            match = _FILENAME_RE.match(path.name)
+            if match is None:  # pragma: no cover - glob guarantees the shape
+                continue
+            discovered.append((int(match.group(1)), path))
+        return discovered

--- a/rune_bench/storage/sqlite.py
+++ b/rune_bench/storage/sqlite.py
@@ -62,83 +62,15 @@ class SQLiteStorageAdapter:
         return connection
 
     def _initialize(self) -> None:
+        # Schema creation is delegated to the Migrator so the same set of
+        # versioned ``NNNN_*.sql`` files drives every storage backend (today
+        # SQLite; rune#233 adds Postgres). The Migrator is idempotent, so
+        # reopening an existing database is a no-op.
+        from rune_bench.storage.migrator import Migrator
+
         with self._connect() as conn:
             conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS jobs (
-                    job_id TEXT PRIMARY KEY,
-                    tenant_id TEXT NOT NULL,
-                    kind TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    request_json TEXT NOT NULL,
-                    result_json TEXT,
-                    error TEXT,
-                    message TEXT,
-                    created_at REAL NOT NULL,
-                    updated_at REAL NOT NULL
-                )
-                """
-            )
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS idempotency_keys (
-                    tenant_id TEXT NOT NULL,
-                    operation TEXT NOT NULL,
-                    idempotency_key TEXT NOT NULL,
-                    job_id TEXT NOT NULL,
-                    created_at REAL NOT NULL,
-                    PRIMARY KEY (tenant_id, operation, idempotency_key)
-                )
-                """
-            )
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS workflow_events (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    job_id TEXT,
-                    event TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    duration_ms REAL,
-                    error_type TEXT,
-                    labels_json TEXT,
-                    recorded_at REAL NOT NULL
-                )
-                """
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_workflow_events_job_id ON workflow_events(job_id)"
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_workflow_events_event ON workflow_events(event)"
-            )
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS chain_state (
-                    job_id TEXT PRIMARY KEY,
-                    state_json TEXT NOT NULL,
-                    overall_status TEXT NOT NULL,
-                    updated_at REAL NOT NULL
-                )
-                """
-            )
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS audit_artifact (
-                    artifact_id TEXT PRIMARY KEY,
-                    job_id TEXT NOT NULL,
-                    kind TEXT NOT NULL,
-                    name TEXT NOT NULL,
-                    size_bytes INTEGER NOT NULL,
-                    sha256 TEXT NOT NULL,
-                    content BLOB NOT NULL,
-                    created_at REAL NOT NULL
-                )
-                """
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_audit_artifact_job_id ON audit_artifact(job_id)"
-            )
+            Migrator().apply_pending(conn)
 
     # ── Chain state ────────────────────────────────────────────────────────
     #

--- a/tests/test_storage_migrator.py
+++ b/tests/test_storage_migrator.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :class:`rune_bench.storage.migrator.Migrator`."""
+
+from __future__ import annotations
+
+import pathlib
+import sqlite3
+import time
+
+import pytest
+
+from rune_bench.storage import make_storage
+from rune_bench.storage.migrator import Migrator
+
+_EXPECTED_TABLES = {
+    "jobs",
+    "idempotency_keys",
+    "workflow_events",
+    "chain_state",
+    "audit_artifact",
+}
+_EXPECTED_VERSIONS = [1, 2, 3, 4, 5]
+
+
+def _fresh_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_migrator_applies_all_on_empty_db() -> None:
+    conn = _fresh_conn()
+
+    applied = Migrator().apply_pending(conn)
+
+    assert applied == _EXPECTED_VERSIONS
+    versions = {
+        int(row[0])
+        for row in conn.execute("SELECT version FROM schema_version").fetchall()
+    }
+    assert versions == set(_EXPECTED_VERSIONS)
+
+
+def test_migrator_idempotent() -> None:
+    conn = _fresh_conn()
+    migrator = Migrator()
+
+    first = migrator.apply_pending(conn)
+    second = migrator.apply_pending(conn)
+
+    assert first == _EXPECTED_VERSIONS
+    assert second == []
+    # No duplicate rows inserted on the second run.
+    (count,) = conn.execute("SELECT COUNT(*) FROM schema_version").fetchone()
+    assert count == len(_EXPECTED_VERSIONS)
+
+
+def test_migrator_partial_state() -> None:
+    conn = _fresh_conn()
+    migrator = Migrator()
+
+    # Pre-seed: pretend migrations 1–3 were applied out of band (e.g. a
+    # previous release) so the migrator must only apply 4 and 5.
+    conn.execute(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at REAL NOT NULL)"
+    )
+    now = time.time()
+    for version in (1, 2, 3):
+        conn.execute(
+            "INSERT INTO schema_version(version, applied_at) VALUES (?, ?)",
+            (version, now),
+        )
+    conn.commit()
+
+    applied = migrator.apply_pending(conn)
+
+    assert applied == [4, 5]
+    versions = {
+        int(row[0])
+        for row in conn.execute("SELECT version FROM schema_version").fetchall()
+    }
+    assert versions == {1, 2, 3, 4, 5}
+
+
+def test_migrator_invalid_sql_raises_with_context(tmp_path: pathlib.Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "0001_broken.sql").write_text(
+        "THIS IS NOT VALID SQL;\n", encoding="utf-8"
+    )
+    conn = _fresh_conn()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        Migrator(migrations_dir=migrations_dir).apply_pending(conn)
+
+    message = str(exc_info.value)
+    assert "0001_broken.sql" in message
+    assert "migration 1" in message
+    # The rollback must have un-done the failed version so schema_version
+    # still shows nothing applied.
+    (count,) = conn.execute("SELECT COUNT(*) FROM schema_version").fetchone()
+    assert count == 0
+
+
+def test_migrator_records_applied_at_timestamp() -> None:
+    conn = _fresh_conn()
+    before = time.time()
+
+    Migrator().apply_pending(conn)
+
+    after = time.time()
+    rows = conn.execute(
+        "SELECT version, applied_at FROM schema_version ORDER BY version"
+    ).fetchall()
+    assert [int(r[0]) for r in rows] == _EXPECTED_VERSIONS
+    for row in rows:
+        stamp = float(row[1])
+        assert before <= stamp <= after
+
+
+def test_migration_files_apply_cleanly_to_real_sqlite() -> None:
+    conn = _fresh_conn()
+
+    Migrator().apply_pending(conn)
+
+    names = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    # ``schema_version`` is the bookkeeping table; the five domain tables
+    # must all exist alongside it.
+    assert _EXPECTED_TABLES.issubset(names)
+    assert "schema_version" in names
+
+    # Indexes from 0003 and 0005 must also exist.
+    index_names = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()
+    }
+    assert "idx_workflow_events_job_id" in index_names
+    assert "idx_workflow_events_event" in index_names
+    assert "idx_audit_artifact_job_id" in index_names
+
+
+def test_make_storage_memory_still_works_after_migration_refactor() -> None:
+    # Regression guard: the shared-cache :memory: trick from rune#231 must
+    # still round-trip after the Migrator took over schema creation.
+    store = make_storage("sqlite:///:memory:")
+
+    job_id, created = store.create_job(
+        tenant_id="tenant-a",
+        kind="benchmark",
+        request_payload={"q": 1},
+    )
+    assert created is True
+    fetched = store.get_job(job_id, tenant_id="tenant-a")
+    assert fetched is not None and fetched.job_id == job_id


### PR DESCRIPTION
## Summary

- Extract the inline `CREATE TABLE` blocks from `SQLiteStorageAdapter._initialize` into versioned `NNNN_*.sql` files under `rune_bench/storage/migrations/` and add a ~50-LOC `Migrator` that applies pending migrations transactionally and idempotently.
- Second child of Epic lpasquali/rune-docs#195 (External database support): the upcoming `PostgresStorageAdapter` (rune#233) will share the same migration files so every adapter stays in lock-step without pulling SQLAlchemy/alembic (~80 transitive deps) or an extra runtime dep like yoyo-migrations.
- Zero runtime behavior change for fresh databases: the adapter produces a byte-equivalent schema, the `:memory:` shared-cache trick from rune#231 still works, and every existing test passes unchanged.

Closes lpasquali/rune#232
Epic: lpasquali/rune-docs#195

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

(Rationale: the schema produced by the 5 migration files is byte-equivalent to what the inline `CREATE TABLE IF NOT EXISTS` blocks produced in `_initialize()`. No API routes, contracts, drivers, backends, Helm values, or Dockerfiles were touched. The externally observable behavior of every store method is unchanged for any fresh database.)

## Level 2 Checklist

- [x] Full test suite passes (1035 passed, 8 skipped)
- [x] Coverage not degraded — 97.11% overall (floor: 97%); `rune_bench/storage/migrator.py` at **100%** (41 stmts, 0 missed)
- [x] No unintended CI side effects — no changes to any `.github/workflows/` file, no new deps, no new scanner config

## Audit Checks

No triggers fired.

(No dependency added/bumped, no new agent integration or driver, no new build/CI tool, no API endpoint/auth/CRD change, no CI workflow modification, no Dockerfile/base image change, no VEX statement change, no Helm values change. The only runtime-adjacent diff is the `_initialize()` body, which now delegates to the `Migrator` and produces the same schema on fresh databases.)

## Acceptance Criteria Evidence

- [x] New directory `rune_bench/storage/migrations/` contains `0001_jobs.sql`, `0002_idempotency_keys.sql`, `0003_workflow_events.sql` (+ both indexes), `0004_chain_state.sql`, `0005_audit_artifact.sql` (+ the `idx_audit_artifact_job_id` index). Each file uses plain `CREATE TABLE` (not `IF NOT EXISTS`); the `Migrator`'s `schema_version` mechanism handles idempotency.
- [x] New file `rune_bench/storage/migrator.py` defines `Migrator` with the exact signature from the spec: `__init__(*, migrations_dir: pathlib.Path | None = None)` defaulting to `pathlib.Path(__file__).parent / "migrations"`, and `apply_pending(conn: sqlite3.Connection) -> list[int]` returning the newly-applied versions (empty on re-run).
- [x] Transactional: each migration runs inside an explicit `BEGIN … COMMIT`. On failure the migrator calls `conn.rollback()` and raises `RuntimeError` containing the version and filename, chaining the underlying driver error via `raise … from exc`. Because SQLite's `executescript()` issues an implicit commit at the start (which would break the envelope), the migrator splits on `;` and executes each non-empty statement individually — documented in a code comment in `migrator.py`.
- [x] Idempotent: re-running a fully-applied database returns `[]` and inserts no new rows. Verified by `test_migrator_idempotent`.
- [x] Records version + `applied_at` (`time.time()`) in `schema_version` after each successful migration. Verified by `test_migrator_records_applied_at_timestamp`.
- [x] `SQLiteStorageAdapter._initialize()` is now a three-line delegation (`PRAGMA journal_mode=WAL` + `Migrator().apply_pending(conn)`). All inline `CREATE TABLE` blocks are removed.
- [x] `make_storage("sqlite:///:memory:")` still works after the refactor: the `:memory:` shared-cache URI anchor from rune#231 is untouched, and the regression guard `test_make_storage_memory_still_works_after_migration_refactor` round-trips a job through `create_job` → `get_job`.
- [x] All existing tests pass with no modification (1035 passed, 8 skipped).
- [x] New tests in `tests/test_storage_migrator.py`: `test_migrator_applies_all_on_empty_db`, `test_migrator_idempotent`, `test_migrator_partial_state`, `test_migrator_invalid_sql_raises_with_context`, `test_migrator_records_applied_at_timestamp`, `test_migration_files_apply_cleanly_to_real_sqlite`, plus the `:memory:` regression guard.
- [x] Coverage stays at or above **97%** — CI gate reaches **97.11%** (vs. 97% floor).

### Test evidence

```
$ python -m pytest -p no:cacheprovider
...
rune_bench/storage/migrator.py              41     0  100%
rune_bench/storage/sqlite.py               178     6   97%
rune_bench/storage/__init__.py              17     0  100%
rune_bench/storage/base.py                  17     0  100%
TOTAL                                     4116   119  97%
Required test coverage of 97% reached. Total coverage: 97.11%
1035 passed, 8 skipped, 237 warnings in 22.48s
```

New test names:
- `tests/test_storage_migrator.py::test_migrator_applies_all_on_empty_db`
- `tests/test_storage_migrator.py::test_migrator_idempotent`
- `tests/test_storage_migrator.py::test_migrator_partial_state`
- `tests/test_storage_migrator.py::test_migrator_invalid_sql_raises_with_context`
- `tests/test_storage_migrator.py::test_migrator_records_applied_at_timestamp`
- `tests/test_storage_migrator.py::test_migration_files_apply_cleanly_to_real_sqlite`
- `tests/test_storage_migrator.py::test_make_storage_memory_still_works_after_migration_refactor`

## Test Plan Evidence

- [x] Unit: 7 new tests in `tests/test_storage_migrator.py` cover empty-DB apply, idempotency, partial state (pre-seeded versions 1-3 → only 4/5 run), invalid-SQL rollback with file+version context, `applied_at` timestamp sanity window, schema shape via `sqlite_master`, and the `:memory:` round-trip regression.
- [x] Regression: existing `tests/test_job_store.py` (32 tests), `tests/test_storage_factory.py` (9 tests), `tests/test_job_store_backcompat.py` (2 tests), `tests/test_api_server.py`, and all other suites pass unchanged — 1035 passed total.
- [x] Coverage: 97.11% overall; `rune_bench/storage/migrator.py` at **100%** (41 stmts, 0 missed).
- [x] Lint: `ruff check rune rune_bench tests` — new files clean. (The only 3 ruff errors in the tree are pre-existing on `main` in `tests/test_async_transports_and_remaining.py` and `tests/test_new_transports_and_chain.py`.)
- [x] Types: `mypy rune_bench` — new files clean. (The only 9 mypy errors are pre-existing on `main` in `drivers/langgraph/`, `drivers/browser.py`, `drivers/http.py`, and `workflows.py`.)
- [x] Security: `bandit -r rune_bench -ll` — 0 High, 7 Medium, 16 Low — same counts as `main` (new code adds nothing).

## Breaking Changes

**Upgrade path for pre-existing deployments**: RUNE is pre-alpha (0.0.0a4, no backward compatibility guarantees per `SYSTEM_PROMPT.md`). The only persistent data is the development `.rune-api/jobs.db`. Because the migration files use plain `CREATE TABLE` (not `CREATE TABLE IF NOT EXISTS`), opening an existing DB that was created with the pre-migration code will fail on `0001_jobs.sql` since the `jobs` table already exists and no row has been recorded in `schema_version`. Mitigation: delete `.rune-api/jobs.db` before upgrading (dev-only data). A future "pre-seed schema_version from detected tables" bootstrap is tracked under the Epic and will land before GA — not needed for pre-alpha.

For everything else (fresh installs, CI, `:memory:` tests, new on-disk databases), the schema produced by the 5 migration files is byte-equivalent to the old `_initialize()`:

- Same table names, column names, types, nullability, and primary keys.
- Same two workflow-events indexes (`idx_workflow_events_job_id`, `idx_workflow_events_event`) and the same `idx_audit_artifact_job_id` index.
- `schema_version` is a new bookkeeping table, additive and non-colliding.

## Notes for Reviewer

- The decision to split each SQL file on `;` instead of using `executescript()` is driven by SQLite's `executescript()` behavior: it issues an implicit `COMMIT` before running, which would immediately close the `BEGIN` envelope and defeat the rollback-on-failure guarantee. The split is safe because every statement in the current migration files is a single DDL statement (no triggers, no `BEGIN/END` blocks), and the trade-off is documented with an inline comment in `migrator.py`.
- The migration files are registered in `pyproject.toml` `[tool.setuptools.package-data]` so the wheel ships with the SQL files — without this the Migrator would find an empty directory when installed via `pip install rune`.
- The Migrator is intentionally SQL-portable for the upcoming Postgres adapter: no SQLite-specific pragmas, no `AUTOINCREMENT` tricks beyond what already existed, and no driver-specific syntax. `BLOB` vs `BYTEA` and `REAL` vs `DOUBLE PRECISION` are deferred to rune#233's dialect mechanism.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>