### PR TITLE
feat(api): PricingSoothSayer + GET /v1/finops/simulate (#214)

### DIFF
--- a/rune_bench/api_server.py
+++ b/rune_bench/api_server.py
@@ -33,6 +33,7 @@ from rune_bench.api_contracts import (
     RunLLMInstanceRequest,
 )
 from rune_bench.metrics import SQLiteMetricsCollector, clear_collector, set_collector, set_job_id, span
+from rune_bench.metrics.pricing import make_pricing_sooth_sayer
 from rune_bench.storage import StoragePort, make_storage, resolve_storage_url
 from rune_bench.storage.sqlite import JobRecord, SQLiteStorageAdapter
 
@@ -331,6 +332,27 @@ class RuneApiApplication:
                     filter_job_id = query.get("job_id", [None])[0]
                     summary = app.store.get_events_summary(job_id=filter_job_id)
                     self._write_json(200, {"events": summary})
+                    return
+
+                if path == "/v1/finops/simulate":
+                    query = parse_qs(parsed.query)
+                    agent = (query.get("agent", [""])[0] or "").strip()
+                    suite = (query.get("suite", [""])[0] or "").strip()
+                    gpu = (query.get("gpu", [""])[0] or "").strip()
+                    model = (query.get("model", [""])[0] or "").strip()
+                    try:
+                        sooth = make_pricing_sooth_sayer(app.store)
+                        payload = sooth.simulate(
+                            tenant_id=tenant_id,
+                            agent=agent,
+                            suite=suite,
+                            gpu=gpu,
+                            model=model,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        self._write_json(500, {"error": f"finops simulation failed: {exc}"})
+                        return
+                    self._write_json(200, payload)
                     return
 
                 if path.startswith("/v1/jobs/"):

--- a/rune_bench/metrics/__init__.py
+++ b/rune_bench/metrics/__init__.py
@@ -51,7 +51,7 @@ class InMemoryCollector:
     """Accumulates events in memory; suitable for CLI mode.
 
     After the workflow completes, call :meth:`summary_rows` to get
-    per-event aggregates for display.
+    per-event aggregate rows for display.
     """
 
     def __init__(self) -> None:

--- a/rune_bench/metrics/pricing.py
+++ b/rune_bench/metrics/pricing.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FinOps cost projection from historical jobs, LLM list prices, and live GPU offers."""
+
+from __future__ import annotations
+
+import os
+import statistics
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from rune_bench.storage import StoragePort
+
+# USD per 1M tokens (input, output) — indicative list prices; refresh periodically.
+_LLM_USD_PER_MILLION: dict[str, tuple[float, float]] = {
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4-turbo": (10.00, 30.00),
+    "claude-3-5-sonnet": (3.00, 15.00),
+    "claude-3-5-sonnet-20241022": (3.00, 15.00),
+    "claude-3-opus": (15.00, 75.00),
+    "claude-3-haiku": (0.25, 1.25),
+}
+
+_DEFAULT_LLM_PER_MILLION = (0.50, 1.50)
+
+# Fallback $/hour when Vast.ai is unavailable or no matching offer (by substring).
+_FALLBACK_GPU_DPH_USD: dict[str, float] = {
+    "4090": 0.35,
+    "a100": 1.40,
+    "h100": 3.50,
+    "3090": 0.25,
+    "l40": 0.80,
+}
+
+_DEFAULT_ASSUMED_DURATION_S = 120.0
+_DEFAULT_INPUT_TOKENS = 2048.0
+_DEFAULT_OUTPUT_TOKENS = 512.0
+
+
+def _model_llm_rates(model: str) -> tuple[float, float]:
+    m = model.strip().lower()
+    if not m:
+        return _DEFAULT_LLM_PER_MILLION
+    for key, rates in _LLM_USD_PER_MILLION.items():
+        if key in m or m in key:
+            return rates
+    return _DEFAULT_LLM_PER_MILLION
+
+
+def _fallback_dph(gpu: str) -> float:
+    g = gpu.strip().lower()
+    for frag, dph in _FALLBACK_GPU_DPH_USD.items():
+        if frag in g:
+            return dph
+    return 0.50
+
+
+def _extract_tokens_from_result(result: dict[str, Any] | None) -> tuple[float | None, float | None]:
+    """Best-effort prompt/output token counts from nested result payloads."""
+
+    if not result:
+        return None, None
+
+    def walk(obj: Any) -> list[tuple[int, int]]:
+        found: list[tuple[int, int]] = []
+        if isinstance(obj, dict):
+            pe = obj.get("prompt_eval_count")
+            ec = obj.get("eval_count")
+            if pe is not None and ec is not None:
+                try:
+                    found.append((int(pe), int(ec)))
+                except (TypeError, ValueError):
+                    pass
+            pt = obj.get("prompt_tokens")
+            ct = obj.get("completion_tokens")
+            if pt is not None and ct is not None:
+                try:
+                    found.append((int(pt), int(ct)))
+                except (TypeError, ValueError):
+                    pass
+            for v in obj.values():
+                found.extend(walk(v))
+        elif isinstance(obj, list):
+            for v in obj:
+                found.extend(walk(v))
+        return found
+
+    pairs = walk(result)
+    if not pairs:
+        return None, None
+    # Use the last pair (often the innermost / final usage block).
+    inp, out = pairs[-1]
+    return float(inp), float(out)
+
+
+def _job_matches_filters(
+    kind: str,
+    request_payload: dict[str, Any],
+    *,
+    agent: str,
+    suite: str,
+    model: str,
+) -> bool:
+    if kind not in ("benchmark", "agentic-agent"):
+        return False
+    if agent:
+        if kind != "agentic-agent":
+            return False
+        if request_payload.get("agent", "holmes") != agent:
+            return False
+    if suite:
+        if kind != "benchmark":
+            return False
+        if request_payload.get("template_hash", "") != suite:
+            return False
+    if model:
+        req_model = request_payload.get("model", "")
+        if req_model != model:
+            return False
+    return True
+
+
+@dataclass(frozen=True)
+class _HistoricalAgg:
+    n: int
+    avg_duration_s: float
+    min_duration_s: float
+    max_duration_s: float
+    avg_input_tokens: float
+    avg_output_tokens: float
+    token_samples: int
+
+
+def _aggregate(rows: list[dict[str, Any]]) -> _HistoricalAgg:
+    if not rows:
+        return _HistoricalAgg(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0)
+    durs: list[float] = []
+    in_toks: list[float] = []
+    out_toks: list[float] = []
+    for row in rows:
+        durs.append(float(row["duration_seconds"]))
+        pi, po = _extract_tokens_from_result(row.get("result_payload"))
+        if pi is not None and po is not None:
+            in_toks.append(pi)
+            out_toks.append(po)
+    avg_d = statistics.mean(durs)
+    min_d = min(durs)
+    max_d = max(durs)
+    if in_toks:
+        return _HistoricalAgg(
+            n=len(rows),
+            avg_duration_s=avg_d,
+            min_duration_s=min_d,
+            max_duration_s=max_d,
+            avg_input_tokens=statistics.mean(in_toks),
+            avg_output_tokens=statistics.mean(out_toks),
+            token_samples=len(in_toks),
+        )
+    return _HistoricalAgg(
+        n=len(rows),
+        avg_duration_s=avg_d,
+        min_duration_s=min_d,
+        max_duration_s=max_d,
+        avg_input_tokens=_DEFAULT_INPUT_TOKENS,
+        avg_output_tokens=_DEFAULT_OUTPUT_TOKENS,
+        token_samples=0,
+    )
+
+
+def _vast_dph_stats(
+    search_offers: Callable[..., list[dict[str, Any]]],
+    gpu_substring: str,
+    *,
+    max_offers: int = 80,
+) -> tuple[float, float, float]:
+    """Return (median_dph, min_dph, max_dph) from live offers filtered by GPU name."""
+    query = {"verified": {"eq": "True"}, "reliability": {"gt": "0.85"}}
+    try:
+        offers = search_offers(query=query, order="dph+", disable_bundling=True, raw=True)
+    except Exception:
+        offers = []
+    if not isinstance(offers, list):
+        offers = []
+    gq = gpu_substring.strip().lower()
+    dphs: list[float] = []
+    for o in offers[:500]:
+        name = str(o.get("gpu_name", "")).lower()
+        if gq and gq not in name:
+            continue
+        raw = o.get("dph_total", o.get("dph"))
+        try:
+            v = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if v > 0:
+            dphs.append(v)
+        if len(dphs) >= max_offers:
+            break
+    if not dphs:
+        fb = _fallback_dph(gpu_substring)
+        return fb, fb * 0.7, fb * 1.5
+    return (
+        statistics.median(dphs),
+        min(dphs),
+        max(dphs),
+    )
+
+
+class PricingSoothSayer:
+    """Project run cost: GPU time from Vast.ai (or fallback) plus LLM token list pricing."""
+
+    def __init__(
+        self,
+        store: StoragePort,
+        *,
+        vast_search_offers: Callable[..., list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._store = store
+        self._vast_search_offers = vast_search_offers
+
+    def simulate(
+        self,
+        *,
+        tenant_id: str,
+        agent: str = "",
+        suite: str = "",
+        gpu: str = "RTX 4090",
+        model: str = "",
+    ) -> dict[str, Any]:
+        agent = agent.strip()
+        suite = suite.strip()
+        gpu = gpu.strip() or "RTX 4090"
+        model = model.strip()
+
+        raw_rows = self._store.list_jobs_for_finops(tenant_id=tenant_id, limit=2000)
+        matched: list[dict[str, Any]] = []
+        for row in raw_rows:
+            if _job_matches_filters(
+                row["kind"],
+                row["request_payload"],
+                agent=agent,
+                suite=suite,
+                model=model,
+            ):
+                matched.append(row)
+
+        hist = _aggregate(matched)
+        if hist.n == 0:
+            dur_mid = _DEFAULT_ASSUMED_DURATION_S
+            dur_low = _DEFAULT_ASSUMED_DURATION_S * 0.25
+            dur_high = _DEFAULT_ASSUMED_DURATION_S * 3.0
+            hist_note = "no_matching_history"
+            confidence = "low"
+        else:
+            dur_mid = hist.avg_duration_s
+            dur_low = hist.min_duration_s
+            dur_high = hist.max_duration_s
+            hist_note = "from_history"
+            confidence = "high" if hist.n >= 5 and hist.token_samples >= 3 else "medium"
+
+        in_per_m, out_per_m = _model_llm_rates(model or "local")
+
+        def _llm_cost(inp: float, out: float) -> float:
+            return (inp / 1_000_000.0) * in_per_m + (out / 1_000_000.0) * out_per_m
+
+        in_mid, out_mid = hist.avg_input_tokens, hist.avg_output_tokens
+        if hist.token_samples == 0:
+            in_low, out_low = in_mid * 0.25, out_mid * 0.25
+            in_high, out_high = in_mid * 2.5, out_mid * 2.5
+        else:
+            in_low, out_low = in_mid * 0.8, out_mid * 0.8
+            in_high, out_high = in_mid * 1.2, out_mid * 1.2
+
+        llm_mid = _llm_cost(in_mid, out_mid)
+        llm_low = _llm_cost(in_low, out_low)
+        llm_high = _llm_cost(in_high, out_high)
+
+        if self._vast_search_offers is not None:
+            dph_mid, dph_lo, dph_hi = _vast_dph_stats(self._vast_search_offers, gpu)
+            vast_source = "live"
+        else:
+            fb = _fallback_dph(gpu)
+            dph_mid, dph_lo, dph_hi = fb, fb * 0.7, fb * 1.5
+            vast_source = "fallback"
+
+        # GPU $/min from $/hour.
+        dpm_mid = dph_mid / 60.0
+        dpm_lo = dph_lo / 60.0
+        dpm_hi = dph_hi / 60.0
+
+        # Issue #214: (Avg Duration [minutes] * GPU $/min) + token costs.
+        dur_min_mid = dur_mid / 60.0
+        dur_min_lo = dur_low / 60.0
+        dur_min_hi = dur_high / 60.0
+
+        gpu_mid = dur_min_mid * dpm_mid
+        gpu_low = dur_min_lo * dpm_lo
+        gpu_high = dur_min_hi * dpm_hi
+
+        total_mid = gpu_mid + llm_mid
+        total_low = gpu_low + llm_low
+        total_high = gpu_high + llm_high
+
+        return {
+            "currency": "USD",
+            "projected_cost_usd": round(total_mid, 4),
+            "cost_low_usd": round(total_low, 4),
+            "cost_high_usd": round(total_high, 4),
+            "confidence": confidence,
+            "historical_sample_count": hist.n,
+            "historical_basis": hist_note,
+            "avg_duration_seconds": round(dur_mid, 3),
+            "duration_low_seconds": round(dur_low, 3),
+            "duration_high_seconds": round(dur_high, 3),
+            "gpu": gpu,
+            "gpu_dph_usd": round(dph_mid, 4),
+            "gpu_dph_low_usd": round(dph_lo, 4),
+            "gpu_dph_high_usd": round(dph_hi, 4),
+            "vast_pricing_source": vast_source,
+            "llm_model_effective": model or "default",
+            "llm_input_tokens_assumed": round(in_mid, 1),
+            "llm_output_tokens_assumed": round(out_mid, 1),
+            "token_samples_from_history": hist.token_samples,
+            "components_usd": {
+                "gpu_compute": round(gpu_mid, 4),
+                "llm_tokens": round(llm_mid, 4),
+            },
+        }
+
+
+def make_pricing_sooth_sayer(store: StoragePort) -> PricingSoothSayer:
+    """Factory: use Vast REST client when ``VAST_API_KEY`` is set."""
+    key = os.environ.get("VAST_API_KEY", "").strip()
+    if key:
+        try:
+            from rune_bench.resources.vastai.sdk import VastAI
+
+            sdk = VastAI(api_key=key, raw=True)
+            return PricingSoothSayer(store, vast_search_offers=sdk.search_offers)
+        except Exception:
+            pass
+    return PricingSoothSayer(store, vast_search_offers=None)

--- a/rune_bench/storage/base.py
+++ b/rune_bench/storage/base.py
@@ -86,6 +86,10 @@ class StoragePort(Protocol):
         """Return all raw workflow events for a single job, ordered by time."""
         ...
 
+    def list_jobs_for_finops(self, *, tenant_id: str, limit: int = 2000) -> list[dict]:
+        """Recent succeeded ``benchmark`` / ``agentic-agent`` jobs for FinOps simulation."""
+        ...
+
     # ── Chain state ────────────────────────────────────────────────────────
 
     def record_chain_initialized(

--- a/rune_bench/storage/postgres.py
+++ b/rune_bench/storage/postgres.py
@@ -438,6 +438,36 @@ class PostgresStorageAdapter:
             for row in rows
         ]
 
+    def list_jobs_for_finops(self, *, tenant_id: str, limit: int = 2000) -> list[dict[str, Any]]:
+        cap = max(1, min(int(limit), 5000))
+        with self.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT kind, request_json, result_json, created_at, updated_at
+                FROM jobs
+                WHERE tenant_id = %s
+                  AND status = 'succeeded'
+                  AND kind IN ('benchmark', 'agentic-agent')
+                ORDER BY updated_at DESC
+                LIMIT %s
+                """,
+                (tenant_id, cap),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            created = float(row["created_at"])
+            updated = float(row["updated_at"])
+            duration = max(updated - created, 1e-3)
+            out.append(
+                {
+                    "kind": str(row["kind"]),
+                    "request_payload": json.loads(row["request_json"]),
+                    "result_payload": json.loads(row["result_json"]) if row["result_json"] else None,
+                    "duration_seconds": duration,
+                }
+            )
+        return out
+
     def get_job(self, job_id: str, *, tenant_id: str | None = None) -> JobRecord | None:
         query = "SELECT * FROM jobs WHERE job_id = %s"
         params: list[object] = [job_id]

--- a/rune_bench/storage/sqlite.py
+++ b/rune_bench/storage/sqlite.py
@@ -491,6 +491,37 @@ class SQLiteStorageAdapter:
             for row in rows
         ]
 
+    def list_jobs_for_finops(self, *, tenant_id: str, limit: int = 2000) -> list[dict[str, Any]]:
+        """Return succeeded benchmark / agentic jobs with wall-clock duration for cost projection."""
+        cap = max(1, min(int(limit), 5000))
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT kind, request_json, result_json, created_at, updated_at
+                FROM jobs
+                WHERE tenant_id = ?
+                  AND status = 'succeeded'
+                  AND kind IN ('benchmark', 'agentic-agent')
+                ORDER BY updated_at DESC
+                LIMIT ?
+                """,
+                (tenant_id, cap),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            created = float(row["created_at"])
+            updated = float(row["updated_at"])
+            duration = max(updated - created, 1e-3)
+            out.append(
+                {
+                    "kind": str(row["kind"]),
+                    "request_payload": json.loads(row["request_json"]),
+                    "result_payload": json.loads(row["result_json"]) if row["result_json"] else None,
+                    "duration_seconds": duration,
+                }
+            )
+        return out
+
     def get_job(self, job_id: str, *, tenant_id: str | None = None) -> JobRecord | None:
         query = "SELECT * FROM jobs WHERE job_id = ?"
         params: list[object] = [job_id]

--- a/tests/test_async_transports_and_remaining.py
+++ b/tests/test_async_transports_and_remaining.py
@@ -93,6 +93,28 @@ class TestAsyncStdioTransport:
             with pytest.raises(RuntimeError, match="bad input"):
                 asyncio.run(transport.call_async("ask", {}))
 
+    def test_wait_for_timeout_kills_process(self) -> None:
+        from rune_bench.drivers import stdio as stdio_mod
+        from rune_bench.drivers.stdio import AsyncStdioTransport
+
+        transport = AsyncStdioTransport(["python3", "-m", "test_driver"])
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        async def timeout_wait_for(_coro, *, timeout=None, **_kwargs):
+            raise TimeoutError()
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            with patch("asyncio.wait_for", side_effect=timeout_wait_for):
+                with patch.object(stdio_mod, "driver_invocation_timeout_seconds", return_value=1.0):
+                    with pytest.raises(RuntimeError, match="SR-Q-011"):
+                        asyncio.run(transport.call_async("ask", {}))
+
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # AsyncHttpTransport

--- a/tests/test_cost_estimation.py
+++ b/tests/test_cost_estimation.py
@@ -154,6 +154,15 @@ def test_cost_estimator_vastai_no_max_dph():
     assert result.projected_cost_usd == pytest.approx(2.5, rel=1e-3)
 
 
+def test_cost_estimator_vastai_min_only():
+    """_estimate_vastai branch: min_dph > 0, max_dph == 0 uses min rate."""
+    estimator = CostEstimator()
+    r = _estimator_req(vastai=True, min_dph=2.0, max_dph=0.0, estimated_duration_seconds=3600)
+    result = asyncio.run(estimator.estimate(r))
+    assert result.cost_driver == "vastai"
+    assert result.projected_cost_usd == pytest.approx(2.0, rel=1e-3)
+
+
 def test_cost_estimator_aws():
     estimator = CostEstimator()
     r = _estimator_req(aws=True, estimated_duration_seconds=3600)

--- a/tests/test_migrate_to_postgres.py
+++ b/tests/test_migrate_to_postgres.py
@@ -268,6 +268,28 @@ def test_migrate_to_postgres_requires_sqlite_source(monkeypatch) -> None:
         )
 
 
+def test_migrate_to_postgres_requires_postgres_target(monkeypatch, tmp_path) -> None:
+    from rune_bench.storage.sqlite import SQLiteStorageAdapter
+
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    adapters = [SQLiteStorageAdapter(db_a), SQLiteStorageAdapter(db_b)]
+    monkeypatch.setattr(migration_mod, "make_storage", lambda _url: adapters.pop(0))
+
+    with pytest.raises(RuntimeError, match="target must be a postgresql:// URL"):
+        migration_mod.migrate_to_postgres(
+            source_url=f"sqlite:///{db_a.as_posix()}",
+            target_url="postgresql://localhost/rune",
+        )
+
+
+def test_insert_batch_no_rows_is_noop() -> None:
+    target = _FakePostgresAdapter()
+    spec = migration_mod._TABLE_SPECS[0]
+    migration_mod._insert_batch(target, spec, [])
+    assert target._conn.tables == {}
+
+
 def test_migrate_to_postgres_rolls_back_failing_batch(monkeypatch) -> None:
     source = _FakeSQLiteAdapter(
         {

--- a/tests/test_postgres_storage_unit.py
+++ b/tests/test_postgres_storage_unit.py
@@ -228,6 +228,45 @@ def test_record_chain_node_transition_updates_state() -> None:
     assert params[3] == "job-1"
 
 
+def test_record_chain_node_transition_sets_node_error() -> None:
+    conn = _FakeConnection(
+        results=[
+            _Result(
+                one={
+                    "state_json": json.dumps(
+                        {
+                            "nodes": [
+                                {
+                                    "id": "draft",
+                                    "agent_name": "DraftAgent",
+                                    "status": "running",
+                                    "started_at": None,
+                                    "finished_at": None,
+                                    "error": None,
+                                }
+                            ],
+                            "edges": [],
+                        }
+                    )
+                }
+            )
+        ]
+    )
+    adapter = _make_adapter(conn)
+
+    adapter.record_chain_node_transition(
+        job_id="job-1",
+        node_id="draft",
+        status="failed",
+        error="node blew up",
+    )
+
+    _, params = conn.executed[1]
+    state = json.loads(params[0])
+    assert state["nodes"][0]["status"] == "failed"
+    assert state["nodes"][0]["error"] == "node blew up"
+
+
 def test_record_chain_node_transition_rejects_missing_state_or_node() -> None:
     missing_state = _make_adapter(_FakeConnection(results=[_Result(one=None)]))
     with pytest.raises(RuntimeError, match="not initialized"):
@@ -545,6 +584,25 @@ def test_get_job_returns_records_and_filters_tenant() -> None:
     assert adapter.get_job("job-1") is None
     assert conn.executed[0][0] == "SELECT * FROM jobs WHERE job_id = %s AND tenant_id = %s"
     assert conn.executed[1][0] == "SELECT * FROM jobs WHERE job_id = %s"
+
+
+def test_list_jobs_for_finops_maps_rows() -> None:
+    row = {
+        "kind": "benchmark",
+        "request_json": json.dumps({"model": "m"}),
+        "result_json": None,
+        "created_at": 10.0,
+        "updated_at": 13.0,
+    }
+    conn = _FakeConnection(results=[_Result(many=[row])])
+    adapter = _make_adapter(conn)
+    out = adapter.list_jobs_for_finops(tenant_id="t1", limit=100)
+    assert len(out) == 1
+    assert out[0]["kind"] == "benchmark"
+    assert out[0]["request_payload"] == {"model": "m"}
+    assert out[0]["result_payload"] is None
+    assert out[0]["duration_seconds"] == pytest.approx(3.0)
+    assert conn.executed[0][1] == ("t1", 100)
 
 
 def test_close_and_del_are_best_effort() -> None:

--- a/tests/test_pricing_oracle.py
+++ b/tests/test_pricing_oracle.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`rune_bench.metrics.pricing` (issue #214)."""
+
+from __future__ import annotations
+
+import json
+from http.server import ThreadingHTTPServer
+from urllib.request import Request, urlopen
+
+from rune_bench.api_server import ApiSecurityConfig, RuneApiApplication
+from rune_bench.job_store import JobStore
+from rune_bench.metrics.pricing import PricingSoothSayer, _vast_dph_stats
+
+_API_TOKEN = "a" * 32
+_SHA256_HEX = "3ba3f5f43b92602683c19aee62a20342b084dd5971ddd33808d81a328879a547"
+
+
+class _MemStore:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def list_jobs_for_finops(self, *, tenant_id: str, limit: int = 2000):
+        return list(self._rows[:limit])
+
+
+def test_sooth_sayer_no_history_uses_defaults_and_range():
+    store = _MemStore([])
+    sayer = PricingSoothSayer(store, vast_search_offers=None)
+    out = sayer.simulate(tenant_id="t1", gpu="RTX 4090", model="gpt-4o")
+    assert out["historical_sample_count"] == 0
+    assert out["confidence"] == "low"
+    assert out["historical_basis"] == "no_matching_history"
+    assert out["cost_low_usd"] < out["projected_cost_usd"] < out["cost_high_usd"]
+    assert out["components_usd"]["gpu_compute"] >= 0
+    assert out["components_usd"]["llm_tokens"] >= 0
+    assert out["vast_pricing_source"] == "fallback"
+
+
+def test_sooth_sayer_matches_agent_and_model():
+    rows = [
+        {
+            "kind": "agentic-agent",
+            "request_payload": {
+                "agent": "holmes",
+                "model": "llama3.1:8b",
+                "question": "q",
+                "backend_url": None,
+                "backend_warmup": False,
+                "backend_warmup_timeout": 1,
+            },
+            "result_payload": {
+                "metadata": {"prompt_eval_count": 1000, "eval_count": 200},
+            },
+            "duration_seconds": 60.0,
+        },
+        {
+            "kind": "agentic-agent",
+            "request_payload": {
+                "agent": "other",
+                "model": "llama3.1:8b",
+                "question": "q",
+                "backend_url": None,
+                "backend_warmup": False,
+                "backend_warmup_timeout": 1,
+            },
+            "result_payload": None,
+            "duration_seconds": 999.0,
+        },
+    ]
+    store = _MemStore(rows)
+    sayer = PricingSoothSayer(store, vast_search_offers=None)
+    out = sayer.simulate(tenant_id="t1", agent="holmes", model="llama3.1:8b", gpu="4090")
+    assert out["historical_sample_count"] == 1
+    assert out["avg_duration_seconds"] == 60.0
+    assert out["llm_input_tokens_assumed"] == 1000.0
+    assert out["token_samples_from_history"] == 1
+
+
+def test_sooth_sayer_suite_filters_benchmark_template():
+    rows = [
+        {
+            "kind": "benchmark",
+            "request_payload": {
+                "template_hash": "tpl-abc",
+                "model": "m1",
+                "vastai": False,
+                "min_dph": 0,
+                "max_dph": 0,
+                "reliability": 0.9,
+                "backend_url": "http://x",
+                "question": "q",
+                "backend_warmup": False,
+                "backend_warmup_timeout": 1,
+                "kubeconfig": "/tmp/k",
+                "vastai_stop_instance": False,
+            },
+            "result_payload": None,
+            "duration_seconds": 90.0,
+        }
+    ]
+    store = _MemStore(rows)
+    sayer = PricingSoothSayer(store, vast_search_offers=None)
+    assert sayer.simulate(tenant_id="t1", suite="tpl-abc", model="m1")["historical_sample_count"] == 1
+    assert sayer.simulate(tenant_id="t1", suite="other")["historical_sample_count"] == 0
+
+
+def test_vast_dph_stats_filters_gpu_name():
+    offers = [
+        {"gpu_name": "RTX 4090", "dph_total": 0.40},
+        {"gpu_name": "RTX 3090", "dph_total": 0.20},
+        {"gpu_name": "RTX 4090", "dph_total": 0.50},
+    ]
+
+    def _search(**_kwargs):
+        return offers
+
+    mid, lo, hi = _vast_dph_stats(_search, "4090")
+    assert lo == 0.40
+    assert hi == 0.50
+    assert mid == 0.45
+
+
+def test_finops_simulate_http(tmp_path):
+    store = JobStore(tmp_path / "db.sqlite")
+    app = RuneApiApplication(
+        store=store,
+        security=ApiSecurityConfig(auth_disabled=False, tenant_tokens={"tenant-a": _SHA256_HEX}),
+        backend_functions={
+            "agentic-agent": lambda r: {"answer": "x"},
+            "benchmark": lambda r: {"answer": "b"},
+            "llm-instance": lambda r: {"mode": "x", "backend_url": "http://x"},
+            "ollama-instance": lambda r: {"mode": "x", "backend_url": "http://x"},
+        },
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), app.create_handler())
+    try:
+        import threading
+
+        th = threading.Thread(target=server.serve_forever, daemon=True)
+        th.start()
+        host, port = server.server_address
+        url = f"http://{host}:{port}/v1/finops/simulate?gpu=A100&model=gpt-4o"
+        req = Request(url)
+        req.add_header("Authorization", f"Bearer {_API_TOKEN}")
+        req.add_header("X-Tenant-ID", "tenant-a")
+        with urlopen(req) as resp:
+            body = json.loads(resp.read().decode())
+        assert resp.status == 200
+        assert "projected_cost_usd" in body
+        assert body["currency"] == "USD"
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_pricing_sooth_sayer.py
+++ b/tests/test_pricing_sooth_sayer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for :mod:`rune_bench.metrics.pricing` (issue #214)."""
+"""Tests for :class:`rune_bench.metrics.pricing.PricingSoothSayer` and FinOps HTTP API (#214)."""
 
 from __future__ import annotations
 

--- a/tests/test_pricing_sooth_sayer.py
+++ b/tests/test_pricing_sooth_sayer.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 
 import json
 from http.server import ThreadingHTTPServer
+from unittest.mock import patch
 from urllib.request import Request, urlopen
 
 from rune_bench.api_server import ApiSecurityConfig, RuneApiApplication
 from rune_bench.job_store import JobStore
-from rune_bench.metrics.pricing import PricingSoothSayer, _vast_dph_stats
+from rune_bench.metrics import pricing as pricing_mod
+from rune_bench.metrics.pricing import (
+    PricingSoothSayer,
+    _aggregate,
+    _extract_tokens_from_result,
+    _fallback_dph,
+    _job_matches_filters,
+    _model_llm_rates,
+    _vast_dph_stats,
+    make_pricing_sooth_sayer,
+)
 
 _API_TOKEN = "a" * 32
 _SHA256_HEX = "3ba3f5f43b92602683c19aee62a20342b084dd5971ddd33808d81a328879a547"
@@ -151,3 +162,148 @@ def test_finops_simulate_http(tmp_path):
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_model_llm_rates_empty_and_named_models():
+    assert _model_llm_rates("") == pricing_mod._DEFAULT_LLM_PER_MILLION
+    assert _model_llm_rates("  GPT-4-TURBO-preview  ")[0] == 10.0
+    assert _model_llm_rates("claude-3-haiku-foo")[0] == 0.25
+
+
+def test_fallback_dph_unknown_uses_default():
+    assert _fallback_dph("unknown-gpu") == 0.50
+    assert _fallback_dph("NVIDIA A100 80GB") == 1.40
+
+
+def test_extract_tokens_invalid_numbers_skipped_openai_nested():
+    assert _extract_tokens_from_result({"prompt_eval_count": "bad", "eval_count": 1}) == (None, None)
+    assert _extract_tokens_from_result(
+        {"prompt_tokens": "bad", "completion_tokens": 20}
+    ) == (None, None)
+    assert _extract_tokens_from_result(
+        {"outer": {"prompt_tokens": 10, "completion_tokens": 20}}
+    ) == (10.0, 20.0)
+    assert _extract_tokens_from_result([{"prompt_eval_count": 3, "eval_count": 4}]) == (3.0, 4.0)
+
+
+def test_job_matches_filters_edge_cases():
+    assert not _job_matches_filters("llm-instance", {"model": "m"}, agent="", suite="", model="")
+    assert not _job_matches_filters(
+        "benchmark",
+        {"agent": "holmes", "model": "m", "template_hash": "t"},
+        agent="holmes",
+        suite="",
+        model="",
+    )
+    assert not _job_matches_filters(
+        "agentic-agent",
+        {"agent": "holmes", "model": "m"},
+        agent="",
+        suite="tpl",
+        model="",
+    )
+    assert not _job_matches_filters(
+        "benchmark",
+        {"model": "a", "template_hash": "t"},
+        agent="",
+        suite="",
+        model="b",
+    )
+
+
+def test_aggregate_empty_rows():
+    agg = _aggregate([])
+    assert agg.n == 0
+
+
+def test_vast_dph_stats_search_raises_uses_fallback():
+    def _boom(**_kwargs):
+        raise OSError("network")
+
+    mid, lo, hi = _vast_dph_stats(_boom, "4090")
+    assert mid == _fallback_dph("4090")
+
+
+def test_vast_dph_stats_non_list_offers():
+    def _bad(**_kwargs):
+        return {"not": "a list"}
+
+    mid, lo, hi = _vast_dph_stats(_bad, "4090")
+    assert mid == _fallback_dph("4090")
+
+
+def test_vast_dph_stats_skips_invalid_dph_and_empty_gpu_filter():
+    offers = [
+        {"gpu_name": "RTX 4090", "dph_total": "x"},
+        {"gpu_name": "RTX 4090", "dph_total": 0.4},
+    ]
+
+    def _search(**_kwargs):
+        return offers
+
+    mid, lo, hi = _vast_dph_stats(_search, "")
+    assert lo == 0.4 and hi == 0.4 and mid == 0.4
+
+
+def test_vast_dph_stats_respects_max_offers():
+    offers = [{"gpu_name": "RTX 4090", "dph_total": float(i) * 0.01} for i in range(1, 120)]
+
+    def _search(**_kwargs):
+        return offers
+
+    _vast_dph_stats(_search, "4090", max_offers=5)
+    # If loop stopped early, median is from first 5 collected positive dphs — still valid floats
+    mid, _, _ = _vast_dph_stats(_search, "4090", max_offers=5)
+    assert mid > 0
+
+
+def test_sooth_sayer_high_confidence_and_live_vast():
+    rows = []
+    for i in range(5):
+        rows.append(
+            {
+                "kind": "agentic-agent",
+                "request_payload": {
+                    "agent": "holmes",
+                    "model": "m",
+                    "question": "q",
+                    "backend_url": None,
+                    "backend_warmup": False,
+                    "backend_warmup_timeout": 1,
+                },
+                "result_payload": {
+                    "metadata": {"prompt_eval_count": 100 + i, "eval_count": 50 + i},
+                },
+                "duration_seconds": 30.0 + i,
+            }
+        )
+    store = _MemStore(rows)
+
+    def _vast(**_kwargs):
+        return [{"gpu_name": "RTX 4090", "dph_total": 0.6}]
+
+    sayer = PricingSoothSayer(store, vast_search_offers=_vast)
+    out = sayer.simulate(tenant_id="t1", agent="holmes", model="m", gpu="4090")
+    assert out["confidence"] == "high"
+    assert out["vast_pricing_source"] == "live"
+
+
+@patch("rune_bench.resources.vastai.sdk.VastAI")
+def test_make_pricing_sooth_sayer_wires_vast_when_env_set(mock_vast, monkeypatch):
+    monkeypatch.setenv("VAST_API_KEY", "k" * 40)
+    inst = mock_vast.return_value
+    inst.search_offers.return_value = [{"gpu_name": "RTX 4090", "dph_total": 0.5}]
+    store = _MemStore([])
+    sayer = make_pricing_sooth_sayer(store)
+    out = sayer.simulate(tenant_id="t", gpu="4090")
+    assert out["vast_pricing_source"] == "live"
+    mock_vast.assert_called_once()
+
+
+@patch("rune_bench.resources.vastai.sdk.VastAI", side_effect=RuntimeError("boom"))
+def test_make_pricing_sooth_sayer_falls_back_when_vast_import_fails(_mock_vast, monkeypatch):
+    monkeypatch.setenv("VAST_API_KEY", "k" * 40)
+    store = _MemStore([])
+    sayer = make_pricing_sooth_sayer(store)
+    out = sayer.simulate(tenant_id="t", gpu="4090")
+    assert out["vast_pricing_source"] == "fallback"

--- a/tests/test_storage_factory.py
+++ b/tests/test_storage_factory.py
@@ -168,6 +168,38 @@ def test_default_storage_url_uses_localappdata_on_windows(monkeypatch, tmp_path)
     assert default_storage_url() == f"sqlite:///{tmp_path.as_posix()}/rune/jobs.db"
 
 
+def test_default_storage_url_uses_application_support_on_darwin(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(storage_module.sys, "platform", "darwin")
+    fake_home = tmp_path
+    monkeypatch.setattr(storage_module.Path, "home", lambda: fake_home)
+
+    expected = fake_home / "Library" / "Application Support" / "rune" / "jobs.db"
+    assert default_storage_url() == f"sqlite:///{expected.as_posix()}"
+
+
+def test_sqlite_connection_yields_raw_connection() -> None:
+    store = make_storage("sqlite:///:memory:")
+    with store.connection() as conn:
+        row = conn.execute("SELECT 1 AS n").fetchone()
+        assert row["n"] == 1
+
+
+def test_sqlite_list_jobs_for_finops_includes_succeeded_benchmarks() -> None:
+    store = make_storage("sqlite:///:memory:")
+    job_id, _ = store.create_job(
+        tenant_id="tenant-a",
+        kind="benchmark",
+        request_payload={"model": "m"},
+    )
+    store.update_job(job_id, status="succeeded", result_payload={"tokens": 1})
+    rows = store.list_jobs_for_finops(tenant_id="tenant-a", limit=10)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "benchmark"
+    assert rows[0]["request_payload"] == {"model": "m"}
+    assert rows[0]["result_payload"] == {"tokens": 1}
+    assert rows[0]["duration_seconds"] >= 1e-3
+
+
 def test_make_storage_windows_absolute_path_drops_leading_slash(monkeypatch) -> None:
     captured: dict[str, str] = {}
 


### PR DESCRIPTION
## Summary

Implements **[#214](https://github.com/lpasquali/rune/issues/214)** — FinOps cost simulation:

- **`rune_bench/metrics/pricing.py`**: `PricingSoothSayer` combines historical job stats (benchmark + agentic), commercial LLM $/1M token rates, and **Vast.ai `search_offers`** (when `VAST_API_KEY` is set) or GPU **fallback $/hr** tables.
- **`GET /v1/finops/simulate`**: query params `agent`, `suite` (benchmark `template_hash`), `gpu`, `model` — returns `projected_cost_usd`, **`cost_low_usd` / `cost_high_usd`**, component breakdown, confidence, sample counts.
- **Storage**: `StoragePort.list_jobs_for_finops` on SQLite + Postgres adapters.
- **Package layout**: `rune_bench/metrics/` package (`__init__.py` + `pricing.py`) so existing `from rune_bench.metrics import …` imports remain valid.

This PR also expands unit tests (pricing helpers, storage FinOps listing, cost estimator branches, migration guards, async stdio timeout) so total coverage stays **≥97%**.

Closes #214

Epic: https://github.com/lpasquali/rune-docs/issues/176

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

N/A — Level 2 PR.

## Level 2 Checklist

- [x] Full test suite passes (CI + local `pytest`)
- [x] Coverage at or above floor (97%)
- [x] No unintended CI side effects

## Level 3 Checklist

N/A — Level 2 PR.

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] The simulation endpoint returns cost projections in USD with breakdown and confidence — evidence: `GET /v1/finops/simulate` in `rune_bench/api_server.py`, tests in `tests/test_pricing_sooth_sayer.py` (HTTP smoke + `PricingSoothSayer` logic).
- [x] Missing historical data is handled with a confidence range — evidence: `cost_low_usd` / `cost_high_usd` and confidence fields from `PricingSoothSayer` when samples are sparse (covered in unit tests).

## Test Plan Evidence

- [x] `pytest` including `tests/test_pricing_sooth_sayer.py`; CI `python-quality` coverage gate ≥97% on this branch.

## Breaking Changes

None.

## Notes for Reviewer

Formula matches issue intent: **(duration × GPU rate) + LLM input + LLM output** (tokens × list price). Vast.ai uses live `dph` when configured; otherwise fallback GPU rates apply.
