### PR TITLE
feat(storage): add PostgreSQL adapter, DB URL wiring, and migration tooling

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -111,8 +111,8 @@ jobs:
         env:
           RUNE_PG_TEST_URL: postgresql://postgres:test@127.0.0.1:5432/rune
         run: >-
-          pytest -m integration_postgres tests/integration/test_postgres_storage.py
-          --cov=rune_bench.storage.postgres --cov-report=term-missing
+          pytest -o addopts='' -m integration_postgres tests/integration/test_postgres_storage.py
+          --cov=rune_bench.storage.postgres --cov-report=term-missing --cov-fail-under=0
 
   # ─── Shared: Container Build (Multi-arch) ──────────────────────────────────
   container:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -67,7 +67,7 @@ jobs:
       python-version: "3.14"
       coverage-threshold: "97"
       source-dirs: "rune_bench rune"
-      test-deps: "pytest pytest-cov pytest-xdist respx"
+      test-deps: "pytest pytest-cov pytest-xdist respx psycopg[binary,pool]"
       path-filter: '^(rune/|rune_bench/|tests/|requirements\.txt|pyproject\.toml)'
       allowed-license-exceptions: "bashlex,borb"
     secrets: inherit
@@ -80,6 +80,40 @@ jobs:
     with:
       path-filter: "^(rune/|rune_bench/|tests/|requirements\\.txt|pyproject\\.toml)"
 
+  # ─── PostgreSQL Integration ────────────────────────────────────────────────
+  postgres-integration:
+    name: Postgres Integration
+    needs: [changes, python-quality]
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: rune
+          POSTGRES_PASSWORD: test
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d rune"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.14"
+      - name: Install package and test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[dev,pg]"
+      - name: Run Postgres integration suite
+        env:
+          RUNE_PG_TEST_URL: postgresql://postgres:test@127.0.0.1:5432/rune
+        run: >-
+          pytest -m integration_postgres tests/integration/test_postgres_storage.py
+          --cov=rune_bench.storage.postgres --cov-report=term-missing
+
   # ─── Shared: Container Build (Multi-arch) ──────────────────────────────────
   container:
     needs: [changes, security]
@@ -91,7 +125,7 @@ jobs:
 
   # ─── Compliance/Merge Gate ──────────────────────────────────────────────────
   compliance:
