### PR TITLE
fix(docker): kubectl binary matches image CPU arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,16 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # kubectl — fetch binary here so the final image needs no curl/wget/git
-# TARGETARCH is injected automatically by docker buildx for multi-arch builds
+# TARGETARCH is set by buildx --platform; do not default to amd64 or arm64
+# hosts pull the wrong kubectl binary. Fall back to dpkg for plain docker build.
 ARG KUBECTL_VERSION=v1.35.3
-ARG TARGETARCH=amd64
-RUN curl -fsSL \
-    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
-    -o /usr/local/bin/kubectl \
- && chmod +x /usr/local/bin/kubectl
+ARG TARGETARCH
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    curl -fsSL \
+    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+    -o /usr/local/bin/kubectl; \
+    chmod +x /usr/local/bin/kubectl
 
 # Isolated virtualenv — only this directory is copied to the final stage
 RUN python -m venv /opt/venv


### PR DESCRIPTION
## Summary

Remove the `ARG TARGETARCH=amd64` default when downloading kubectl in the `rune` image builder. On arm64 images that pulled the **amd64** kubectl binary. Use buildx `TARGETARCH` when present, otherwise `dpkg --print-architecture`.

## Definition of Done

- [x] **Level 2**
- [ ] **Level 1**
- [ ] **Level 3**

## Acceptance Criteria Evidence

- `docker build` on linux/arm64 logs `arch=arm64` and completes.
- `rune-ui`, `rune-audit`, `rune-docs` Dockerfiles audited: no platform pins / amd64 defaults.

## Audit Checks

No triggers fired.

## Breaking Changes

None.

Made with [Cursor](https://cursor.com)