### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ pyvenv.cfg
 # OS
 .DS_Store
 Thumbs.db
+
+# Claude Code per-project agent state
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore` so Claude Code per-project state is never committed.

**Ecosystem ([rune-docs#199](https://github.com/lpasquali/rune-docs/issues/199)):** the other seven repos already had this ignore on `main`; **rune** was the remaining gap.

Fixes https://github.com/lpasquali/rune-docs/issues/199

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

*Skipped (Level 2).*

## Level 2 Checklist

- [x] Full test suite passes (unchanged; no Python edits)
- [x] Coverage not degraded (N/A — `.gitignore` only)
- [x] No unintended CI side effects

## Level 3 Checklist

*Skipped (Level 2).*

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| *(none)* | — | `.gitignore` only; no deps, workflows, or API changes |

## Acceptance Criteria Evidence

- [x] **rune** — `.claude/` appended under OS section in `.gitignore` (diff on this PR).
- [x] **Other seven repos** — Already satisfied on `main` per issue sweep; this PR completes **rune**.
- [x] **`git check-ignore`** — Matches `.claude` paths (see Test Plan Evidence).

## Test Plan Evidence

```text
$ mkdir -p .claude && git check-ignore -v .claude .claude/foo
.gitignore:35:.claude/	.claude
.gitignore:35:.claude/	.claude/foo
```

## Breaking Changes

None.

## Notes for Reviewer

None.