-    needs: [security, python-quality, integration, container]
+    needs: [security, python-quality, integration, postgres-integration, container]
     if: always()
     uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@main
     with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,15 @@ vastai = [
 catalog = [
     "pyyaml>=6.0",
 ]
+pg = [
+    "psycopg[binary,pool]>=3.2",
+]
 all = [
     "holmesgpt>=0.23.0",
     "supabase>=2.5,<2.29",
     "httpx>=0.27.0",
     "pyyaml>=6.0",
+    "psycopg[binary,pool]>=3.2",
 ]
 dev = [
     "pytest>=8",

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,5 @@ addopts = -q --cov=rune_bench --cov=rune --cov-report=term-missing:skip-covered 
 markers =
 	regression: regression safeguards for previously fixed bugs
 	integration: live-service integration tests (require a real Ollama instance; set OLLAMA_TEST_URL)
+	integration_postgres: live Postgres storage tests (require RUNE_PG_TEST_URL)
 	uat: User Acceptance Tests (require live credentials or are skipped by default in CI; run with -m uat; exclude in CI with -m "not uat")

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -66,6 +66,12 @@ warmup_existing_ollama_model = warmup_backend_model
 provision_vastai_ollama = provision_vastai_backend
 
 app = typer.Typer(help="RUNE — Reliability Use-case Numeric Evaluator", add_completion=False)
+db_app = typer.Typer(
+    help="Database maintenance utilities",
+    add_completion=False,
+    no_args_is_help=True,
+)
+app.add_typer(db_app, name="db")
 console = Console()
 
 # Load rune.yaml (project) / ~/.rune/config.yaml (global) before reading env vars.
@@ -535,6 +541,12 @@ def serve_api(
         envvar="RUNE_API_PORT",
         help="Port to bind API server to (default: 8080 in containers, random free port locally)",
     ),
+    db_url: str | None = typer.Option(
+        None,
+        "--db-url",
+        envvar="RUNE_DB_URL",
+        help="Storage URL for the API server (sqlite:// or postgresql://)",
+    ),
     debug: bool = typer.Option(
         False,
         "--debug",
@@ -554,13 +566,79 @@ def serve_api(
     ))
 
     try:
-        app_server = RuneApiApplication.from_env()
+        app_server = RuneApiApplication.from_env(db_url=db_url)
         app_server.serve(host=api_host, port=resolved_port)
     except KeyboardInterrupt:
         console.print("\n[yellow]Server stopped.[/yellow]")
         raise typer.Exit(0)
     except Exception as exc:
         _print_error_and_exit(f"Server error: {exc}")
+
+
+@db_app.command("migrate-to-postgres")
+def migrate_db_to_postgres(
+    source: str = typer.Option(
+        ...,
+        "--source",
+        help="Source storage URL (expected: sqlite://...)",
+    ),
+    target: str = typer.Option(
+        ...,
+        "--target",
+        help="Target storage URL (expected: postgresql://...)",
+    ),
+    batch_size: int = typer.Option(
+        1000,
+        "--batch-size",
+        min=1,
+        help="Rows to migrate per batch",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show row counts without writing to PostgreSQL",
+    ),
+) -> None:
+    """Copy an existing SQLite database into PostgreSQL."""
+    try:
+        from rune_bench.storage.migrate_to_postgres import migrate_to_postgres
+    except ImportError:
+        _print_error_and_exit(
+            "Postgres migration requires psycopg; install 'rune-bench[pg]'"
+        )
+
+    def _report_progress(table_name: str, copied: int, total: int, is_dry_run: bool) -> None:
+        if is_dry_run:
+            return
+        console.print(f"[cyan]{table_name}[/cyan]: migrated {copied}/{total} rows")
+
+    try:
+        results = migrate_to_postgres(
+            source_url=source,
+            target_url=target,
+            batch_size=batch_size,
+            dry_run=dry_run,
+            reporter=_report_progress,
+        )
+    except Exception as exc:
+        _print_error_and_exit(str(exc))
+
+    summary = Table(
+        title="Database Migration Plan" if dry_run else "Database Migration Summary",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    summary.add_column("Table")
+    summary.add_column("Source Rows", justify="right")
+    summary.add_column("Migrated Rows", justify="right")
+
+    for result in results:
+        migrated = "-" if result.dry_run else str(result.migrated_count)
+        summary.add_row(result.table, str(result.source_count), migrated)
+
+    console.print(summary)
+    if dry_run:
+        console.print("[yellow]Dry run complete: no rows were written.[/yellow]")
 
 
 @app.command("run-llm-instance")

--- a/rune_bench/api_server.py
+++ b/rune_bench/api_server.py
@@ -12,7 +12,6 @@ import threading
 import time
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 from typing import Callable, TypeAlias
 from urllib.parse import parse_qs, urlparse
 
@@ -31,7 +30,7 @@ from rune_bench.api_contracts import (
     RunLLMInstanceRequest,
 )
 from rune_bench.metrics import SQLiteMetricsCollector, clear_collector, set_collector, set_job_id, span
-from rune_bench.storage import StoragePort
+from rune_bench.storage import StoragePort, make_storage, resolve_storage_url
 from rune_bench.storage.sqlite import JobRecord, SQLiteStorageAdapter
 
 # Back-compat alias: legacy tests and callers still reference
@@ -116,9 +115,12 @@ class RuneApiApplication:
         self.auth_lock = threading.Lock()
 
     @classmethod
-    def from_env(cls) -> "RuneApiApplication":
-        db_path = os.environ.get("RUNE_API_DB_PATH", ".rune-api/jobs.db")
-        return cls(store=SQLiteStorageAdapter(Path(db_path)), security=ApiSecurityConfig.from_env())
+    def from_env(cls, *, db_url: str | None = None) -> "RuneApiApplication":
+        resolved_db_url = resolve_storage_url(db_url)
+        return cls(
+            store=make_storage(resolved_db_url),
+            security=ApiSecurityConfig.from_env(),
+        )
 
     def create_handler(self):
         app = self

--- a/rune_bench/common/config.py
+++ b/rune_bench/common/config.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import yaml
 
-# Maps YAML config keys → corresponding RUNE_* env var names.
+# Maps flat YAML config keys → corresponding RUNE_* env var names.
 # Intentionally excludes secrets: RUNE_API_TOKEN, VAST_API_KEY.
 _FIELD_ENV_MAP: dict[str, str] = {
     # Global / backend
@@ -54,6 +54,11 @@ _FIELD_ENV_MAP: dict[str, str] = {
     "question": "RUNE_QUESTION",
     "model": "RUNE_MODEL",
     "kubeconfig": "RUNE_KUBECONFIG",
+}
+
+# Nested database section (top-level and/or defaults/profiles).
+_DATABASE_ENV_MAP: dict[str, str] = {
+    "url": "RUNE_DB_URL",
 }
 
 # Maps nested attestation section keys → RUNE_ATTESTATION_* env vars.
@@ -94,6 +99,10 @@ defaults:
 
   # Execution backend (local | http)
   backend: local
+
+  # Database settings (leave unset to use the built-in local SQLite path).
+  # database:
+  #   url: postgresql://rune:change-me@postgres:5432/rune
 
   # LLM Backend settings
   backend_type: ollama
@@ -136,6 +145,10 @@ profiles:
     backend_url: http://localhost:11434
     backend_warmup: false
     model: llama3.1:8b
+
+# Top-level infrastructure fallback (can also live under defaults/profiles):
+# database:
+#   url: postgresql://rune:change-me@postgres:5432/rune
 
 # Attestation settings (TPM 2.0 hardware PCR verification).
 # Can be placed at the top level (infrastructure config) or under
@@ -241,6 +254,16 @@ def load_config(profile: str | None = None) -> dict[str, Any]:
     for key, env_var in _FIELD_ENV_MAP.items():
         if key in effective and env_var not in os.environ:
             os.environ[env_var] = _to_env_str(effective[key])
+
+    # Database config mirrors attestation: a top-level section acts as
+    # infrastructure-wide fallback, while defaults/profiles can override it.
+    database_cfg: dict[str, Any] = _merge(
+        raw.get("database") or {},
+        effective.get("database") or {},
+    )
+    for key, env_var in _DATABASE_ENV_MAP.items():
+        if key in database_cfg and env_var not in os.environ:
+            os.environ[env_var] = _to_env_str(database_cfg[key])
 
     # Handle nested attestation section.  The section may appear at the
     # top level of the YAML (as infrastructure config, separate from per-run

--- a/rune_bench/storage/__init__.py
+++ b/rune_bench/storage/__init__.py
@@ -9,22 +9,94 @@ touching the API server.
 
 from __future__ import annotations
 
+import os
+import re
+import sys
+from pathlib import Path
 from urllib.parse import urlparse
 
 from rune_bench.storage.base import StoragePort
 from rune_bench.storage.migrator import Migrator
 from rune_bench.storage.sqlite import JobRecord, SQLiteStorageAdapter
 
+try:
+    from rune_bench.storage.postgres import PostgresStorageAdapter
+except ImportError:  # pragma: no cover - exercised when pg extras are absent
+    PostgresStorageAdapter = None  # type: ignore[assignment]
+
 __all__ = [
     "JobRecord",
     "Migrator",
+    "PostgresStorageAdapter",
     "SQLiteStorageAdapter",
     "StoragePort",
+    "default_storage_url",
     "make_storage",
+    "resolve_storage_url",
 ]
 
 
-_SUPPORTED_SCHEMES = ("sqlite://",)
+_SUPPORTED_SCHEMES = ("sqlite://", "postgresql://")
+_WINDOWS_ABS_PATH_RE = re.compile(r"^/[A-Za-z]:/")
+
+
+def _default_sqlite_db_path() -> str:
+    if sys.platform == "win32":
+        base_dir = os.environ.get("LOCALAPPDATA") or str(
+            Path.home() / "AppData" / "Local"
+        )
+    elif sys.platform == "darwin":
+        base_dir = str(Path.home() / "Library" / "Application Support")
+    else:
+        base_dir = os.environ.get("XDG_DATA_HOME") or str(
+            Path.home() / ".local" / "share"
+        )
+    return str(Path(base_dir) / "rune" / "jobs.db")
+
+
+def _sqlite_path_to_url(db_path: str) -> str:
+    normalized = db_path.strip()
+    if normalized in ("", ":memory:"):
+        return "sqlite:///:memory:"
+    path = Path(normalized)
+    if path.is_absolute():
+        return f"sqlite:///{path.as_posix()}"
+    return f"sqlite:///./{path.as_posix()}"
+
+
+def default_storage_url() -> str:
+    """Return the built-in SQLite storage URL used when nothing is configured."""
+    return _sqlite_path_to_url(_default_sqlite_db_path())
+
+
+def resolve_storage_url(
+    db_url: str | None = None, *, legacy_db_path: str | None = None
+) -> str:
+    """Resolve storage config with back-compat for ``RUNE_API_DB_PATH``.
+
+    Precedence:
+
+    1. Explicit ``db_url`` argument
+    2. ``RUNE_DB_URL``
+    3. Explicit ``legacy_db_path`` argument
+    4. ``RUNE_API_DB_PATH``
+    5. built-in SQLite default under the platform data directory
+    """
+    explicit_url = (db_url or "").strip()
+    if explicit_url:
+        return explicit_url
+
+    env_url = os.environ.get("RUNE_DB_URL", "").strip()
+    if env_url:
+        return env_url
+
+    legacy_path = (legacy_db_path or "").strip()
+    if not legacy_path:
+        legacy_path = os.environ.get("RUNE_API_DB_PATH", "").strip()
+    if legacy_path:
+        return _sqlite_path_to_url(legacy_path)
+
+    return default_storage_url()
 
 
 def make_storage(url: str) -> StoragePort:
@@ -34,6 +106,7 @@ def make_storage(url: str) -> StoragePort:
 
     * ``sqlite:///absolute/path/to/file.db`` — file-backed SQLite
     * ``sqlite:///:memory:`` — in-memory SQLite (test fixtures)
+    * ``postgresql://user:pass@host:5432/db`` — PostgreSQL via psycopg3
 
     Unknown schemes raise :class:`RuntimeError` with the list of supported
     schemes, so boot-time config errors surface with an actionable message.
@@ -46,11 +119,21 @@ def make_storage(url: str) -> StoragePort:
         path = parsed.path
         if path in ("/:memory:", ":memory:", ""):
             db_path = ":memory:"
+        elif path.startswith("/./") or path.startswith("/../"):
+            db_path = path[1:]
+        elif _WINDOWS_ABS_PATH_RE.match(path):
+            db_path = path[1:]
         else:
             # urlparse strips the leading '//' so an absolute file path
             # arrives here as "/abs/path" — SQLite consumes that verbatim.
             db_path = path
         return SQLiteStorageAdapter(db_path)
+    if scheme in ("postgres", "postgresql", "postgresql+psycopg", "postgres+psycopg"):
+        if PostgresStorageAdapter is None:
+            raise RuntimeError(
+                "postgresql storage requires psycopg; install 'rune-bench[pg]'"
+            )
+        return PostgresStorageAdapter(url)
     raise RuntimeError(
         f"unsupported storage URL scheme {parsed.scheme!r}; "
         f"supported: {', '.join(_SUPPORTED_SCHEMES)}"

--- a/rune_bench/storage/migrate_to_postgres.py
+++ b/rune_bench/storage/migrate_to_postgres.py
@@ -160,7 +160,8 @@ def migrate_to_postgres(
 
 def _count_rows(source: SQLiteStorageAdapter, table_name: str) -> int:
     with source.connection() as conn:
-        row = conn.execute(f"SELECT COUNT(*) AS total FROM {table_name}").fetchone()
+        statement = f"SELECT COUNT(*) AS total FROM {table_name}"  # nosec B608
+        row = conn.execute(statement).fetchone()
     return int(row["total"])
 
 
@@ -171,10 +172,9 @@ def _fetch_batch(
     batch_size: int,
     offset: int,
 ) -> list[dict]:
-    query = (
-        f"SELECT {', '.join(spec.columns)} FROM {spec.name} "
-        f"ORDER BY {', '.join(spec.order_by)} LIMIT ? OFFSET ?"
-    )
+    columns = ", ".join(spec.columns)
+    order_by = ", ".join(spec.order_by)
+    query = f"SELECT {columns} FROM {spec.name} ORDER BY {order_by} LIMIT ? OFFSET ?"  # nosec B608
     with source.connection() as conn:
         rows = conn.execute(query, (batch_size, offset)).fetchall()
     return [{column: row[column] for column in spec.columns} for row in rows]
@@ -187,12 +187,10 @@ def _insert_batch(
 ) -> None:
     if not rows:
         return
+    columns = ", ".join(spec.columns)
     placeholders = ", ".join(["%s"] * len(spec.columns))
     conflict = ", ".join(spec.conflict_columns)
-    statement = (
-        f"INSERT INTO {spec.name} ({', '.join(spec.columns)}) "
-        f"VALUES ({placeholders}) ON CONFLICT ({conflict}) DO NOTHING"
-    )
+    statement = f"INSERT INTO {spec.name} ({columns}) VALUES ({placeholders}) ON CONFLICT ({conflict}) DO NOTHING"  # nosec B608
     failing_row: dict | None = None
     with target.connection() as conn:
         try:

--- a/rune_bench/storage/migrate_to_postgres.py
+++ b/rune_bench/storage/migrate_to_postgres.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Copy an existing SQLite RUNE database into PostgreSQL in bounded batches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from rune_bench.storage import make_storage
+from rune_bench.storage.postgres import PostgresStorageAdapter
+from rune_bench.storage.sqlite import SQLiteStorageAdapter
+
+MigrationReporter = Callable[[str, int, int, bool], None]
+
+
+@dataclass(frozen=True)
+class TableMigrationResult:
+    table: str
+    source_count: int
+    migrated_count: int
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class _TableSpec:
+    name: str
+    columns: tuple[str, ...]
+    order_by: tuple[str, ...]
+    conflict_columns: tuple[str, ...]
+    reset_sequence_sql: str | None = None
+
+
+_TABLE_SPECS = (
+    _TableSpec(
+        name="jobs",
+        columns=(
+            "job_id",
+            "tenant_id",
+            "kind",
+            "status",
+            "request_json",
+            "result_json",
+            "error",
+            "message",
+            "created_at",
+            "updated_at",
+        ),
+        order_by=("job_id",),
+        conflict_columns=("job_id",),
+    ),
+    _TableSpec(
+        name="idempotency_keys",
+        columns=("tenant_id", "operation", "idempotency_key", "job_id", "created_at"),
+        order_by=("tenant_id", "operation", "idempotency_key"),
+        conflict_columns=("tenant_id", "operation", "idempotency_key"),
+    ),
+    _TableSpec(
+        name="workflow_events",
+        columns=(
+            "id",
+            "job_id",
+            "event",
+            "status",
+            "duration_ms",
+            "error_type",
+            "labels_json",
+            "recorded_at",
+        ),
+        order_by=("id",),
+        conflict_columns=("id",),
+        reset_sequence_sql="""
+            SELECT setval(
+                pg_get_serial_sequence('workflow_events', 'id'),
+                COALESCE((SELECT MAX(id) FROM workflow_events), 1),
+                EXISTS(SELECT 1 FROM workflow_events)
+            )
+        """,
+    ),
+    _TableSpec(
+        name="chain_state",
+        columns=("job_id", "state_json", "overall_status", "updated_at"),
+        order_by=("job_id",),
+        conflict_columns=("job_id",),
+    ),
+    _TableSpec(
+        name="audit_artifact",
+        columns=(
+            "artifact_id",
+            "job_id",
+            "kind",
+            "name",
+            "size_bytes",
+            "sha256",
+            "content",
+            "created_at",
+        ),
+        order_by=("artifact_id",),
+        conflict_columns=("artifact_id",),
+    ),
+)
+
+
+def migrate_to_postgres(
+    *,
+    source_url: str,
+    target_url: str,
+    batch_size: int = 1000,
+    dry_run: bool = False,
+    reporter: MigrationReporter | None = None,
+) -> list[TableMigrationResult]:
+    """Copy every supported table from SQLite to PostgreSQL in batches."""
+    if batch_size < 1:
+        raise RuntimeError("batch_size must be >= 1")
+
+    source = make_storage(source_url)
+    target = make_storage(target_url)
+    if not isinstance(source, SQLiteStorageAdapter):
+        raise RuntimeError("source must be a sqlite:// URL")
+    if not isinstance(target, PostgresStorageAdapter):
+        raise RuntimeError("target must be a postgresql:// URL")
+
+    results: list[TableMigrationResult] = []
+    for spec in _TABLE_SPECS:
+        total = _count_rows(source, spec.name)
+        if reporter is not None:
+            reporter(spec.name, 0, total, dry_run)
+        if dry_run:
+            results.append(
+                TableMigrationResult(
+                    table=spec.name,
+                    source_count=total,
+                    migrated_count=0,
+                    dry_run=True,
+                )
+            )
+            continue
+
+        migrated = 0
+        for offset in range(0, total, batch_size):
+            rows = _fetch_batch(source, spec, batch_size=batch_size, offset=offset)
+            _insert_batch(target, spec, rows)
+            migrated += len(rows)
+            if reporter is not None:
+                reporter(spec.name, migrated, total, False)
+
+        if spec.reset_sequence_sql is not None:
+            with target.connection() as conn:
+                conn.execute(spec.reset_sequence_sql)
+
+        results.append(
+            TableMigrationResult(
+                table=spec.name,
+                source_count=total,
+                migrated_count=migrated,
+                dry_run=False,
+            )
+        )
+    return results
+
+
+def _count_rows(source: SQLiteStorageAdapter, table_name: str) -> int:
+    with source.connection() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS total FROM {table_name}").fetchone()
+    return int(row["total"])
+
+
+def _fetch_batch(
+    source: SQLiteStorageAdapter,
+    spec: _TableSpec,
+    *,
+    batch_size: int,
+    offset: int,
+) -> list[dict]:
+    query = (
+        f"SELECT {', '.join(spec.columns)} FROM {spec.name} "
+        f"ORDER BY {', '.join(spec.order_by)} LIMIT ? OFFSET ?"
+    )
+    with source.connection() as conn:
+        rows = conn.execute(query, (batch_size, offset)).fetchall()
+    return [{column: row[column] for column in spec.columns} for row in rows]
+
+
+def _insert_batch(
+    target: PostgresStorageAdapter,
+    spec: _TableSpec,
+    rows: list[dict],
+) -> None:
+    if not rows:
+        return
+    placeholders = ", ".join(["%s"] * len(spec.columns))
+    conflict = ", ".join(spec.conflict_columns)
+    statement = (
+        f"INSERT INTO {spec.name} ({', '.join(spec.columns)}) "
+        f"VALUES ({placeholders}) ON CONFLICT ({conflict}) DO NOTHING"
+    )
+    failing_row: dict | None = None
+    with target.connection() as conn:
+        try:
+            for row in rows:
+                failing_row = row
+                conn.execute(
+                    statement,
+                    [row[column] for column in spec.columns],
+                )
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            raise RuntimeError(
+                f"failed migrating table {spec.name} row {failing_row!r}: {exc}"
+            ) from exc

--- a/rune_bench/storage/migrations/0001_jobs.sql
+++ b/rune_bench/storage/migrations/0001_jobs.sql
@@ -1,3 +1,4 @@
+-- migrate:sqlite
 CREATE TABLE jobs (
     job_id TEXT PRIMARY KEY,
     tenant_id TEXT NOT NULL,
@@ -9,4 +10,18 @@ CREATE TABLE jobs (
     message TEXT,
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL
+);
+
+-- migrate:postgres
+CREATE TABLE jobs (
+    job_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    status TEXT NOT NULL,
+    request_json TEXT NOT NULL,
+    result_json TEXT,
+    error TEXT,
+    message TEXT,
+    created_at DOUBLE PRECISION NOT NULL,
+    updated_at DOUBLE PRECISION NOT NULL
 );

--- a/rune_bench/storage/migrations/0002_idempotency_keys.sql
+++ b/rune_bench/storage/migrations/0002_idempotency_keys.sql
@@ -1,8 +1,19 @@
+-- migrate:sqlite
 CREATE TABLE idempotency_keys (
     tenant_id TEXT NOT NULL,
     operation TEXT NOT NULL,
     idempotency_key TEXT NOT NULL,
     job_id TEXT NOT NULL,
     created_at REAL NOT NULL,
+    PRIMARY KEY (tenant_id, operation, idempotency_key)
+);
+
+-- migrate:postgres
+CREATE TABLE idempotency_keys (
+    tenant_id TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    created_at DOUBLE PRECISION NOT NULL,
     PRIMARY KEY (tenant_id, operation, idempotency_key)
 );

--- a/rune_bench/storage/migrations/0003_workflow_events.sql
+++ b/rune_bench/storage/migrations/0003_workflow_events.sql
@@ -1,3 +1,4 @@
+-- migrate:sqlite
 CREATE TABLE workflow_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id TEXT,
@@ -9,6 +10,19 @@ CREATE TABLE workflow_events (
     recorded_at REAL NOT NULL
 );
 
+-- migrate:postgres
+CREATE TABLE workflow_events (
+    id BIGSERIAL PRIMARY KEY,
+    job_id TEXT,
+    event TEXT NOT NULL,
+    status TEXT NOT NULL,
+    duration_ms DOUBLE PRECISION,
+    error_type TEXT,
+    labels_json TEXT,
+    recorded_at DOUBLE PRECISION NOT NULL
+);
+
+-- migrate:all
 CREATE INDEX idx_workflow_events_job_id ON workflow_events(job_id);
 
 CREATE INDEX idx_workflow_events_event ON workflow_events(event);

--- a/rune_bench/storage/migrations/0004_chain_state.sql
+++ b/rune_bench/storage/migrations/0004_chain_state.sql
@@ -1,6 +1,15 @@
+-- migrate:sqlite
 CREATE TABLE chain_state (
     job_id TEXT PRIMARY KEY,
     state_json TEXT NOT NULL,
     overall_status TEXT NOT NULL,
     updated_at REAL NOT NULL
+);
+
+-- migrate:postgres
+CREATE TABLE chain_state (
+    job_id TEXT PRIMARY KEY,
+    state_json TEXT NOT NULL,
+    overall_status TEXT NOT NULL,
+    updated_at DOUBLE PRECISION NOT NULL
 );

--- a/rune_bench/storage/migrations/0005_audit_artifact.sql
+++ b/rune_bench/storage/migrations/0005_audit_artifact.sql
@@ -1,3 +1,4 @@
+-- migrate:sqlite
 CREATE TABLE audit_artifact (
     artifact_id TEXT PRIMARY KEY,
     job_id TEXT NOT NULL,
@@ -9,4 +10,17 @@ CREATE TABLE audit_artifact (
     created_at REAL NOT NULL
 );
 
+-- migrate:postgres
+CREATE TABLE audit_artifact (
+    artifact_id TEXT PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    content BYTEA NOT NULL,
+    created_at DOUBLE PRECISION NOT NULL
+);
+
+-- migrate:all
 CREATE INDEX idx_audit_artifact_job_id ON audit_artifact(job_id);

--- a/rune_bench/storage/migrator.py
+++ b/rune_bench/storage/migrator.py
@@ -18,8 +18,10 @@ import pathlib
 import re
 import sqlite3
 import time
+from typing import Any
 
 _FILENAME_RE = re.compile(r"^(\d{4})_.*\.sql$")
+_DIALECT_MARKER_RE = re.compile(r"^\s*--\s*migrate:(all|sqlite|postgres)\s*$")
 
 # Tables created by migrations 0001–0005 before ``schema_version`` existed
 # (legacy on-disk SQLite). Used to pre-seed ``schema_version`` so unconditional
@@ -34,7 +36,7 @@ _PREEXISTING_TABLE_TO_MIGRATION: dict[str, int] = {
 
 
 class Migrator:
-    """Apply pending SQL migrations to a SQLite connection.
+    """Apply pending SQL migrations to a storage connection.
 
     The migrations directory contains ``NNNN_<slug>.sql`` files. Each file is
     executed in a single transaction and, on success, the version is recorded
@@ -42,23 +44,32 @@ class Migrator:
     up-to-date database is a no-op.
     """
 
-    def __init__(self, *, migrations_dir: pathlib.Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        migrations_dir: pathlib.Path | None = None,
+        dialect: str = "sqlite",
+    ) -> None:
         self._migrations_dir = (
             migrations_dir
             if migrations_dir is not None
             else pathlib.Path(__file__).parent / "migrations"
         )
+        if dialect not in {"sqlite", "postgres"}:
+            raise ValueError(f"unsupported migrator dialect {dialect!r}")
+        self._dialect = dialect
 
-    def apply_pending(self, conn: sqlite3.Connection) -> list[int]:
+    def apply_pending(self, conn: Any) -> list[int]:
         """Apply every migration newer than the current ``schema_version``.
 
         Returns the list of newly-applied version numbers (empty if the
         database is already up to date). Each migration runs inside an
-        explicit ``BEGIN ... COMMIT``; a failure rolls back that migration
-        and re-raises :class:`RuntimeError` with the offending version and
-        filename so the underlying driver error is never swallowed.
+        explicit transaction boundary; a failure rolls back that migration and
+        re-raises :class:`RuntimeError` with the offending version and filename
+        so the underlying driver error is never swallowed.
         """
-        self._bootstrap_legacy_schema(conn)
+        if self._dialect == "sqlite":
+            self._bootstrap_legacy_schema(conn)
         self._ensure_bookkeeping_table(conn)
         applied = self._already_applied(conn)
         newly_applied: list[int] = []
@@ -66,21 +77,17 @@ class Migrator:
         for version, path in self._discover():
             if version in applied:
                 continue
-            sql_text = path.read_text(encoding="utf-8")
-            # SQLite's ``executescript()`` issues an implicit COMMIT before
-            # running, which would break our explicit BEGIN…COMMIT envelope.
-            # Split on ';' and execute each non-empty statement individually
-            # so the whole migration lives inside one transaction and we can
-            # ROLLBACK cleanly on failure.
+            sql_text = self._render_for_dialect(path.read_text(encoding="utf-8"))
             statements = [s.strip() for s in sql_text.split(";") if s.strip()]
-            conn.execute("BEGIN")
+            if not statements:
+                raise RuntimeError(
+                    f"migration {version} ({path.name}) rendered no SQL "
+                    f"for dialect {self._dialect}"
+                )
             try:
                 for statement in statements:
                     conn.execute(statement)
-                conn.execute(
-                    "INSERT INTO schema_version(version, applied_at) VALUES (?, ?)",
-                    (version, time.time()),
-                )
+                self._insert_schema_version(conn, version)
                 conn.commit()
             except Exception as exc:
                 conn.rollback()
@@ -139,20 +146,60 @@ class Migrator:
             )
         conn.commit()
 
-    def _ensure_bookkeeping_table(self, conn: sqlite3.Connection) -> None:
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS schema_version (
-                version INTEGER PRIMARY KEY,
-                applied_at REAL NOT NULL
+    def _ensure_bookkeeping_table(self, conn: Any) -> None:
+        if self._dialect == "sqlite":
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY,
+                    applied_at REAL NOT NULL
+                )
+                """
             )
-            """
-        )
+        else:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY,
+                    applied_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
         conn.commit()
 
-    def _already_applied(self, conn: sqlite3.Connection) -> set[int]:
+    def _already_applied(self, conn: Any) -> set[int]:
         rows = conn.execute("SELECT version FROM schema_version").fetchall()
-        return {int(row[0]) for row in rows}
+        versions: set[int] = set()
+        for row in rows:
+            try:
+                versions.add(int(row[0]))
+            except (KeyError, TypeError):
+                versions.add(int(row["version"]))
+        return versions
+
+    def _insert_schema_version(self, conn: Any, version: int) -> None:
+        if self._dialect == "sqlite":
+            conn.execute(
+                "INSERT INTO schema_version(version, applied_at) VALUES (?, ?)",
+                (version, time.time()),
+            )
+            return
+        conn.execute(
+            "INSERT INTO schema_version(version, applied_at) VALUES (%s, %s)",
+            (version, time.time()),
+        )
+
+    def _render_for_dialect(self, sql_text: str) -> str:
+        rendered: list[str] = []
+        active = "all"
+        for line in sql_text.splitlines():
+            marker = _DIALECT_MARKER_RE.match(line)
+            if marker is not None:
+                active = marker.group(1)
+                continue
+            if active in {"all", self._dialect}:
+                rendered.append(line)
+        return "\n".join(rendered)
 
     def _discover(self) -> list[tuple[int, pathlib.Path]]:
         discovered: list[tuple[int, pathlib.Path]] = []

--- a/rune_bench/storage/postgres.py
+++ b/rune_bench/storage/postgres.py
@@ -1,101 +1,82 @@
 # SPDX-License-Identifier: Apache-2.0
-"""SQLite-backed implementation of :class:`rune_bench.storage.StoragePort`."""
+"""PostgreSQL-backed implementation of :class:`rune_bench.storage.StoragePort`."""
 
 from __future__ import annotations
 
+import hashlib
 import json
-import sqlite3
+import os
 import time
 import uuid
 from contextlib import contextmanager
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Iterator
+
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
+
+from rune_bench.storage.migrator import Migrator
+from rune_bench.storage.sqlite import JobRecord
 
 if TYPE_CHECKING:
     from rune_bench.metrics import MetricsEvent
 
 
-@dataclass(frozen=True)
-class JobRecord:
-    job_id: str
-    tenant_id: str
-    kind: str
-    status: str
-    request_payload: dict
-    result_payload: dict | None
-    error: str | None
-    message: str | None
-    created_at: float
-    updated_at: float
+class PostgresStorageAdapter:
+    _CHAIN_STATUS_PRIORITY = ("failed", "running", "pending", "success", "skipped")
+    _AUDIT_ARTIFACT_KINDS = frozenset(
+        {
+            "slsa_provenance",
+            "sbom",
+            "tla_report",
+            "sigstore_bundle",
+            "rekor_entry",
+            "tpm_attestation",
+        }
+    )
 
-
-class SQLiteStorageAdapter:
-    def __init__(self, db_path: str | Path) -> None:
-        self._db_path = str(db_path)
-        self._memory_uri: str | None = None
-        if self._db_path == ":memory:":
-            # A bare ":memory:" connection is per-connection, so every
-            # ``self._connect()`` call would land on a different empty
-            # database. Use SQLite's shared-cache memory URI with a unique
-            # name so that every connection in this process sees the same
-            # in-memory database, then we pin one connection open for its
-            # lifetime to keep the cache alive.
-            self._memory_uri = (
-                f"file:rune-mem-{uuid.uuid4().hex}?mode=memory&cache=shared"
-            )
-            self._memory_anchor: sqlite3.Connection | None = sqlite3.connect(
-                self._memory_uri, uri=True, timeout=30, check_same_thread=False
-            )
-        else:
-            self._memory_anchor = None
-            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+    def __init__(self, db_url: str) -> None:
+        self._db_url = db_url
+        self._pool = ConnectionPool(
+            conninfo=db_url,
+            min_size=self._pool_min_size(),
+            max_size=self._pool_max_size(),
+            open=True,
+            kwargs={"row_factory": dict_row},
+        )
+        self._pool.wait()
         self._initialize()
 
-    def _connect(self) -> sqlite3.Connection:
-        if self._memory_uri is not None:
-            connection = sqlite3.connect(
-                self._memory_uri, uri=True, timeout=30, check_same_thread=False
-            )
-        else:
-            connection = sqlite3.connect(self._db_path, timeout=30, check_same_thread=False)
-        connection.row_factory = sqlite3.Row
-        return connection
+    @staticmethod
+    def _pool_min_size() -> int:
+        value = int(os.environ.get("RUNE_PG_POOL_MIN", "1"))
+        if value < 1:
+            raise RuntimeError("RUNE_PG_POOL_MIN must be >= 1")
+        return value
+
+    @classmethod
+    def _pool_max_size(cls) -> int:
+        value = int(os.environ.get("RUNE_PG_POOL_MAX", "10"))
+        if value < cls._pool_min_size():
+            raise RuntimeError("RUNE_PG_POOL_MAX must be >= RUNE_PG_POOL_MIN")
+        return value
 
     @contextmanager
-    def connection(self) -> Any:
-        """Yield a raw SQLite connection for internal tooling/tests."""
-        with self._connect() as conn:
+    def connection(self) -> Iterator[Any]:
+        with self._pool.connection() as conn:
             yield conn
 
+    def close(self) -> None:
+        self._pool.close()
+
+    def __del__(self) -> None:  # pragma: no cover - best-effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def _initialize(self) -> None:
-        # Schema creation is delegated to the Migrator so the same set of
-        # versioned ``NNNN_*.sql`` files drives every storage backend (today
-        # SQLite; rune#233 adds Postgres). The Migrator is idempotent, so
-        # reopening an existing database is a no-op.
-        from rune_bench.storage.migrator import Migrator
-
-        with self._connect() as conn:
-            conn.execute("PRAGMA journal_mode=WAL")
-            Migrator().apply_pending(conn)
-
-    # ── Chain state ────────────────────────────────────────────────────────
-    #
-    # Persists the live execution state of a multi-agent chain (DAG) keyed by
-    # job_id. The full state is stored as a single JSON blob (one row per job)
-    # to keep node-status updates atomic and avoid per-node row management.
-    #
-    # Schema of state_json:
-    #   {
-    #     "nodes": [
-    #       {"id": "step-name", "agent_name": "...", "status": "pending|running|success|failed|skipped",
-    #        "started_at": <float|null>, "finished_at": <float|null>, "error": <str|null>}
-    #     ],
-    #     "edges": [{"from": "dep-step-name", "to": "step-name"}]
-    #   }
-
-    _CHAIN_STATUS_PRIORITY = ("failed", "running", "pending", "success", "skipped")
+        with self.connection() as conn:
+            Migrator(dialect="postgres").apply_pending(conn)
 
     @classmethod
     def _compute_overall_chain_status(cls, nodes: list[dict]) -> str:
@@ -108,7 +89,6 @@ class SQLiteStorageAdapter:
             return "running"
         if "pending" in statuses:
             return "pending"
-        # all nodes terminal-non-failed: success unless every node was skipped
         if statuses == {"skipped"}:
             return "skipped"
         return "success"
@@ -120,7 +100,6 @@ class SQLiteStorageAdapter:
         nodes: list[dict],
         edges: list[dict],
     ) -> None:
-        """Initialize chain state for a job. Idempotent — overwrites any prior state."""
         normalized_nodes: list[dict] = []
         for node in nodes:
             normalized_nodes.append(
@@ -137,11 +116,11 @@ class SQLiteStorageAdapter:
         state = {"nodes": normalized_nodes, "edges": normalized_edges}
         overall = self._compute_overall_chain_status(normalized_nodes)
         now = time.time()
-        with self._connect() as conn:
+        with self.connection() as conn:
             conn.execute(
                 """
                 INSERT INTO chain_state(job_id, state_json, overall_status, updated_at)
-                VALUES (?, ?, ?, ?)
+                VALUES (%s, %s, %s, %s)
                 ON CONFLICT(job_id) DO UPDATE SET
                     state_json = excluded.state_json,
                     overall_status = excluded.overall_status,
@@ -160,15 +139,14 @@ class SQLiteStorageAdapter:
         finished_at: float | None = None,
         error: str | None = None,
     ) -> None:
-        """Update one node's fields and recompute overall status. Raises if chain not initialized."""
-        with self._connect() as conn:
+        with self.connection() as conn:
             row = conn.execute(
-                "SELECT state_json FROM chain_state WHERE job_id = ?",
+                "SELECT state_json FROM chain_state WHERE job_id = %s",
                 (job_id,),
             ).fetchone()
             if row is None:
                 raise RuntimeError(f"chain state not initialized for job_id={job_id}")
-            state = json.loads(row["state_json"])
+            state = json.loads(str(row["state_json"]))
             for node in state["nodes"]:
                 if node["id"] == node_id:
                     node["status"] = status
@@ -187,47 +165,26 @@ class SQLiteStorageAdapter:
             conn.execute(
                 """
                 UPDATE chain_state
-                SET state_json = ?, overall_status = ?, updated_at = ?
-                WHERE job_id = ?
+                SET state_json = %s, overall_status = %s, updated_at = %s
+                WHERE job_id = %s
                 """,
                 (json.dumps(state), overall, time.time(), job_id),
             )
 
     def get_chain_state(self, job_id: str) -> dict | None:
-        """Return {nodes, edges, overall_status} for the chain, or None if no state recorded."""
-        with self._connect() as conn:
+        with self.connection() as conn:
             row = conn.execute(
-                "SELECT state_json, overall_status FROM chain_state WHERE job_id = ?",
+                "SELECT state_json, overall_status FROM chain_state WHERE job_id = %s",
                 (job_id,),
             ).fetchone()
             if row is None:
                 return None
-            state = json.loads(row["state_json"])
+            state = json.loads(str(row["state_json"]))
             return {
                 "nodes": state["nodes"],
                 "edges": state["edges"],
                 "overall_status": row["overall_status"],
             }
-
-    # ── Audit artifacts ────────────────────────────────────────────────────
-    #
-    # Persists compliance evidence (SLSA provenance, SBOM, TLA+ verification,
-    # Sigstore bundle, Rekor entry, TPM attestation) collected against a
-    # benchmark run, keyed by ``(job_id, artifact_id)``. Bytes are stored as
-    # SQLite BLOBs because the typical artifact is small (KB to low-MB) and
-    # we want list+download to be transactional and self-contained. A future
-    # migration can move BLOBs out to filesystem/S3 if needed.
-
-    _AUDIT_ARTIFACT_KINDS = frozenset(
-        {
-            "slsa_provenance",
-            "sbom",
-            "tla_report",
-            "sigstore_bundle",
-            "rekor_entry",
-            "tpm_attestation",
-        }
-    )
 
     def record_audit_artifact(
         self,
@@ -237,40 +194,33 @@ class SQLiteStorageAdapter:
         name: str,
         content: bytes,
     ) -> str:
-        """Insert a new audit artifact and return its generated artifact_id.
-
-        Raises ``ValueError`` if ``kind`` is not in the allowed set.
-        """
         if kind not in self._AUDIT_ARTIFACT_KINDS:
             raise ValueError(
                 f"unknown audit artifact kind {kind!r}; expected one of "
                 f"{sorted(self._AUDIT_ARTIFACT_KINDS)}"
             )
-        import hashlib
-
         artifact_id = str(uuid.uuid4())
         sha256 = hashlib.sha256(content).hexdigest()
         size_bytes = len(content)
         now = time.time()
-        with self._connect() as conn:
+        with self.connection() as conn:
             conn.execute(
                 """
                 INSERT INTO audit_artifact(
                     artifact_id, job_id, kind, name, size_bytes, sha256, content, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (artifact_id, job_id, kind, name, size_bytes, sha256, content, now),
             )
         return artifact_id
 
     def list_audit_artifacts(self, job_id: str) -> list[dict]:
-        """Return metadata for all artifacts of a job (no bytes), oldest first."""
-        with self._connect() as conn:
+        with self.connection() as conn:
             rows = conn.execute(
                 """
                 SELECT artifact_id, kind, name, size_bytes, sha256, created_at
                 FROM audit_artifact
-                WHERE job_id = ?
+                WHERE job_id = %s
                 ORDER BY created_at ASC, artifact_id ASC
                 """,
                 (job_id,),
@@ -293,18 +243,12 @@ class SQLiteStorageAdapter:
         job_id: str,
         artifact_id: str,
     ) -> tuple[bytes, str, str] | None:
-        """Return ``(content_bytes, name, kind)`` for one artifact, or ``None`` if missing.
-
-        The ``job_id`` is required (and matched in the WHERE clause) so callers
-        cannot fetch an artifact that doesn't belong to the job they're querying
-        — this is the building block the API endpoint uses for tenant scoping.
-        """
-        with self._connect() as conn:
+        with self.connection() as conn:
             row = conn.execute(
                 """
                 SELECT content, name, kind
                 FROM audit_artifact
-                WHERE job_id = ? AND artifact_id = ?
+                WHERE job_id = %s AND artifact_id = %s
                 """,
                 (job_id, artifact_id),
             ).fetchone()
@@ -312,13 +256,15 @@ class SQLiteStorageAdapter:
             return None
         return bytes(row["content"]), row["name"], row["kind"]
 
-    def mark_incomplete_jobs_failed(self, message: str = "server restarted before job completion") -> None:
+    def mark_incomplete_jobs_failed(
+        self, message: str = "server restarted before job completion"
+    ) -> None:
         now = time.time()
-        with self._connect() as conn:
+        with self.connection() as conn:
             conn.execute(
                 """
                 UPDATE jobs
-                SET status = ?, error = ?, message = ?, updated_at = ?
+                SET status = %s, error = %s, message = %s, updated_at = %s
                 WHERE status IN ('queued', 'running')
                 """,
                 ("failed", message, message, now),
@@ -333,13 +279,13 @@ class SQLiteStorageAdapter:
         idempotency_key: str | None = None,
     ) -> tuple[str, bool]:
         now = time.time()
-        with self._connect() as conn:
+        with self.connection() as conn:
             if idempotency_key:
                 existing = conn.execute(
                     """
                     SELECT job_id
                     FROM idempotency_keys
-                    WHERE tenant_id = ? AND operation = ? AND idempotency_key = ?
+                    WHERE tenant_id = %s AND operation = %s AND idempotency_key = %s
                     """,
                     (tenant_id, kind, idempotency_key),
                 ).fetchone()
@@ -349,8 +295,11 @@ class SQLiteStorageAdapter:
             job_id = str(uuid.uuid4())
             conn.execute(
                 """
-                INSERT INTO jobs(job_id, tenant_id, kind, status, request_json, result_json, error, message, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO jobs(
+                    job_id, tenant_id, kind, status, request_json, result_json,
+                    error, message, created_at, updated_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     job_id,
@@ -368,8 +317,10 @@ class SQLiteStorageAdapter:
             if idempotency_key:
                 conn.execute(
                     """
-                    INSERT INTO idempotency_keys(tenant_id, operation, idempotency_key, job_id, created_at)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO idempotency_keys(
+                        tenant_id, operation, idempotency_key, job_id, created_at
+                    )
+                    VALUES (%s, %s, %s, %s, %s)
                     """,
                     (tenant_id, kind, idempotency_key, job_id, now),
                 )
@@ -388,32 +339,36 @@ class SQLiteStorageAdapter:
         values: list[object] = []
 
         if status is not None:
-            fields.append("status = ?")
+            fields.append("status = %s")
             values.append(status)
         if result_payload is not None:
-            fields.append("result_json = ?")
+            fields.append("result_json = %s")
             values.append(json.dumps(result_payload, sort_keys=True))
         if error is not None:
-            fields.append("error = ?")
+            fields.append("error = %s")
             values.append(error)
         if message is not None:
-            fields.append("message = ?")
+            fields.append("message = %s")
             values.append(message)
 
-        fields.append("updated_at = ?")
+        fields.append("updated_at = %s")
         values.append(time.time())
         values.append(job_id)
 
-        with self._connect() as conn:
-            conn.execute(f"UPDATE jobs SET {', '.join(fields)} WHERE job_id = ?", values)  # nosec B608 — fields are hardcoded column names, values are parameterized
+        with self.connection() as conn:
+            conn.execute(
+                f"UPDATE jobs SET {', '.join(fields)} WHERE job_id = %s",
+                values,
+            )  # nosec B608 - fields are fixed column names
 
     def record_workflow_event(self, event: "MetricsEvent") -> None:
-        """Persist a single workflow lifecycle event."""
-        with self._connect() as conn:
+        with self.connection() as conn:
             conn.execute(
                 """
-                INSERT INTO workflow_events(job_id, event, status, duration_ms, error_type, labels_json, recorded_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO workflow_events(
+                    job_id, event, status, duration_ms, error_type, labels_json, recorded_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     event.job_id,
@@ -427,30 +382,24 @@ class SQLiteStorageAdapter:
             )
 
     def get_events_summary(self, *, job_id: str | None = None) -> list[dict]:
-        """Return per-event aggregate statistics.
-
-        When *job_id* is given, only events for that job are included.
-        Rows are ordered by event name and include count, ok/error split,
-        and avg/min/max duration in milliseconds — suitable for cross-run comparison.
-        """
         query = """
             SELECT
                 event,
-                COUNT(*)                                              AS total,
-                SUM(CASE WHEN status = 'ok'    THEN 1 ELSE 0 END)   AS ok_count,
-                SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END)    AS error_count,
-                ROUND(AVG(duration_ms), 1)                           AS avg_ms,
-                ROUND(MIN(duration_ms), 1)                           AS min_ms,
-                ROUND(MAX(duration_ms), 1)                           AS max_ms
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+                SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error_count,
+                ROUND(AVG(duration_ms)::numeric, 1) AS avg_ms,
+                ROUND(MIN(duration_ms)::numeric, 1) AS min_ms,
+                ROUND(MAX(duration_ms)::numeric, 1) AS max_ms
             FROM workflow_events
         """
         params: list[object] = []
         if job_id is not None:
-            query += " WHERE job_id = ?"
+            query += " WHERE job_id = %s"
             params.append(job_id)
         query += " GROUP BY event ORDER BY event"
 
-        with self._connect() as conn:
+        with self.connection() as conn:
             rows = conn.execute(query, params).fetchall()
 
         return [
@@ -467,13 +416,12 @@ class SQLiteStorageAdapter:
         ]
 
     def get_events_for_job(self, job_id: str) -> list[dict]:
-        """Return all raw workflow events for a single job, ordered by recorded_at."""
-        with self._connect() as conn:
+        with self.connection() as conn:
             rows = conn.execute(
                 """
                 SELECT event, status, duration_ms, error_type, labels_json, recorded_at
                 FROM workflow_events
-                WHERE job_id = ?
+                WHERE job_id = %s
                 ORDER BY recorded_at
                 """,
                 (job_id,),
@@ -492,13 +440,13 @@ class SQLiteStorageAdapter:
         ]
 
     def get_job(self, job_id: str, *, tenant_id: str | None = None) -> JobRecord | None:
-        query = "SELECT * FROM jobs WHERE job_id = ?"
+        query = "SELECT * FROM jobs WHERE job_id = %s"
         params: list[object] = [job_id]
         if tenant_id is not None:
-            query += " AND tenant_id = ?"
+            query += " AND tenant_id = %s"
             params.append(tenant_id)
 
-        with self._connect() as conn:
+        with self.connection() as conn:
             row = conn.execute(query, params).fetchone()
 
         if row is None:

--- a/rune_bench/storage/postgres.py
+++ b/rune_bench/storage/postgres.py
@@ -354,12 +354,11 @@ class PostgresStorageAdapter:
         fields.append("updated_at = %s")
         values.append(time.time())
         values.append(job_id)
+        assignments = ", ".join(fields)
+        statement = f"UPDATE jobs SET {assignments} WHERE job_id = %s"  # nosec B608
 
         with self.connection() as conn:
-            conn.execute(
-                f"UPDATE jobs SET {', '.join(fields)} WHERE job_id = %s",
-                values,
-            )  # nosec B608 - fields are fixed column names
+            conn.execute(statement, values)
 
     def record_workflow_event(self, event: "MetricsEvent") -> None:
         with self.connection() as conn:

--- a/tests/integration/test_postgres_storage.py
+++ b/tests/integration/test_postgres_storage.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from rune_bench.metrics import MetricsEvent
+from rune_bench.storage import make_storage
+from rune_bench.storage.postgres import PostgresStorageAdapter
+
+pytestmark = pytest.mark.integration_postgres
+
+
+def _pg_test_url() -> str:
+    url = os.environ.get("RUNE_PG_TEST_URL", "").strip()
+    if not url:
+        pytest.skip("set RUNE_PG_TEST_URL to run postgres integration tests")
+    return url
+
+
+def _reset_store(store: PostgresStorageAdapter) -> None:
+    with store.connection() as conn:
+        conn.execute(
+            """
+            TRUNCATE TABLE
+                audit_artifact,
+                chain_state,
+                workflow_events,
+                idempotency_keys,
+                jobs
+            RESTART IDENTITY
+            """
+        )
+
+
+@pytest.fixture
+def pg_store():
+    store = make_storage(_pg_test_url())
+    assert isinstance(store, PostgresStorageAdapter)
+    _reset_store(store)
+    try:
+        yield store
+    finally:
+        _reset_store(store)
+        store.close()
+
+
+def test_postgres_storage_round_trips_jobs_and_idempotency(pg_store) -> None:
+    job_id_1, created_1 = pg_store.create_job(
+        tenant_id="tenant-a",
+        kind="benchmark",
+        request_payload={"question": "q1"},
+        idempotency_key="same-key",
+    )
+    job_id_2, created_2 = pg_store.create_job(
+        tenant_id="tenant-a",
+        kind="benchmark",
+        request_payload={"question": "q1"},
+        idempotency_key="same-key",
+    )
+    job_id_3, created_3 = pg_store.create_job(
+        tenant_id="tenant-b",
+        kind="benchmark",
+        request_payload={"question": "q1"},
+        idempotency_key="same-key",
+    )
+
+    assert created_1 is True
+    assert created_2 is False
+    assert created_3 is True
+    assert job_id_1 == job_id_2
+    assert job_id_3 != job_id_1
+
+    pg_store.update_job(
+        job_id_1,
+        status="running",
+        result_payload={"phase": "start"},
+        message="working",
+    )
+    job = pg_store.get_job(job_id_1, tenant_id="tenant-a")
+    assert job is not None
+    assert job.status == "running"
+    assert job.result_payload == {"phase": "start"}
+    assert job.message == "working"
+    assert pg_store.get_job(job_id_1, tenant_id="tenant-b") is None
+
+
+def test_postgres_storage_metrics_chain_audit_and_recovery(pg_store) -> None:
+    job_id, _ = pg_store.create_job(
+        tenant_id="tenant-a",
+        kind="agentic-agent",
+        request_payload={"question": "q1"},
+    )
+    pg_store.update_job(job_id, status="running", message="still running")
+
+    pg_store.record_workflow_event(
+        MetricsEvent(
+            event="phase.a",
+            status="ok",
+            duration_ms=12.5,
+            labels={"backend": "pg"},
+            recorded_at=time.time(),
+            job_id=job_id,
+        )
+    )
+    summary = {row["event"]: row for row in pg_store.get_events_summary(job_id=job_id)}
+    assert summary["phase.a"]["total"] == 1
+    rows = pg_store.get_events_for_job(job_id)
+    assert rows[0]["labels"]["backend"] == "pg"
+
+    pg_store.record_chain_initialized(
+        job_id=job_id,
+        nodes=[{"id": "draft", "agent_name": "DraftAgent"}],
+        edges=[],
+    )
+    pg_store.record_chain_node_transition(
+        job_id=job_id,
+        node_id="draft",
+        status="success",
+        finished_at=42.0,
+    )
+    state = pg_store.get_chain_state(job_id)
+    assert state is not None
+    assert state["overall_status"] == "success"
+    assert state["nodes"][0]["finished_at"] == 42.0
+
+    artifact_id = pg_store.record_audit_artifact(
+        job_id=job_id,
+        kind="sbom",
+        name="sbom.json",
+        content=b"{}",
+    )
+    artifacts = pg_store.list_audit_artifacts(job_id)
+    assert artifacts[0]["artifact_id"] == artifact_id
+    content, name, kind = pg_store.get_audit_artifact(
+        job_id=job_id,
+        artifact_id=artifact_id,
+    ) or (b"", "", "")
+    assert content == b"{}"
+    assert name == "sbom.json"
+    assert kind == "sbom"
+
+    pg_store.mark_incomplete_jobs_failed("restarted")
+    job = pg_store.get_job(job_id, tenant_id="tenant-a")
+    assert job is not None
+    assert job.status == "failed"
+    assert job.error == "restarted"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,18 @@ defaults:
         load_config()
         assert os.environ["RUNE_VASTAI_MAX_DPH"] == "3.5"
 
+    def test_database_url_is_injected_from_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("RUNE_DB_URL", raising=False)
+        _write_yaml(tmp_path / "rune.yaml", """\
+version: "1"
+defaults:
+  database:
+    url: postgresql://rune:test@postgres:5432/rune
+""")
+        load_config()
+        assert os.environ["RUNE_DB_URL"] == "postgresql://rune:test@postgres:5432/rune"
+
 
 # ---------------------------------------------------------------------------
 # load_config — profile activation
@@ -147,6 +159,21 @@ profiles:
         result = load_config(None)
         assert result["model"] == "llama3.1:8b"
         assert os.environ["RUNE_MODEL"] == "llama3.1:8b"
+
+    def test_profile_can_override_database_url(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("RUNE_DB_URL", raising=False)
+        _write_yaml(tmp_path / "rune.yaml", """\
+version: "1"
+database:
+  url: postgresql://root:root@db:5432/base
+profiles:
+  production:
+    database:
+      url: postgresql://root:root@db:5432/prod
+""")
+        load_config("production")
+        assert os.environ["RUNE_DB_URL"] == "postgresql://root:root@db:5432/prod"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -80,6 +80,7 @@ def test_resolve_backend_type_env_unsupported(monkeypatch):
 def test_serve_api_keyboard_interrupt_and_error(monkeypatch):
     # Avoid unrelated side effects
     monkeypatch.setattr(rune, "_enable_debug_if_requested", lambda _d: None)
+    captured: dict[str, object] = {}
 
     class AppServerInterrupt:
         def serve(self, host, port):
@@ -89,14 +90,27 @@ def test_serve_api_keyboard_interrupt_and_error(monkeypatch):
         def serve(self, host, port):
             raise RuntimeError("boom")
 
-    monkeypatch.setattr("rune_bench.api_server.RuneApiApplication.from_env", lambda: AppServerInterrupt())
-    with pytest.raises(typer.Exit) as exc:
-        rune.serve_api(api_host="127.0.0.1", api_port=9999, debug=False)
-    assert exc.value.exit_code == 0
+    def _from_env_interrupt(*, db_url=None):
+        captured["interrupt_db_url"] = db_url
+        return AppServerInterrupt()
 
-    monkeypatch.setattr("rune_bench.api_server.RuneApiApplication.from_env", lambda: AppServerError())
+    monkeypatch.setattr("rune_bench.api_server.RuneApiApplication.from_env", _from_env_interrupt)
     with pytest.raises(typer.Exit) as exc:
-        rune.serve_api(api_host="127.0.0.1", api_port=9999, debug=False)
+        rune.serve_api(
+            api_host="127.0.0.1",
+            api_port=9999,
+            db_url="postgresql://db/rune",
+            debug=False,
+        )
+    assert exc.value.exit_code == 0
+    assert captured["interrupt_db_url"] == "postgresql://db/rune"
+
+    monkeypatch.setattr(
+        "rune_bench.api_server.RuneApiApplication.from_env",
+        lambda *, db_url=None: AppServerError(),
+    )
+    with pytest.raises(typer.Exit) as exc:
+        rune.serve_api(api_host="127.0.0.1", api_port=9999, db_url=None, debug=False)
     assert exc.value.exit_code == 1
 
 

--- a/tests/test_db_cli.py
+++ b/tests/test_db_cli.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+import rune
+import rune_bench.storage.migrate_to_postgres as migration_mod
+from rune_bench.storage.migrate_to_postgres import TableMigrationResult
+
+
+def test_db_migrate_to_postgres_cli_dry_run(monkeypatch) -> None:
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        migration_mod,
+        "migrate_to_postgres",
+        lambda **_kwargs: [
+            TableMigrationResult(
+                table="jobs",
+                source_count=3,
+                migrated_count=0,
+                dry_run=True,
+            )
+        ],
+    )
+
+    result = runner.invoke(
+        rune.app,
+        [
+            "db",
+            "migrate-to-postgres",
+            "--source",
+            "sqlite:///:memory:",
+            "--target",
+            "postgresql://localhost/rune",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Database Migration Plan" in result.output
+    assert "Dry run complete" in result.output
+    assert "jobs" in result.output
+
+
+def test_db_migrate_to_postgres_cli_reports_failure(monkeypatch) -> None:
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        migration_mod,
+        "migrate_to_postgres",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    result = runner.invoke(
+        rune.app,
+        [
+            "db",
+            "migrate-to-postgres",
+            "--source",
+            "sqlite:///:memory:",
+            "--target",
+            "postgresql://localhost/rune",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "boom" in result.output

--- a/tests/test_migrate_to_postgres.py
+++ b/tests/test_migrate_to_postgres.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+import rune_bench.storage.migrate_to_postgres as migration_mod
+
+
+class _Result:
+    def __init__(self, *, one=None, many=None):
+        self._one = one
+        self._many = many or []
+
+    def fetchone(self):
+        return self._one
+
+    def fetchall(self):
+        return self._many
+
+
+class _FakeSourceConnection:
+    def __init__(self, tables: dict[str, list[dict]]):
+        self.tables = tables
+
+    def execute(self, query: str, params=None):
+        normalized = " ".join(query.split())
+        if normalized.startswith("SELECT COUNT(*) AS total FROM "):
+            table_name = normalized.rsplit(" ", 1)[-1]
+            return _Result(one={"total": len(self.tables[table_name])})
+        if normalized.startswith("SELECT ") and " LIMIT ? OFFSET ?" in normalized:
+            table_name = normalized.split(" FROM ", 1)[1].split(" ORDER BY", 1)[0]
+            batch_size, offset = params
+            rows = self.tables[table_name][offset : offset + batch_size]
+            return _Result(many=[dict(row) for row in rows])
+        raise AssertionError(f"unexpected source query: {query}")
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+
+class _FakeTargetConnection:
+    def __init__(self) -> None:
+        self.tables: dict[str, list[dict]] = {}
+        self._keys: dict[str, set[tuple]] = {}
+        self.commits = 0
+        self.rollbacks = 0
+        self.sequence_reset = False
+        self.fail_on_table: str | None = None
+
+    def execute(self, query: str, params=None):
+        normalized = " ".join(query.split())
+        if normalized.startswith("INSERT INTO "):
+            table_name = normalized.split("INSERT INTO ", 1)[1].split(" (", 1)[0]
+            if self.fail_on_table == table_name:
+                raise RuntimeError("insert failed")
+            columns_text = normalized.split(f"INSERT INTO {table_name} (", 1)[1].split(
+                ") VALUES", 1
+            )[0]
+            conflict_text = normalized.split("ON CONFLICT (", 1)[1].split(
+                ") DO NOTHING", 1
+            )[0]
+            columns = [item.strip() for item in columns_text.split(",")]
+            conflict_columns = [item.strip() for item in conflict_text.split(",")]
+            row = dict(zip(columns, params, strict=True))
+            row_key = tuple(row[column] for column in conflict_columns)
+            seen = self._keys.setdefault(table_name, set())
+            if row_key not in seen:
+                seen.add(row_key)
+                self.tables.setdefault(table_name, []).append(row)
+            return _Result()
+        if "setval(" in normalized:
+            self.sequence_reset = True
+            return _Result()
+        raise AssertionError(f"unexpected target query: {query}")
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _FakeSQLiteAdapter:
+    def __init__(self, tables: dict[str, list[dict]]):
+        self._conn = _FakeSourceConnection(tables)
+
+    @contextmanager
+    def connection(self):
+        yield self._conn
+
+
+class _FakePostgresAdapter:
+    def __init__(self):
+        self._conn = _FakeTargetConnection()
+
+    @contextmanager
+    def connection(self):
+        yield self._conn
+
+
+def _patch_storage(monkeypatch, source, target) -> None:
+    storages = [source, target]
+    monkeypatch.setattr(migration_mod, "SQLiteStorageAdapter", _FakeSQLiteAdapter)
+    monkeypatch.setattr(migration_mod, "PostgresStorageAdapter", _FakePostgresAdapter)
+    monkeypatch.setattr(migration_mod, "make_storage", lambda _url: storages.pop(0))
+
+
+def test_migrate_to_postgres_copies_rows_in_batches(monkeypatch) -> None:
+    source = _FakeSQLiteAdapter(
+        {
+            "jobs": [
+                {
+                    "job_id": "job-1",
+                    "tenant_id": "tenant-a",
+                    "kind": "benchmark",
+                    "status": "queued",
+                    "request_json": "{}",
+                    "result_json": None,
+                    "error": None,
+                    "message": "accepted",
+                    "created_at": 1.0,
+                    "updated_at": 1.0,
+                }
+            ],
+            "idempotency_keys": [
+                {
+                    "tenant_id": "tenant-a",
+                    "operation": "benchmark",
+                    "idempotency_key": "idem-1",
+                    "job_id": "job-1",
+                    "created_at": 1.0,
+                }
+            ],
+            "workflow_events": [
+                {
+                    "id": 7,
+                    "job_id": "job-1",
+                    "event": "phase.a",
+                    "status": "ok",
+                    "duration_ms": 12.3,
+                    "error_type": None,
+                    "labels_json": "{}",
+                    "recorded_at": 2.0,
+                }
+            ],
+            "chain_state": [
+                {
+                    "job_id": "job-1",
+                    "state_json": '{"nodes": [], "edges": []}',
+                    "overall_status": "pending",
+                    "updated_at": 2.0,
+                }
+            ],
+            "audit_artifact": [
+                {
+                    "artifact_id": "artifact-1",
+                    "job_id": "job-1",
+                    "kind": "sbom",
+                    "name": "sbom.json",
+                    "size_bytes": 2,
+                    "sha256": "ab" * 32,
+                    "content": b"{}",
+                    "created_at": 3.0,
+                }
+            ],
+        }
+    )
+    target = _FakePostgresAdapter()
+    _patch_storage(monkeypatch, source, target)
+    progress: list[tuple[str, int, int, bool]] = []
+
+    results = migration_mod.migrate_to_postgres(
+        source_url="sqlite:///:memory:",
+        target_url="postgresql://localhost/rune",
+        batch_size=1,
+        reporter=lambda table, copied, total, dry_run: progress.append(
+            (table, copied, total, dry_run)
+        ),
+    )
+
+    assert [result.table for result in results] == [
+        "jobs",
+        "idempotency_keys",
+        "workflow_events",
+        "chain_state",
+        "audit_artifact",
+    ]
+    assert target._conn.tables["jobs"][0]["job_id"] == "job-1"
+    assert target._conn.tables["workflow_events"][0]["id"] == 7
+    assert target._conn.sequence_reset is True
+    assert ("jobs", 1, 1, False) in progress
+
+    # Re-running the migration is a no-op on the target because inserts use
+    # ON CONFLICT DO NOTHING on each table's primary key.
+    _patch_storage(monkeypatch, source, target)
+    migration_mod.migrate_to_postgres(
+        source_url="sqlite:///:memory:",
+        target_url="postgresql://localhost/rune",
+        batch_size=2,
+    )
+    assert len(target._conn.tables["jobs"]) == 1
+    assert len(target._conn.tables["workflow_events"]) == 1
+
+
+def test_migrate_to_postgres_dry_run_does_not_write(monkeypatch) -> None:
+    source = _FakeSQLiteAdapter(
+        {
+            "jobs": [{"job_id": "job-1"}],
+            "idempotency_keys": [],
+            "workflow_events": [],
+            "chain_state": [],
+            "audit_artifact": [],
+        }
+    )
+    target = _FakePostgresAdapter()
+    _patch_storage(monkeypatch, source, target)
+
+    results = migration_mod.migrate_to_postgres(
+        source_url="sqlite:///:memory:",
+        target_url="postgresql://localhost/rune",
+        dry_run=True,
+    )
+
+    assert results[0].table == "jobs"
+    assert results[0].source_count == 1
+    assert results[0].migrated_count == 0
+    assert results[0].dry_run is True
+    assert target._conn.tables == {}
+
+
+def test_migrate_to_postgres_rejects_invalid_batch_size(monkeypatch) -> None:
+    source = _FakeSQLiteAdapter(
+        {
+            "jobs": [],
+            "idempotency_keys": [],
+            "workflow_events": [],
+            "chain_state": [],
+            "audit_artifact": [],
+        }
+    )
+    target = _FakePostgresAdapter()
+    _patch_storage(monkeypatch, source, target)
+
+    with pytest.raises(RuntimeError, match="batch_size must be >= 1"):
+        migration_mod.migrate_to_postgres(
+            source_url="sqlite:///:memory:",
+            target_url="postgresql://localhost/rune",
+            batch_size=0,
+        )
+
+
+def test_migrate_to_postgres_requires_sqlite_source(monkeypatch) -> None:
+    target = _FakePostgresAdapter()
+    storages = [object(), target]
+    monkeypatch.setattr(migration_mod, "SQLiteStorageAdapter", _FakeSQLiteAdapter)
+    monkeypatch.setattr(migration_mod, "PostgresStorageAdapter", _FakePostgresAdapter)
+    monkeypatch.setattr(migration_mod, "make_storage", lambda _url: storages.pop(0))
+
+    with pytest.raises(RuntimeError, match="source must be a sqlite:// URL"):
+        migration_mod.migrate_to_postgres(
+            source_url="sqlite:///:memory:",
+            target_url="postgresql://localhost/rune",
+        )
+
+
+def test_migrate_to_postgres_rolls_back_failing_batch(monkeypatch) -> None:
+    source = _FakeSQLiteAdapter(
+        {
+            "jobs": [
+                {
+                    "job_id": "job-1",
+                    "tenant_id": "tenant-a",
+                    "kind": "benchmark",
+                    "status": "queued",
+                    "request_json": "{}",
+                    "result_json": None,
+                    "error": None,
+                    "message": "accepted",
+                    "created_at": 1.0,
+                    "updated_at": 1.0,
+                }
+            ],
+            "idempotency_keys": [],
+            "workflow_events": [],
+            "chain_state": [],
+            "audit_artifact": [],
+        }
+    )
+    target = _FakePostgresAdapter()
+    target._conn.fail_on_table = "jobs"
+    _patch_storage(monkeypatch, source, target)
+
+    with pytest.raises(RuntimeError, match="failed migrating table jobs row"):
+        migration_mod.migrate_to_postgres(
+            source_url="sqlite:///:memory:",
+            target_url="postgresql://localhost/rune",
+        )
+
+    assert target._conn.rollbacks == 1

--- a/tests/test_postgres_storage_unit.py
+++ b/tests/test_postgres_storage_unit.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+
+import pytest
+
+from rune_bench.metrics import MetricsEvent
+from rune_bench.storage import postgres as postgres_module
+from rune_bench.storage.postgres import PostgresStorageAdapter
+
+
+class _Result:
+    def __init__(self, *, one=None, many=None):
+        self._one = one
+        self._many = list(many or [])
+
+    def fetchone(self):
+        return self._one
+
+    def fetchall(self):
+        return list(self._many)
+
+
+class _FakeConnection:
+    def __init__(self, *, results=None):
+        self.results = list(results or [])
+        self.executed: list[tuple[str, object]] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def execute(self, query: str, params=None):
+        normalized = " ".join(str(query).split())
+        self.executed.append((normalized, params))
+        if self.results:
+            result = self.results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        return _Result()
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConnection):
+        self.conn = conn
+        self.closed = False
+        self.wait_called = False
+
+    @contextmanager
+    def connection(self):
+        yield self.conn
+
+    def close(self) -> None:
+        self.closed = True
+
+    def wait(self) -> None:
+        self.wait_called = True
+
+
+def _make_adapter(conn: _FakeConnection | None = None) -> PostgresStorageAdapter:
+    adapter = PostgresStorageAdapter.__new__(PostgresStorageAdapter)
+    adapter._db_url = "postgresql://user:pass@localhost:5432/rune"
+    adapter._pool = _FakePool(conn or _FakeConnection())
+    return adapter
+
+
+def test_postgres_adapter_constructor_uses_pool_settings(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeConnectionPool(_FakePool):
+        def __init__(self, **kwargs):
+            super().__init__(_FakeConnection())
+            captured.update(kwargs)
+
+    initialize_calls: list[str] = []
+
+    def fake_initialize(self) -> None:
+        initialize_calls.append(self._db_url)
+
+    monkeypatch.setenv("RUNE_PG_POOL_MIN", "2")
+    monkeypatch.setenv("RUNE_PG_POOL_MAX", "5")
+    monkeypatch.setattr(postgres_module, "ConnectionPool", FakeConnectionPool)
+    monkeypatch.setattr(PostgresStorageAdapter, "_initialize", fake_initialize)
+
+    adapter = PostgresStorageAdapter("postgresql://user:pass@localhost:5432/rune")
+
+    assert captured == {
+        "conninfo": "postgresql://user:pass@localhost:5432/rune",
+        "min_size": 2,
+        "max_size": 5,
+        "open": True,
+        "kwargs": {"row_factory": postgres_module.dict_row},
+    }
+    assert isinstance(adapter._pool, FakeConnectionPool)
+    assert adapter._pool.wait_called is True
+    assert initialize_calls == ["postgresql://user:pass@localhost:5432/rune"]
+
+
+def test_postgres_pool_size_validation(monkeypatch) -> None:
+    monkeypatch.setenv("RUNE_PG_POOL_MIN", "3")
+    monkeypatch.setenv("RUNE_PG_POOL_MAX", "7")
+    assert PostgresStorageAdapter._pool_min_size() == 3
+    assert PostgresStorageAdapter._pool_max_size() == 7
+
+    monkeypatch.setenv("RUNE_PG_POOL_MIN", "0")
+    with pytest.raises(RuntimeError, match="RUNE_PG_POOL_MIN must be >= 1"):
+        PostgresStorageAdapter._pool_min_size()
+
+    monkeypatch.setenv("RUNE_PG_POOL_MIN", "4")
+    monkeypatch.setenv("RUNE_PG_POOL_MAX", "2")
+    with pytest.raises(RuntimeError, match="RUNE_PG_POOL_MAX must be >= RUNE_PG_POOL_MIN"):
+        PostgresStorageAdapter._pool_max_size()
+
+
+def test_postgres_connection_and_initialize_use_pool(monkeypatch) -> None:
+    conn = _FakeConnection()
+    adapter = _make_adapter(conn)
+    calls: list[object] = []
+
+    class FakeMigrator:
+        def __init__(self, *, dialect: str):
+            calls.append(dialect)
+
+        def apply_pending(self, received_conn) -> None:
+            calls.append(received_conn)
+
+    monkeypatch.setattr(postgres_module, "Migrator", FakeMigrator)
+
+    with adapter.connection() as raw_conn:
+        assert raw_conn is conn
+    adapter._initialize()
+
+    assert calls == ["postgres", conn]
+
+
+@pytest.mark.parametrize(
+    ("nodes", "expected"),
+    [
+        ([], "pending"),
+        ([{"id": "a"}], "pending"),
+        ([{"id": "a", "status": "running"}], "running"),
+        ([{"id": "a", "status": "failed"}], "failed"),
+        ([{"id": "a", "status": "skipped"}], "skipped"),
+        ([{"id": "a", "status": "success"}], "success"),
+    ],
+)
+def test_compute_overall_chain_status(nodes: list[dict], expected: str) -> None:
+    assert PostgresStorageAdapter._compute_overall_chain_status(nodes) == expected
+
+
+def test_record_chain_initialized_normalizes_state() -> None:
+    conn = _FakeConnection()
+    adapter = _make_adapter(conn)
+
+    adapter.record_chain_initialized(
+        job_id="job-1",
+        nodes=[{"id": "draft", "agent_name": "DraftAgent"}],
+        edges=[{"from": "draft", "to": "review"}],
+    )
+
+    query, params = conn.executed[0]
+    state = json.loads(params[1])
+    assert "INSERT INTO chain_state(job_id, state_json, overall_status, updated_at)" in query
+    assert params[0] == "job-1"
+    assert params[2] == "pending"
+    assert state == {
+        "nodes": [
+            {
+                "id": "draft",
+                "agent_name": "DraftAgent",
+                "status": "pending",
+                "started_at": None,
+                "finished_at": None,
+                "error": None,
+            }
+        ],
+        "edges": [{"from": "draft", "to": "review"}],
+    }
+
+
+def test_record_chain_node_transition_updates_state() -> None:
+    conn = _FakeConnection(
+        results=[
+            _Result(
+                one={
+                    "state_json": json.dumps(
+                        {
+                            "nodes": [
+                                {
+                                    "id": "draft",
+                                    "agent_name": "DraftAgent",
+                                    "status": "pending",
+                                    "started_at": None,
+                                    "finished_at": None,
+                                    "error": None,
+                                }
+                            ],
+                            "edges": [],
+                        }
+                    )
+                }
+            )
+        ]
+    )
+    adapter = _make_adapter(conn)
+
+    adapter.record_chain_node_transition(
+        job_id="job-1",
+        node_id="draft",
+        status="success",
+        started_at=1.0,
+        finished_at=2.0,
+    )
+
+    _, params = conn.executed[1]
+    state = json.loads(params[0])
+    assert state["nodes"][0]["status"] == "success"
+    assert state["nodes"][0]["started_at"] == 1.0
+    assert state["nodes"][0]["finished_at"] == 2.0
+    assert params[1] == "success"
+    assert params[3] == "job-1"
+
+
+def test_record_chain_node_transition_rejects_missing_state_or_node() -> None:
+    missing_state = _make_adapter(_FakeConnection(results=[_Result(one=None)]))
+    with pytest.raises(RuntimeError, match="not initialized"):
+        missing_state.record_chain_node_transition(
+            job_id="job-1",
+            node_id="draft",
+            status="running",
+        )
+
+    missing_node = _make_adapter(
+        _FakeConnection(
+            results=[_Result(one={"state_json": json.dumps({"nodes": [], "edges": []})})]
+        )
+    )
+    with pytest.raises(RuntimeError, match="not found"):
+        missing_node.record_chain_node_transition(
+            job_id="job-1",
+            node_id="draft",
+            status="running",
+        )
+
+
+def test_get_chain_state_handles_missing_and_present_rows() -> None:
+    missing = _make_adapter(_FakeConnection(results=[_Result(one=None)]))
+    assert missing.get_chain_state("job-1") is None
+
+    present = _make_adapter(
+        _FakeConnection(
+            results=[
+                _Result(
+                    one={
+                        "state_json": json.dumps({"nodes": [{"id": "draft"}], "edges": []}),
+                        "overall_status": "running",
+                    }
+                )
+            ]
+        )
+    )
+    assert present.get_chain_state("job-1") == {
+        "nodes": [{"id": "draft"}],
+        "edges": [],
+        "overall_status": "running",
+    }
+
+
+def test_audit_artifact_methods_validate_and_round_trip(monkeypatch) -> None:
+    conn = _FakeConnection(
+        results=[
+            _Result(),
+            _Result(
+                many=[
+                    {
+                        "artifact_id": "artifact-1",
+                        "kind": "sbom",
+                        "name": "sbom.json",
+                        "size_bytes": 2,
+                        "sha256": "ab" * 32,
+                        "created_at": 10.0,
+                    }
+                ]
+            ),
+            _Result(one={"content": b"{}", "name": "sbom.json", "kind": "sbom"}),
+            _Result(one=None),
+        ]
+    )
+    adapter = _make_adapter(conn)
+    monkeypatch.setattr(postgres_module.uuid, "uuid4", lambda: "artifact-1")
+    monkeypatch.setattr(postgres_module.time, "time", lambda: 10.0)
+
+    with pytest.raises(ValueError, match="unknown audit artifact kind"):
+        adapter.record_audit_artifact(
+            job_id="job-1",
+            kind="unknown",
+            name="bad.bin",
+            content=b"payload",
+        )
+
+    artifact_id = adapter.record_audit_artifact(
+        job_id="job-1",
+        kind="sbom",
+        name="sbom.json",
+        content=b"{}",
+    )
+
+    insert_query, insert_params = conn.executed[0]
+    assert artifact_id == "artifact-1"
+    assert "INSERT INTO audit_artifact(" in insert_query
+    assert insert_params == (
+        "artifact-1",
+        "job-1",
+        "sbom",
+        "sbom.json",
+        2,
+        "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        b"{}",
+        10.0,
+    )
+
+    assert adapter.list_audit_artifacts("job-1") == [
+        {
+            "artifact_id": "artifact-1",
+            "kind": "sbom",
+            "name": "sbom.json",
+            "size_bytes": 2,
+            "sha256": "ab" * 32,
+            "created_at": 10.0,
+        }
+    ]
+    assert adapter.get_audit_artifact(job_id="job-1", artifact_id="artifact-1") == (
+        b"{}",
+        "sbom.json",
+        "sbom",
+    )
+    assert adapter.get_audit_artifact(job_id="job-1", artifact_id="missing") is None
+
+
+def test_mark_incomplete_jobs_failed_updates_rows(monkeypatch) -> None:
+    conn = _FakeConnection()
+    adapter = _make_adapter(conn)
+    monkeypatch.setattr(postgres_module.time, "time", lambda: 42.0)
+
+    adapter.mark_incomplete_jobs_failed("restarted")
+
+    query, params = conn.executed[0]
+    assert "UPDATE jobs SET status = %s, error = %s, message = %s, updated_at = %s" in query
+    assert params == ("failed", "restarted", "restarted", 42.0)
+
+
+def test_create_job_handles_new_and_existing_idempotency_keys(monkeypatch) -> None:
+    existing_conn = _FakeConnection(results=[_Result(one={"job_id": "job-existing"})])
+    existing_adapter = _make_adapter(existing_conn)
+
+    assert existing_adapter.create_job(
+        tenant_id="tenant-a",
+        kind="benchmark",
+        request_payload={"question": "q"},
+        idempotency_key="idem-1",
+    ) == ("job-existing", False)
+    assert len(existing_conn.executed) == 1
+
+    new_conn = _FakeConnection(results=[_Result(one=None)])
+    new_adapter = _make_adapter(new_conn)
+    monkeypatch.setattr(postgres_module.uuid, "uuid4", lambda: "job-new")
+    monkeypatch.setattr(postgres_module.time, "time", lambda: 11.5)
+
+    assert new_adapter.create_job(
+        tenant_id="tenant-a",
+        kind="benchmark",
+        request_payload={"question": "q"},
+        idempotency_key="idem-2",
+    ) == ("job-new", True)
+
+    assert "SELECT job_id FROM idempotency_keys" in new_conn.executed[0][0]
+    assert "INSERT INTO jobs(" in new_conn.executed[1][0]
+    assert new_conn.executed[1][1][0] == "job-new"
+    assert new_conn.executed[1][1][4] == json.dumps({"question": "q"}, sort_keys=True)
+    assert "INSERT INTO idempotency_keys(" in new_conn.executed[2][0]
+
+
+def test_update_job_and_event_queries_are_parameterized(monkeypatch) -> None:
+    conn = _FakeConnection()
+    adapter = _make_adapter(conn)
+    monkeypatch.setattr(postgres_module.time, "time", lambda: 33.0)
+
+    adapter.update_job(
+        "job-1",
+        status="running",
+        result_payload={"phase": "start"},
+        error="none",
+        message="working",
+    )
+    adapter.record_workflow_event(
+        MetricsEvent(
+            event="phase.a",
+            status="ok",
+            duration_ms=12.5,
+            labels={"backend": "pg"},
+            recorded_at=44.0,
+            job_id="job-1",
+        )
+    )
+
+    update_query, update_params = conn.executed[0]
+    assert update_query == (
+        "UPDATE jobs SET status = %s, result_json = %s, error = %s, message = %s, "
+        "updated_at = %s WHERE job_id = %s"
+    )
+    assert update_params == [
+        "running",
+        json.dumps({"phase": "start"}, sort_keys=True),
+        "none",
+        "working",
+        33.0,
+        "job-1",
+    ]
+
+    event_query, event_params = conn.executed[1]
+    assert "INSERT INTO workflow_events(" in event_query
+    assert event_params == (
+        "job-1",
+        "phase.a",
+        "ok",
+        12.5,
+        None,
+        json.dumps({"backend": "pg"}, sort_keys=True),
+        44.0,
+    )
+
+
+def test_event_summary_and_job_history_parse_rows() -> None:
+    conn = _FakeConnection(
+        results=[
+            _Result(
+                many=[
+                    {
+                        "event": "phase.a",
+                        "total": 2,
+                        "ok_count": 1,
+                        "error_count": 1,
+                        "avg_ms": 12.5,
+                        "min_ms": 10.0,
+                        "max_ms": 15.0,
+                    }
+                ]
+            ),
+            _Result(
+                many=[
+                    {
+                        "event": "phase.b",
+                        "total": 1,
+                        "ok_count": 1,
+                        "error_count": 0,
+                        "avg_ms": None,
+                        "min_ms": None,
+                        "max_ms": None,
+                    }
+                ]
+            ),
+            _Result(
+                many=[
+                    {
+                        "event": "phase.a",
+                        "status": "ok",
+                        "duration_ms": 12.5,
+                        "error_type": None,
+                        "labels_json": '{"backend": "pg"}',
+                        "recorded_at": 55.0,
+                    }
+                ]
+            ),
+        ]
+    )
+    adapter = _make_adapter(conn)
+
+    assert adapter.get_events_summary(job_id="job-1") == [
+        {
+            "event": "phase.a",
+            "total": 2,
+            "ok": 1,
+            "error": 1,
+            "avg_ms": 12.5,
+            "min_ms": 10.0,
+            "max_ms": 15.0,
+        }
+    ]
+    assert adapter.get_events_summary() == [
+        {
+            "event": "phase.b",
+            "total": 1,
+            "ok": 1,
+            "error": 0,
+            "avg_ms": 0.0,
+            "min_ms": 0.0,
+            "max_ms": 0.0,
+        }
+    ]
+    assert adapter.get_events_for_job("job-1") == [
+        {
+            "event": "phase.a",
+            "status": "ok",
+            "duration_ms": 12.5,
+            "error_type": None,
+            "labels": {"backend": "pg"},
+            "recorded_at": 55.0,
+        }
+    ]
+    assert "WHERE job_id = %s GROUP BY event ORDER BY event" in conn.executed[0][0]
+    assert "GROUP BY event ORDER BY event" in conn.executed[1][0]
+    assert "SELECT event, status, duration_ms, error_type, labels_json, recorded_at" in conn.executed[2][0]
+
+
+def test_get_job_returns_records_and_filters_tenant() -> None:
+    job_row = {
+        "job_id": "job-1",
+        "tenant_id": "tenant-a",
+        "kind": "benchmark",
+        "status": "running",
+        "request_json": '{"question": "q"}',
+        "result_json": '{"answer": "a"}',
+        "error": None,
+        "message": "working",
+        "created_at": 1.0,
+        "updated_at": 2.0,
+    }
+    conn = _FakeConnection(results=[_Result(one=job_row), _Result(one=None)])
+    adapter = _make_adapter(conn)
+
+    record = adapter.get_job("job-1", tenant_id="tenant-a")
+    assert record is not None
+    assert record.job_id == "job-1"
+    assert record.request_payload == {"question": "q"}
+    assert record.result_payload == {"answer": "a"}
+    assert record.message == "working"
+
+    assert adapter.get_job("job-1") is None
+    assert conn.executed[0][0] == "SELECT * FROM jobs WHERE job_id = %s AND tenant_id = %s"
+    assert conn.executed[1][0] == "SELECT * FROM jobs WHERE job_id = %s"
+
+
+def test_close_and_del_are_best_effort() -> None:
+    adapter = _make_adapter(_FakeConnection())
+    adapter.close()
+    assert adapter._pool.closed is True
+
+    class BrokenPool(_FakePool):
+        def close(self) -> None:
+            raise RuntimeError("boom")
+
+    broken = PostgresStorageAdapter.__new__(PostgresStorageAdapter)
+    broken._pool = BrokenPool(_FakeConnection())
+    PostgresStorageAdapter.__del__(broken)

--- a/tests/test_storage_factory.py
+++ b/tests/test_storage_factory.py
@@ -9,6 +9,7 @@ import rune_bench.storage as storage_module
 from rune_bench.storage import (
     StoragePort,
     SQLiteStorageAdapter,
+    default_storage_url,
     make_storage,
     resolve_storage_url,
 )
@@ -90,6 +91,13 @@ def test_make_storage_postgresql_uses_postgres_adapter(monkeypatch) -> None:
     assert captured["url"] == "postgresql://user:pass@localhost:5432/rune"
 
 
+def test_make_storage_postgresql_requires_pg_extra(monkeypatch) -> None:
+    monkeypatch.setattr(storage_module, "PostgresStorageAdapter", None)
+
+    with pytest.raises(RuntimeError, match="requires psycopg"):
+        make_storage("postgresql://user:pass@localhost:5432/rune")
+
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -116,7 +124,17 @@ def test_resolve_storage_url_prefers_explicit_url(monkeypatch) -> None:
     assert resolved == "postgresql://explicit"
 
 
-def test_resolve_storage_url_legacy_memory_path() -> None:
+def test_resolve_storage_url_uses_env_url(monkeypatch) -> None:
+    monkeypatch.setenv("RUNE_DB_URL", "postgresql://env")
+    monkeypatch.delenv("RUNE_API_DB_PATH", raising=False)
+
+    assert resolve_storage_url() == "postgresql://env"
+
+
+def test_resolve_storage_url_legacy_memory_path(monkeypatch) -> None:
+    monkeypatch.delenv("RUNE_DB_URL", raising=False)
+    monkeypatch.delenv("RUNE_API_DB_PATH", raising=False)
+
     assert resolve_storage_url(None, legacy_db_path=":memory:") == "sqlite:///:memory:"
 
 
@@ -127,6 +145,42 @@ def test_resolve_storage_url_legacy_relative_path(monkeypatch) -> None:
     resolved = resolve_storage_url()
 
     assert resolved == "sqlite:///./.rune-api/jobs.db"
+
+
+def test_resolve_storage_url_falls_back_to_default(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("RUNE_DB_URL", raising=False)
+    monkeypatch.delenv("RUNE_API_DB_PATH", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    assert resolve_storage_url() == f"sqlite:///{tmp_path.as_posix()}/rune/jobs.db"
+
+
+def test_default_storage_url_uses_xdg_data_home(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    assert default_storage_url() == f"sqlite:///{tmp_path.as_posix()}/rune/jobs.db"
+
+
+def test_default_storage_url_uses_localappdata_on_windows(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(storage_module.sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+    assert default_storage_url() == f"sqlite:///{tmp_path.as_posix()}/rune/jobs.db"
+
+
+def test_make_storage_windows_absolute_path_drops_leading_slash(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class FakeSQLiteAdapter:
+        def __init__(self, db_path: str) -> None:
+            captured["db_path"] = db_path
+
+    monkeypatch.setattr(storage_module, "SQLiteStorageAdapter", FakeSQLiteAdapter)
+
+    store = make_storage("sqlite:///C:/temp/jobs.db")
+
+    assert isinstance(store, FakeSQLiteAdapter)
+    assert captured["db_path"] == "C:/temp/jobs.db"
 
 
 def test_storage_port_protocol_matches_sqlite_adapter(tmp_path) -> None:

--- a/tests/test_storage_factory.py
+++ b/tests/test_storage_factory.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 
 import pytest
 
-from rune_bench.storage import StoragePort, SQLiteStorageAdapter, make_storage
+import rune_bench.storage as storage_module
+from rune_bench.storage import (
+    StoragePort,
+    SQLiteStorageAdapter,
+    make_storage,
+    resolve_storage_url,
+)
 
 
 def test_make_storage_sqlite_memory() -> None:
@@ -60,10 +66,33 @@ def test_make_storage_sqlite_plus_pysqlite_alias(tmp_path) -> None:
     assert db_file.exists()
 
 
+def test_make_storage_sqlite_relative_dot_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store = make_storage("sqlite:///./nested/jobs.db")
+
+    assert isinstance(store, SQLiteStorageAdapter)
+    store.create_job(tenant_id="t", kind="benchmark", request_payload={})
+    assert (tmp_path / "nested" / "jobs.db").exists()
+
+
+def test_make_storage_postgresql_uses_postgres_adapter(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class FakePostgresAdapter:
+        def __init__(self, url: str) -> None:
+            captured["url"] = url
+
+    monkeypatch.setattr(storage_module, "PostgresStorageAdapter", FakePostgresAdapter)
+
+    store = make_storage("postgresql://user:pass@localhost:5432/rune")
+
+    assert isinstance(store, FakePostgresAdapter)
+    assert captured["url"] == "postgresql://user:pass@localhost:5432/rune"
+
+
 @pytest.mark.parametrize(
     "url",
     [
-        "postgresql://user:pass@localhost/db",
         "redis://localhost:6379/0",
         "mysql://localhost/db",
         "http://example.com/db",
@@ -76,6 +105,28 @@ def test_make_storage_unknown_scheme_raises(url: str) -> None:
     message = str(exc_info.value)
     assert "unsupported storage URL scheme" in message
     assert "sqlite://" in message  # lists supported schemes
+
+
+def test_resolve_storage_url_prefers_explicit_url(monkeypatch) -> None:
+    monkeypatch.setenv("RUNE_DB_URL", "postgresql://env")
+    monkeypatch.setenv("RUNE_API_DB_PATH", ".rune-api/jobs.db")
+
+    resolved = resolve_storage_url("postgresql://explicit", legacy_db_path="legacy.db")
+
+    assert resolved == "postgresql://explicit"
+
+
+def test_resolve_storage_url_legacy_memory_path() -> None:
+    assert resolve_storage_url(None, legacy_db_path=":memory:") == "sqlite:///:memory:"
+
+
+def test_resolve_storage_url_legacy_relative_path(monkeypatch) -> None:
+    monkeypatch.delenv("RUNE_DB_URL", raising=False)
+    monkeypatch.setenv("RUNE_API_DB_PATH", ".rune-api/jobs.db")
+
+    resolved = resolve_storage_url()
+
+    assert resolved == "sqlite:///./.rune-api/jobs.db"
 
 
 def test_storage_port_protocol_matches_sqlite_adapter(tmp_path) -> None:

--- a/tests/test_storage_migrator.py
+++ b/tests/test_storage_migrator.py
@@ -29,9 +29,12 @@ def _migrations_dir() -> pathlib.Path:
 
 
 def _apply_sql_files(conn: sqlite3.Connection, *filenames: str) -> None:
+    migrator = Migrator(dialect="sqlite")
     for name in filenames:
         path = _migrations_dir() / name
-        conn.executescript(path.read_text(encoding="utf-8"))
+        conn.executescript(
+            migrator._render_for_dialect(path.read_text(encoding="utf-8"))
+        )
     conn.commit()
 
 

--- a/tests/test_vastai_instance_manager.py
+++ b/tests/test_vastai_instance_manager.py
@@ -136,6 +136,7 @@ def test_build_connection_details_without_machine_id():
 @pytest.fixture
 def misc_server(tmp_path, monkeypatch):
     monkeypatch.setenv("RUNE_API_AUTH_DISABLED", "1")
+    monkeypatch.delenv("RUNE_DB_URL", raising=False)
     monkeypatch.setenv("RUNE_API_DB_PATH", str(tmp_path / "jobs.db"))
     app = api_server.RuneApiApplication.from_env()
     server = api_server.ThreadingHTTPServer(("127.0.0.1", 0), app.create_handler())


### PR DESCRIPTION
## Summary
- add a `PostgresStorageAdapter`, dialect-aware storage migrations, and `make_storage()` support for `postgresql://` URLs
- wire `RUNE_DB_URL` through YAML/env/CLI resolution, `rune serve --db-url`, and `RuneApiApplication.from_env()` while keeping `RUNE_API_DB_PATH` as a legacy SQLite fallback
- add `rune db migrate-to-postgres`, focused Postgres integration tests, and a CI service job that exercises the new backend against a real `postgres:17-alpine` container

## Definition of Done
- [x] **Level 2**
- [x] PostgreSQL-backed storage implements the shared `StoragePort` behavior used by the API server
- [x] CLI and API startup can resolve `RUNE_DB_URL` while preserving legacy SQLite path compatibility
- [x] Postgres migration tooling and CI coverage are in place for the new storage path

## Acceptance Criteria Evidence
- [x] `make_storage("postgresql://...")` returns a Postgres adapter
- [x] `rune db migrate-to-postgres` copies supported tables in batches and supports `--dry-run`
- [x] local focused storage/API test suite passed
- [x] local live Postgres integration test passed against `postgres:17-alpine`

## Audit Checks
- PASS: introduces `psycopg[binary,pool]>=3.2` only under the optional `pg` extra so default installs remain unchanged
- PASS: adds automated PostgreSQL validation coverage in CI for the new backend path
- PASS: no repository automation reported legal, cyber, or supply-chain audit failures on this branch; merge review can perform any remaining manual approvals required by policy

## Test plan
- [x] `./.venv/bin/ruff check rune/__init__.py rune_bench/api_server.py rune_bench/common/config.py rune_bench/storage/__init__.py rune_bench/storage/sqlite.py rune_bench/storage/migrator.py rune_bench/storage/postgres.py rune_bench/storage/migrate_to_postgres.py tests/test_storage_factory.py tests/test_storage_migrator.py tests/test_config.py tests/test_coverage_completion.py tests/test_migrate_to_postgres.py tests/test_db_cli.py tests/test_vastai_instance_manager.py tests/integration/test_postgres_storage.py`
- [x] `./.venv/bin/pytest --no-cov tests/test_storage_factory.py tests/test_storage_migrator.py tests/test_config.py tests/test_coverage_completion.py tests/test_migrate_to_postgres.py tests/test_db_cli.py tests/test_job_store.py tests/test_metrics.py tests/test_api_server.py tests/test_vastai_instance_manager.py`
- [x] `RUNE_PG_TEST_URL=postgresql://postgres:test@127.0.0.1:5432/rune ./.venv/bin/pytest --no-cov -m integration_postgres tests/integration/test_postgres_storage.py`

## Breaking Changes
- None. `RUNE_API_DB_PATH` remains as a fallback when `RUNE_DB_URL` is unset.

Part of lpasquali/rune-docs#195.
Closes #233.
Closes #234.
Closes #235.
Closes #236.

Made with [Cursor](https://cursor.com)