### PR TITLE
feat(storage): legacy SQLite schema_version bootstrap (rune#241)

### DIFF
--- a/rune_bench/storage/migrator.py
+++ b/rune_bench/storage/migrator.py
@@ -21,6 +21,17 @@ import time
 
 _FILENAME_RE = re.compile(r"^(\d{4})_.*\.sql$")
 
+# Tables created by migrations 0001–0005 before ``schema_version`` existed
+# (legacy on-disk SQLite). Used to pre-seed ``schema_version`` so unconditional
+# ``CREATE TABLE`` migrations do not fail on upgrade. See rune#241.
+_PREEXISTING_TABLE_TO_MIGRATION: dict[str, int] = {
+    "jobs": 1,
+    "idempotency_keys": 2,
+    "workflow_events": 3,
+    "chain_state": 4,
+    "audit_artifact": 5,
+}
+
 
 class Migrator:
     """Apply pending SQL migrations to a SQLite connection.
@@ -47,6 +58,7 @@ class Migrator:
         and re-raises :class:`RuntimeError` with the offending version and
         filename so the underlying driver error is never swallowed.
         """
+        self._bootstrap_legacy_schema(conn)
         self._ensure_bookkeeping_table(conn)
         applied = self._already_applied(conn)
         newly_applied: list[int] = []
@@ -78,6 +90,54 @@ class Migrator:
             newly_applied.append(version)
 
         return newly_applied
+
+    def _bootstrap_legacy_schema(self, conn: sqlite3.Connection) -> None:
+        """Pre-seed ``schema_version`` when upgrading a pre-migration SQLite file.
+
+        Legacy databases created before the migrator landed already contain domain
+        tables but no ``schema_version`` row. :meth:`_ensure_bookkeeping_table`
+        would create an empty bookkeeping table and the first migration would
+        fail with "table already exists". Detect that case via ``sqlite_master``
+        and record versions for tables that are already present.
+        """
+        has_schema_version = (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_version'"
+            ).fetchone()
+            is not None
+        )
+        if has_schema_version:
+            return
+
+        existing = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        pre_existing_versions = sorted(
+            v
+            for tbl, v in _PREEXISTING_TABLE_TO_MIGRATION.items()
+            if tbl in existing
+        )
+        if not pre_existing_versions:
+            return
+
+        conn.execute(
+            """
+            CREATE TABLE schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at REAL NOT NULL
+            )
+            """
+        )
+        now = time.time()
+        for version in pre_existing_versions:
+            conn.execute(
+                "INSERT INTO schema_version(version, applied_at) VALUES (?, ?)",
+                (version, now),
+            )
+        conn.commit()
 
     def _ensure_bookkeeping_table(self, conn: sqlite3.Connection) -> None:
         conn.execute(

--- a/tests/test_storage_migrator.py
+++ b/tests/test_storage_migrator.py
@@ -22,6 +22,19 @@ _EXPECTED_TABLES = {
 _EXPECTED_VERSIONS = [1, 2, 3, 4, 5]
 
 
+def _migrations_dir() -> pathlib.Path:
+    import rune_bench.storage.migrator as migrator_mod
+
+    return pathlib.Path(migrator_mod.__file__).resolve().parent / "migrations"
+
+
+def _apply_sql_files(conn: sqlite3.Connection, *filenames: str) -> None:
+    for name in filenames:
+        path = _migrations_dir() / name
+        conn.executescript(path.read_text(encoding="utf-8"))
+    conn.commit()
+
+
 def _fresh_conn() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
@@ -29,6 +42,8 @@ def _fresh_conn() -> sqlite3.Connection:
 
 
 def test_migrator_applies_all_on_empty_db() -> None:
+    # Acceptance (rune#241): fresh empty DB → bootstrap is a no-op, all
+    # migrations apply.
     conn = _fresh_conn()
 
     applied = Migrator().apply_pending(conn)
@@ -56,6 +71,8 @@ def test_migrator_idempotent() -> None:
 
 
 def test_migrator_partial_state() -> None:
+    # Acceptance (rune#241): DB already has ``schema_version`` → bootstrap is a
+    # no-op; only pending migrations run.
     conn = _fresh_conn()
     migrator = Migrator()
 
@@ -80,6 +97,52 @@ def test_migrator_partial_state() -> None:
         for row in conn.execute("SELECT version FROM schema_version").fetchall()
     }
     assert versions == {1, 2, 3, 4, 5}
+
+
+def test_migrator_legacy_db_without_schema_version_first_three_tables() -> None:
+    # Acceptance (rune#241): legacy file with 0001–0003 tables only → bootstrap
+    # pre-seeds 1–3, then migrations 4 and 5 run.
+    conn = _fresh_conn()
+    _apply_sql_files(
+        conn,
+        "0001_jobs.sql",
+        "0002_idempotency_keys.sql",
+        "0003_workflow_events.sql",
+    )
+
+    applied = Migrator().apply_pending(conn)
+
+    assert applied == [4, 5]
+    versions = {
+        int(row[0])
+        for row in conn.execute("SELECT version FROM schema_version").fetchall()
+    }
+    assert versions == set(_EXPECTED_VERSIONS)
+    names = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert _EXPECTED_TABLES.issubset(names)
+
+
+def test_migrator_legacy_db_without_schema_version_all_five_tables() -> None:
+    # Acceptance (rune#241): legacy file with all domain tables but no
+    # ``schema_version`` table → bootstrap pre-seeds 1–5, then apply is a no-op.
+    conn = _fresh_conn()
+    Migrator().apply_pending(conn)
+    conn.execute("DROP TABLE schema_version")
+    conn.commit()
+
+    applied = Migrator().apply_pending(conn)
+
+    assert applied == []
+    versions = {
+        int(row[0])
+        for row in conn.execute("SELECT version FROM schema_version").fetchall()
+    }
+    assert versions == set(_EXPECTED_VERSIONS)
 
 
 def test_migrator_invalid_sql_raises_with_context(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Summary

Pre-seeds `schema_version` for on-disk SQLite files that already contain domain tables from the pre-migrator era (`rune#241`). `Migrator.apply_pending` calls `_bootstrap_legacy_schema(conn)` before `_ensure_bookkeeping_table`; bootstrap inspects `sqlite_master` and inserts version rows for migrations already reflected by existing tables. Tests cover legacy (first three tables only), legacy (all five tables + dropped bookkeeping), fresh empty DB, and existing `schema_version` (partial state).

Closes #241

## DoD Level

- [ ] **Level 1** — Full Validation (runtime, API, Helm, Dockerfile)
- [x] **Level 2** — Test Infrastructure (test config, CI, coverage, linter)
- [ ] **Level 3** — Documentation (Markdown, MkDocs, diagrams)

## Acceptance Criteria Evidence

- [x] `Migrator.apply_pending` invokes `_bootstrap_legacy_schema` before the migration loop — see `rune_bench/storage/migrator.py`.
- [x] Legacy DB with `jobs` + `idempotency_keys` + `workflow_events` only: bootstrap pre-seeds 1–3, then versions 4–5 apply — `test_migrator_legacy_db_without_schema_version_first_three_tables`.
- [x] Legacy DB with all five domain tables and no `schema_version`: bootstrap pre-seeds 1–5, second `apply_pending` applies nothing — `test_migrator_legacy_db_without_schema_version_all_five_tables`.
- [x] Fresh empty DB and existing `schema_version` paths — `test_migrator_applies_all_on_empty_db`, `test_migrator_partial_state`.
- [x] Full `pytest` suite: coverage ≥ 97%; `ruff check` clean on touched files.

## Audit Checks

No triggers fired.

## Breaking Changes

None. Internal storage bootstrap only; no HTTP or config contract changes.

## Test Plan Evidence

- [x] `pytest` (full suite) meets repository coverage gate (≥ 97%).
- [x] `ruff check rune_bench/storage/migrator.py tests/test_storage_migrator.py`

## Notes for Reviewer

Implements [rune#241](https://github.com/lpasquali/rune/issues/241). Draft until you are ready to merge.

Made with [Cursor](https://cursor.com)
