### PR TITLE
feat: optional pprof-style diagnostics for RUNE API

### DIFF
--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -596,11 +596,23 @@ def serve_api(
         envvar="RUNE_DEBUG",
         help="Show outbound client requests and API calls",
     ),
+    pprof_bind: str | None = typer.Option(
+        None,
+        "--pprof-bind",
+        envvar="RUNE_PPROF_BIND_ADDRESS",
+        help=(
+            "Optional host:port for pprof-style diagnostics (tracemalloc + thread stacks); "
+            "separate from the API port. Use 0 to disable. Example: 127.0.0.1:6060"
+        ),
+    ),
 ) -> None:
     """Start the standalone RUNE API server."""
     from rune_bench.api_server import RuneApiApplication
 
     _enable_debug_if_requested(debug)
+
+    if pprof_bind is not None:
+        os.environ["RUNE_PPROF_BIND_ADDRESS"] = pprof_bind
 
     resolved_port = api_port if api_port is not None else _resolve_serve_port()
     console.print(Panel.fit(

--- a/rune/__init__.py
+++ b/rune/__init__.py
@@ -611,7 +611,9 @@ def serve_api(
 
     _enable_debug_if_requested(debug)
 
-    if pprof_bind is not None:
+    # Typer leaves Option metadata on parameters when the command is invoked
+    # directly (not through the CLI); only propagate real strings to the env.
+    if isinstance(pprof_bind, str):
         os.environ["RUNE_PPROF_BIND_ADDRESS"] = pprof_bind
 
     resolved_port = api_port if api_port is not None else _resolve_serve_port()

--- a/rune_bench/api_server.py
+++ b/rune_bench/api_server.py
@@ -11,6 +11,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+from rune_bench import debug_pprof
 from rune_bench.api_backend import (
     get_cost_estimate,
     list_vastai_models,
@@ -550,6 +551,7 @@ class RuneApiApplication:
             self.store.update_job(job_id, status="failed", error=str(exc))
 
     def serve(self, host: str = "127.0.0.1", port: int = 8080) -> None:
+        debug_pprof.start_background_server_if_configured()
         server = ThreadingHTTPServer((host, port), self.create_handler())
         server.timeout = _HTTP_REQUEST_SOCKET_TIMEOUT_S
         try:

--- a/rune_bench/debug_pprof.py
+++ b/rune_bench/debug_pprof.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional diagnostics HTTP server for RUNE Python processes (API server).
+
+Mirrors the *separate bind address* pattern used for Go ``pprof`` on the
+operator: main traffic on one port, profiling on another. Set
+``RUNE_PPROF_BIND_ADDRESS`` to a TCP address (e.g. ``127.0.0.1:6060``). Use
+``0`` or leave unset to disable.
+
+Endpoints are *pprof-inspired* (index layout similar to ``net/http/pprof``).
+Heap output is ``tracemalloc`` text, not protobuf pprof; use
+``go tool pprof`` only for Go endpoints on the operator.
+
+Security: bind to loopback unless you intentionally expose diagnostics inside
+a secured network namespace (e.g. Kubernetes + NetworkPolicy).
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import os
+import sys
+import threading
+import traceback
+import tracemalloc
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+_logger = logging.getLogger(__name__)
+
+_started = False
+_start_lock = threading.Lock()
+# Populated after a successful bind (for tests and introspection only).
+diag_server: ThreadingHTTPServer | None = None
+
+
+def _heap_text(limit: int = 40) -> str:
+    if not tracemalloc.is_tracing():
+        return "tracemalloc is not active\n"
+    snap = tracemalloc.take_snapshot()
+    lines = [f"Top {limit} allocations by traceback:\n"]
+    for stat in snap.statistics("traceback")[:limit]:
+        lines.append(str(stat))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _threads_text() -> str:
+    out: list[str] = []
+    for ident, frame in sys._current_frames().items():
+        out.append(f"Thread {ident}:")
+        out.extend(traceback.format_stack(frame))
+        out.append("")
+    return "\n".join(out)
+
+
+class _PprofHandler(BaseHTTPRequestHandler):
+    server_version = "RuneDebugPprof/1.0"
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        _logger.debug(fmt, *args)
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        qs = parse_qs(parsed.query)
+
+        if path == "/debug/pprof":
+            body = """<html><head><title>/debug/pprof/</title></head><body>
+/debug/pprof/<br>
+<br>
+Types of profiles available:<br>
+<table>
+<tr><td align=right><a href="/debug/pprof/cmdline">cmdline</a>:</td><td>Process label</td></tr>
+<tr><td align=right><a href="/debug/pprof/heap">heap</a>:</td><td>tracemalloc allocation summary (text)</td></tr>
+<tr><td align=right><a href="/debug/pprof/goroutine?debug=1">goroutine</a>:</td><td>Python thread stacks (debug=1)</td></tr>
+</table>
+<p><small>Enable with RUNE_PPROF_BIND_ADDRESS. Not binary-compatible with go tool pprof.</small></p>
+</body></html>
+"""
+            self._write(200, body.encode(), "text/html; charset=utf-8")
+            return
+
+        if path == "/debug/pprof/cmdline":
+            label = os.environ.get("RUNE_PPROF_CMDLINE", "rune python")
+            self._write(200, (label + "\n").encode(), "text/plain; charset=utf-8")
+            return
+
+        if path == "/debug/pprof/heap":
+            data = _heap_text().encode()
+            self._write(200, data, "text/plain; charset=utf-8")
+            return
+
+        if path == "/debug/pprof/goroutine":
+            if qs.get("debug", ["0"])[0] == "1":
+                data = _threads_text().encode()
+                self._write(200, data, "text/plain; charset=utf-8")
+                return
+            self._write(
+                200,
+                b"goroutine profile: pass ?debug=1 for Python thread stacks\n",
+                "text/plain; charset=utf-8",
+            )
+            return
+
+        msg = f"unknown path: {html.escape(self.path)}"
+        self._write(404, msg.encode(), "text/plain; charset=utf-8")
+
+    def _write(self, code: int, body: bytes, content_type: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _parse_bind_addr(raw: str) -> tuple[str, int]:
+    s = raw.strip()
+    if s.startswith(":"):
+        return "", int(s[1:])
+    host, _, port_s = s.rpartition(":")
+    if not host or not port_s:
+        raise ValueError(f"invalid RUNE_PPROF_BIND_ADDRESS (use host:port or :port): {raw!r}")
+    return host, int(port_s)
+
+
+def start_background_server_if_configured() -> None:
+    """Start a daemon ThreadingHTTPServer if RUNE_PPROF_BIND_ADDRESS is set."""
+    global _started, diag_server
+    raw = os.environ.get("RUNE_PPROF_BIND_ADDRESS", "").strip()
+    if not raw or raw == "0":
+        return
+    with _start_lock:
+        if _started:
+            return
+        try:
+            host, port = _parse_bind_addr(raw)
+        except ValueError as exc:
+            _logger.warning("RUNE_PPROF_BIND_ADDRESS ignored: %s", exc)
+            return
+
+        if not tracemalloc.is_tracing():
+            tracemalloc.start(25)
+
+        try:
+            httpd = ThreadingHTTPServer((host, port), _PprofHandler)
+        except OSError as exc:
+            _logger.warning("RUNE pprof diagnostics server failed to bind %r: %s", raw, exc)
+            return
+
+        diag_server = httpd
+        host_out, port_out = httpd.server_address[:2]
+        _logger.warning(
+            "RUNE pprof diagnostics listening on %s:%s (RUNE_PPROF_BIND_ADDRESS); do not expose publicly",
+            host_out,
+            port_out,
+        )
+
+        def _run() -> None:
+            httpd.serve_forever()
+
+        threading.Thread(target=_run, name="rune-pprof", daemon=True).start()
+        _started = True
+
+
+def reset_for_tests() -> None:
+    """Test hook: stop diagnostics server and allow a fresh ``start_*`` call."""
+    global _started, diag_server
+    with _start_lock:
+        if diag_server is not None:
+            try:
+                diag_server.shutdown()
+            except OSError:
+                pass
+            diag_server = None
+        _started = False

--- a/tests/test_debug_pprof.py
+++ b/tests/test_debug_pprof.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for optional RUNE pprof-style diagnostics server."""
+
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from rune_bench import debug_pprof
+
+
+@pytest.fixture(autouse=True)
+def _pprof_cleanup():
+    yield
+    debug_pprof.reset_for_tests()
+
+
+def test_pprof_disabled_when_unset(monkeypatch):
+    monkeypatch.delenv("RUNE_PPROF_BIND_ADDRESS", raising=False)
+    debug_pprof.start_background_server_if_configured()
+    assert debug_pprof.diag_server is None
+
+
+def test_pprof_disabled_for_zero(monkeypatch):
+    monkeypatch.setenv("RUNE_PPROF_BIND_ADDRESS", "0")
+    debug_pprof.start_background_server_if_configured()
+    assert debug_pprof.diag_server is None
+
+
+def test_pprof_heap_and_index(monkeypatch):
+    monkeypatch.setenv("RUNE_PPROF_BIND_ADDRESS", "127.0.0.1:0")
+    debug_pprof.start_background_server_if_configured()
+    srv = debug_pprof.diag_server
+    assert srv is not None
+    _, port = srv.server_address
+    base = f"http://127.0.0.1:{port}"
+
+    for _ in range(50):
+        time.sleep(0.05)
+        try:
+            with urllib.request.urlopen(base + "/debug/pprof/", timeout=2.0) as r:
+                body = r.read().decode()
+            assert "heap" in body and "goroutine" in body
+            break
+        except urllib.error.URLError:
+            continue
+    else:
+        pytest.fail("diagnostics server did not become ready")
+
+    with urllib.request.urlopen(base + "/debug/pprof/heap", timeout=2.0) as r:
+        heap = r.read().decode()
+    assert "tracemalloc" in heap or "Top" in heap
+
+    with urllib.request.urlopen(base + "/debug/pprof/goroutine?debug=1", timeout=2.0) as r:
+        stacks = r.read().decode()
+    assert "Thread" in stacks


### PR DESCRIPTION
## Summary

Adds an optional separate-bind-address diagnostics server (`/debug/pprof/*`) using tracemalloc and Python thread stacks; controlled by `RUNE_PPROF_BIND_ADDRESS` and `rune serve-api --pprof-bind`.

Closes #259
Epic: n/a

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

Skipped (Level 2).

## Level 2 Checklist

- [x] Full test suite passes (CI quality gates on PR)
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Level 3 Checklist

Skipped (Level 2).

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| *(none)* | — | — |

## Acceptance Criteria Evidence

- [x] Env `RUNE_PPROF_BIND_ADDRESS` and CLI `--pprof-bind` — evidence: `debug_pprof.py`, `rune/__init__.py` `serve_api`
- [x] Diagnostics started from `RuneApiApplication.serve()` when configured — evidence: `api_server.py`
- [x] Unit tests for ephemeral bind — evidence: `tests/test_debug_pprof.py`

## Test Plan Evidence

- [x] `pytest tests/test_debug_pprof.py` (full suite via CI)

## Breaking Changes

None.

## Related PRs

- Operator (Go pprof): https://github.com/lpasquali/rune-operator/pull/109

## Notes for Reviewer

Heap output is tracemalloc text, not protobuf pprof; `go tool pprof` applies to the operator Go endpoint only.
