### PR TITLE
docs(readme): hyperlink IEC 62443-4-1 and SLSA to official specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The core RUNE engine for AI model benchmarking and provisioning.
 All documentation is consolidated in the **[RUNE Documentation Site](https://lpasquali.github.io/rune-docs/)**.
 
 ## 🛡️ Compliance
-- **ML4**: This repository is designed to align with **IEC 62443-4-1 ML4** secure development requirements in preparation for future certification.
-- **SLSA**: Build provenance is designed to follow **SLSA Level 3** guidelines.
+- **ML4**: This repository is designed to align with **[IEC 62443-4-1](https://webstore.iec.ch/publication/33615) ML4** secure development requirements in preparation for future certification. ([ISA overview](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards))
+- **SLSA**: Build provenance is designed to follow **[SLSA Level 3](https://slsa.dev/spec/v1.0/)** guidelines.
 
 ## 📜 License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Hyperlinks **IEC 62443-4-1** and **SLSA Level 3** in the README Compliance section to their official spec URLs. URLs come from the rune-docs External Links Catalog.

Closes #268
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] No markdown build gate here (no mkdocs in `rune`); diff manually reviewed
- [x] Links resolve (HTTP 200/301): https://webstore.iec.ch/publication/33615, https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards, https://slsa.dev/spec/v1.0/

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] IEC 62443-4-1 hyperlinked to IEC Webstore + ISA overview — evidence: diff in `README.md`
- [x] SLSA Level 3 hyperlinked to slsa.dev/spec/v1.0 — evidence: diff in `README.md`
- [x] No other content changes — evidence: `git diff main --stat` shows 1 file, 2 insertions, 2 deletions

## Test Plan Evidence

- [x] Manual diff review on `claude/readme-tool-links`
- [x] `curl -sI` for each target URL returned 2xx/3xx

## Breaking Changes

None. Docs-only README change; no code, API, or deployment surface touched.

## Notes for Reviewer

Part of a cross-repo sweep adding official documentation links to all 8 RUNE repos. Sibling PRs follow for rune-operator, rune-ui, rune-charts, rune-airgapped, rune-audit, rune-ci. All URLs come from the canonical catalog in rune-docs PR #307 (`docs/reference/EXTERNAL_LINKS.md`).